### PR TITLE
Added new pseudo-rule “display-only”, including 3 informative messages

### DIFF
--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -141,6 +141,13 @@ var messages = {
     ,   "structure.h2.abstract":    "First &lt;h2&gt; after div.head must be 'Abstract', was '${was}'."
     ,   "structure.h2.sotd":        "Second &lt;h2&gt; after div.head must be 'Status of This Document', was '${was}'."
     ,   "structure.h2.toc":         "Third &lt;h2&gt; after div.head must be 'Table of Contents', was '${was}'."
+        // structure/display-only
+    ,   'structure.display-only.broken-links': 'The document <strong>must not</strong> have any broken internal links or broken links to other resources at <code>w3.org</code>. The document <strong>should not</strong> have any other broken links.'
+    ,   'structure.display-only.customised-paragraph': 'The document <strong>must</strong> include at least one customized paragraph. \
+This section <strong>should</strong> include the title page date (i.e., the one next to the maturity level at the top of the document). \
+These paragraphs <strong>should</strong> explain the publication context, including rationale and relationships to other work. \
+See <a href="http://www.w3.org/2001/06/manual/#Status">examples and more discussion in the Manual of Style</a>.'
+    ,   'structure.display-only.known-disclosures': 'It <strong>must not</strong> indicate the number of known disclosures at the time of publication.'
         // style/sheet
     ,   "style.sheet.last":         "W3C TR style sheet must be last."
     ,   "style.sheet.not-found":    "Missing W3C TR style sheet."

--- a/lib/profiles/base.js
+++ b/lib/profiles/base.js
@@ -41,6 +41,7 @@ exports.rules = [
 ,   require("../rules/structure/name")
 ,   require("../rules/structure/h2")
 ,   require("../rules/structure/section-ids")
+,   require("../rules/structure/display-only")
 
 // ,   require("../rules/links/internal")
 ,   require("../rules/links/linkchecker")

--- a/lib/rules/structure/display-only.js
+++ b/lib/rules/structure/display-only.js
@@ -1,0 +1,16 @@
+
+'use strict';
+
+exports.name = 'structure.display-only';
+
+exports.check = function (sr, done) {
+
+    sr.info(exports.name, 'broken-links');
+    sr.info(exports.name, 'customised-paragraph');
+    sr.info(exports.name, 'known-disclosures');
+    return done();
+
+};
+
+// EOF
+


### PR DESCRIPTION
I feel there's still some confusion regarding [issues with the label `display-only`](https://github.com/w3c/specberus/labels/display-only). As the label indicates, those should be resolved simply by displaying a particular message to the user, ie not performing any validation. However, there are comments in some of those issues, along the lines of *&ldquo;Too Complex. Leave for v1.5&rdquo;* or *&ldquo;Is this implemented yet?&rdquo;*, which suggest some of the solutions might not be trivial. (?)

In any case, either to *solve* these issues, or simply to *patch* them temporarily until they're properly addressed, I've added a new *pseudo-rule* that will contain all those boilerplate messages.

These three are covered right now:
* #92.
* #96.
* #99.