### PR TITLE
Added optional Oxford comma to copyright

### DIFF
--- a/lib/rules/headers/copyright.js
+++ b/lib/rules/headers/copyright.js
@@ -13,7 +13,7 @@ exports.check = function (sr, done) {
         ,   hatesFreedom = /All Rights Reserved/.test(text)
         ,   evil = "All Rights Reserved\\."
         ,   good = "Some Rights Reserved: this document is dual-licensed, CC-BY and W3C Document License\\."
-        ,   endRex = " W3C liability, trademark and document use rules apply\\.$"
+        ,   endRex = " W3C liability, trademark,? and document use rules apply\\.$"
         ,   rex = new RegExp(startRex + (hatesFreedom ? evil : good) + endRex)
         ;
         if (!rex.test(text)) err("no-match");

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -73,6 +73,8 @@ var tests = {
         ]
     ,   copyright:  [
             { doc: "headers/simple.html" }
+        ,   { doc: "headers/simple-oxford.html" }
+        ,   { doc: "headers/copyright-freedom.html", warnings: ["headers.copyright"] }
         ,   { doc: "headers/copyright-freedom.html", warnings: ["headers.copyright"] }
         ,   { doc: "headers/fails.html", errors: ["headers.copyright"] }
         ]


### PR DESCRIPTION
The copyright check did not permit the use of the Oxford comma in
the statement "W3C liability, trademark, and document use rules apply."
