### PR TITLE
Add positional parameter instead of hard-coded port

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ recent version of Node installed.
 Currently there is no shell to run Specberus. Later we will add both Web and CLI interfaces based
 on the same core library.
 
+### Syntax and command-line parameters
+
+```
+$ nodejs app.js [PORT]
+```
+
+Meaning of positional parameters:
+
+1. `PORT`: where Specberus will be listening for HTTP connections.  
+(Default `80`.)
+
+Examples:
+
+```bash
+$ nodejs app.js 3001
+```
+
+```bash
+$ nodejs app.js
+```
+
 ## Testing
 
 Testing is done using mocha. Simply run:

--- a/app.js
+++ b/app.js
@@ -1,5 +1,8 @@
 /*jshint es5: true*/
 
+// Pseudo-constants:
+var DEFAULT_PORT = 80;
+
 // The Express and Socket.io server interface
 var express = require("express")
 ,   app = express()
@@ -28,7 +31,7 @@ app.use(express.json());
 app.use(express.static("public"));
 
 // listen up
-server.listen(process.env.PORT || 80);
+server.listen(process.argv[2] || process.env.PORT || DEFAULT_PORT);
 
 // VALIDATION PROTOCOL
 //  Client:


### PR DESCRIPTION
(In the same fashion as [Echidna PR #4](https://github.com/w3c/echidna/pull/4).) Hard-coded config details make it hard for anyone to set up and test Specberus. The port number can now be given as a positional parameter (see [the new documentation written about this](https://github.com/w3c/specberus/blob/20d45020cfd84508f60cd944749615fc145c9568/README.md#syntax-and-command-line-parameters)).
