### PR TITLE
Fix #85 (table of contents after the status section, labeled with an h2 element).

### DIFF
--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -19,6 +19,8 @@ var messages = {
         // headers/h2-status
     ,   "headers.h2-status.no-h2":  "No status+date h2 element."
     ,   "headers.h2-status.bad-h2": "Incorrect status h2 header."
+        // headers/h2-toc
+    ,   'headers.h2-toc.missing':  'There is no table of contents after the status section, labeled with a <code>&lt;h2&gt;</code> element with content <em>&ldquo;Table of Contents&rdquo;</em>.'
         // headers/h1-title
     ,   "headers.h1-title.title":   "Content of title and h1 do not match."
         // headers/dl

--- a/lib/profiles/base.js
+++ b/lib/profiles/base.js
@@ -31,6 +31,7 @@ exports.rules = [
 ,   require("../rules/headers/h1-title")
 ,   require("../rules/headers/dl")
 ,   require("../rules/headers/h2-status")
+,   require("../rules/headers/h2-toc")
 
 ,   require("../rules/style/sheet")
 

--- a/lib/rules/headers/h2-toc.js
+++ b/lib/rules/headers/h2-toc.js
@@ -1,0 +1,24 @@
+
+'use strict';
+
+exports.name  = 'headers.h2-toc';
+
+exports.check = function (sr, done) {
+
+    var EXPECTED_HEADING = /Table\ of\ Contents/;
+
+    var toc = sr.$('h2')
+    ,   found = false;
+
+    toc.each(function() {
+        found = found || EXPECTED_HEADING.test(sr.$(this).text());
+    });
+
+    if (!found) sr.warning(exports.name, 'missing');
+
+    return done();
+
+};
+
+// EOF
+


### PR DESCRIPTION
Fix #85.
