### PR TITLE
Various fixes and improvements to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,11 @@ These properties are now returned when found:
 * `docDate`: The date associated to the document.
 * `title`: The (possible) title of the document.
 * `process`: The process rules, **as they appear on the text of the document**, eg `'14 October 2005'`.
-* `group`: The group(s) reponsible for the document (*deliverers*).
+* `deliverers`: The deliverer(s) responsible for the document (WGs, TFs, etc).
 * `thisVersion`: URL of this version of the document.
-* `previousVersion`: URL of the immediately previous version of the document.
+* `previousVersion`: URL of the previous version of the document (the last one, if multiple are shown).
 * `latestVersion`: URL of the latest version of the document.
-* `editorIDs`: ID(s) of the editor(s) responsible for the document.
-* `editorsDraft`: URL of the latest editor's draft.
+* `editorIDs`: ID(s) of the editor(s) responsible for the document, necessarily matching the pattern `/\d+/`.
 
 As an example, validating [`http://www.w3.org/TR/2014/REC-exi-profile-20140909/`](http://www.w3.org/TR/2014/REC-exi-profile-20140909/) (REC)
 emits these pairs of metadata:
@@ -102,7 +101,10 @@ emits these pairs of metadata:
 { previousVersion: 'http://www.w3.org/TR/2014/PR-exi-profile-20140506/' }
 { editorIDs: [] }
 { process: '14 October 2005' }
-{ group: { 'http://www.w3.org/XML/EXI/': 'Efficient XML Interchange Working Group' } }
+{ deliverers: [
+   { homepage: 'http://www.w3.org/XML/EXI/',
+     name: 'Efficient XML Interchange Working Group' }
+  ] }
 ```
 
 If you download that very spec, edit it to include the following metadata&hellip;
@@ -122,7 +124,10 @@ If you download that very spec, edit it to include the following metadata&hellip
 { previousVersion: 'http://www.w3.org/TR/2014/PR-exi-profile-20140506/' }
 { editorIDs: [ '329883', 'foo bar baz' ] }
 { process: '14 October 2005' }
-{ group: { 'http://www.w3.org/XML/EXI/': 'Efficient XML Interchange Working Group' } }
+{ deliverers: [
+   { homepage: 'http://www.w3.org/XML/EXI/',
+     name: 'Efficient XML Interchange Working Group' }
+  ] }
 ```
 
 Another example: when applied to [`http://www.w3.org/TR/wai-aria-1.1/`](http://www.w3.org/TR/wai-aria-1.1/) (WD),
@@ -136,10 +141,12 @@ the following metadata will be found:
 { previousVersion: 'http://www.w3.org/TR/2014/WD-wai-aria-1.1-20140612/' }
 { editorIDs: [] }
 { process: '1 August 2014' }
-{ group:
-   { 'http://www.w3.org/WAI/PF/': 'Protocols & Formats Working Group',
-     'http://www.w3.org/html/wg/': 'HTML Working Group' } }
-{ editorsDraft: 'http://w3c.github.io/aria/aria/aria.html' }
+{ deliverers: [
+   { homepage: 'http://www.w3.org/WAI/PF/',
+     name: 'Protocols & Formats Working Group' },
+   { homepage: 'http://www.w3.org/html/wg/',
+     name: 'HTML Working Group' }
+  ] }
 ```
 
 ## Profiles

--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -41,7 +41,7 @@ var messages = {
     ,   "headers.dl.previous-link":             "Link href and text differ for Previous Version."
     ,   "headers.dl.this-previous-shortname":   "Short names differ between This and Previous Versions."
     ,   "headers.dl.previous-syntax":           "Wrong syntax for Previous Version link."
-    ,   "headers.dl.editor":                    "There must be at least an editor or an author."
+    ,   "headers.dl.editor":                    "There must be at least one editor or author, with proper IDs as attributes."
     ,   "headers.dl.rescinds":                  "Rescinds this Recommendation is missing."
     ,   "headers.dl.rescinds-not-needed":       "Rescinds this Recommendation is included but does not seem necessary."
     ,   "headers.dl.latest-rescinds-order":     "Latest Version must be before Rescinds this Recommendation."

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -157,11 +157,13 @@ exports.check = function (sr, done) {
 
     if (seenEditors) {
         sr.$('dd[data-editor-id]').each(function() {
-            editorIDs.push(sr.$(this).attr('data-editor-id'));
+            if (/\d+/.test(sr.$(this).attr('data-editor-id'))) {
+                editorIDs.push(sr.$(this).attr('data-editor-id'));
+            }
         });
         sr.metadata('editorIDs', editorIDs);
     }
-    else {
+    if (!seenEditors || editorIDs.length < 1) {
         err("editor");
     }
     done();

--- a/lib/rules/heuristic/group.js
+++ b/lib/rules/heuristic/group.js
@@ -5,22 +5,23 @@ exports.name = 'heuristic.group';
 
 exports.check = function (sr, done) {
     var patterns = /.+ interest group$|.+ community group$|.+ working group$/i;
-    var candidates = {};
+    var candidates = [];
     var item;
+    var i;
 
     sr.$('a').each(function () {
         item = sr.$(this);
 
         if (patterns.exec(item.text())) {
-            candidates[item.attr('href')] = item.text();
+            candidates.push({homepage: item.attr('href'), name: item.text()});
         }
     });
 
-    if (Object.keys(candidates).length > 0) {
-        for (item in candidates) {
-            sr.info(exports.name, 'candidate', {name: candidates[item], url: item});
+    if (candidates.length > 0) {
+        for (i = 0; i < candidates.length; i ++) {
+            sr.info(exports.name, 'candidate', {name: candidates[i].name, url: candidates[i].homepage});
         }
-        sr.metadata('group', candidates);
+        sr.metadata('deliverers', candidates);
     }
     else {
         sr.error(exports.name, 'not-found');

--- a/test/docs/headers/dl-mismatch.html
+++ b/test/docs/headers/dl-mismatch.html
@@ -21,7 +21,7 @@
         <dt>Previous Version:</dt>
         <dd><a href='http://www.w3.org/TR/1977/WD-specberus-197703/'>http://www.w3.org/TR/1977/WD-specberus-19770312/</a></dd>
         <dt>Authors:</dt>
-        <dd>Specberus The Cranky</dd>
+        <dd data-editor-id="0">Specberus The Cranky</dd>
       </dl>
       <hr>
     </div>

--- a/test/docs/headers/dl-order.html
+++ b/test/docs/headers/dl-order.html
@@ -21,7 +21,7 @@
         <dt>This Version:</dt>
         <dd><a href='http://www.w3.org/TR/1977/WD-specberus-19770315/'>http://www.w3.org/TR/1977/WD-specberus-19770315/</a></dd>
         <dt>Editor:</dt>
-        <dd>Specberus The Cranky</dd>
+        <dd data-editor-id="3902">Specberus The Cranky</dd>
       </dl>
       <hr>
     </div>

--- a/test/docs/headers/simple.html
+++ b/test/docs/headers/simple.html
@@ -22,7 +22,7 @@
         <dt>Previous Version:</dt>
         <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170312/'>http://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
         <dt>Editor:</dt>
-        <dd>Specberus The Cranky</dd>
+        <dd data-editor-id="3902">Specberus The Cranky</dd>
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017


### PR DESCRIPTION
* Changed metadata key `groups` &rarr; `deliverers`.
* Value of metadata `deliverers` now is not an `Object`, but an `Array`. Each element of the array has keys `homepage` and `name`.
* Changed language about metadata `previousVersion` in `README.md`: *&ldquo;URL of the previous version of the document (the last one, if multiple are shown)&rdquo;*.
* Now, the ID(s) of editor(s) on the document **must** match *regex* `/\d+/`. Otherwise, it's not considered valid, **and a validation error is thrown**. Updated accordingly `README.md` and sample documents for testing. Also, the error message to the user now specifies that particular restriction.