### PR TITLE
Deliverers' ID attribute recognised by Specberus, and spat out as part of metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ following fields:
 
 * `url`: URL of the content to check. One of `url`, `source`, `file`, or `document` must be
   specified and if several are they will be used in this order.
-* `source`: A string with the content to check.
+* `source`: A `String` with the content to check.
 * `file`: A file system path to the content to check.
 * `document`: A DOM `Document` object to be checked.
 * `profile`: A profile object which defines the validation. Required. See below.
@@ -85,13 +85,13 @@ These properties are now returned when found:
 * `title`: The (possible) title of the document.
 * `process`: The process rules, **as they appear on the text of the document**, eg `'14 October 2005'`.
 * `deliverers`: The deliverer(s) responsible for the document (WGs, TFs, etc); an `Array` of `Object`s, each one with these properties:
-  * `homepage`: URL of the grop's home page.
+  * `homepage`: URL of the group's home page.
   * `name`: name of the group, exactly as it is found in the hyperlink on the document.
+* `delivererIDs` ID(s) of the deliverer(s); an `Array` of `Number`s.
 * `thisVersion`: URL of this version of the document.
 * `previousVersion`: URL of the previous version of the document (the last one, if multiple are shown).
 * `latestVersion`: URL of the latest version of the document.
-* `editorIDs`: ID(s) of the editor(s) responsible for the document (an `Array` of `String`s, necessarily matching the pattern `/\d+/`).
-* `delivererID` ID of the group, (a `String`, necessarily matching the pattern `/\d+/`).
+* `editorIDs`: ID(s) of the editor(s) responsible for the document; an `Array` of `Number`s.
 
 As an example, validating [`http://www.w3.org/TR/2014/REC-exi-profile-20140909/`](http://www.w3.org/TR/2014/REC-exi-profile-20140909/) (REC)
 emits these pairs of metadata:
@@ -156,8 +156,8 @@ the following metadata will be found:
 
 Profiles are simple objects that support the following API:
 
-* name: A string being the name of this profile.
-* rules: An array of rule objects which are checked in this profile.
+* name: A `String` being the name of this profile.
+* rules: An `Array` of rule objects which are checked in this profile.
 
 A profile is basically a configuration of what to check. You can load a specific profile from under
 `lib/profiles` or create your own.
@@ -169,21 +169,21 @@ Profiles that are identical to its parent profile, ie that do not add any new ru
   * `TR`
     * `WG-NOTE` (identical)
       * `FPWG-NOTE` (identical)
+    * `IG-NOTE`
+      * `FPIG-NOTE` (identical)
     * `WD` (identical)
     * `PER`
     * `RSCND` (identical)
     * `PR`
     * `CR`
     * `FPWD` (identical)
-  * `IG-NOTE`
-    * `FPIG-NOTE` (identical)
-  * `SUBM`
-  * `MEM-SUBM`
-  * `TEAM-SUBM`
-  * `CG-NOTE`
-  * `FPLC`
-  * `REC`
-  * `LC`
+    * `SUBM`
+    * `MEM-SUBM`
+    * `TEAM-SUBM`
+    * `CG-NOTE`
+    * `FPLC`
+    * `REC`
+    * `LC`
 * `dummy`
 
 ## Validation events

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ These properties are now returned when found:
 * `deliverers`: The deliverer(s) responsible for the document (WGs, TFs, etc); an `Array` of `Object`s, each one with these properties:
   * `homepage`: URL of the grop's home page.
   * `name`: name of the group, exactly as it is found in the hyperlink on the document.
-  * `id` (optional): ID of the group, (a `String`, necessarily matching the pattern `/\d+/`). This property might be missing.
 * `thisVersion`: URL of this version of the document.
 * `previousVersion`: URL of the previous version of the document (the last one, if multiple are shown).
 * `latestVersion`: URL of the latest version of the document.
 * `editorIDs`: ID(s) of the editor(s) responsible for the document (an `Array` of `String`s, necessarily matching the pattern `/\d+/`).
+* `delivererID` ID of the group, (a `String`, necessarily matching the pattern `/\d+/`).
 
 As an example, validating [`http://www.w3.org/TR/2014/REC-exi-profile-20140909/`](http://www.w3.org/TR/2014/REC-exi-profile-20140909/) (REC)
 emits these pairs of metadata:

--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ These properties are now returned when found:
 * `docDate`: The date associated to the document.
 * `title`: The (possible) title of the document.
 * `process`: The process rules, **as they appear on the text of the document**, eg `'14 October 2005'`.
-* `deliverers`: The deliverer(s) responsible for the document (WGs, TFs, etc).
+* `deliverers`: The deliverer(s) responsible for the document (WGs, TFs, etc); an `Array` of `Object`s, each one with these properties:
+  * `homepage`: URL of the grop's home page.
+  * `name`: name of the group, exactly as it is found in the hyperlink on the document.
+  * `id` (optional): ID of the group, (a `String`, necessarily matching the pattern `/\d+/`). This property might be missing.
 * `thisVersion`: URL of this version of the document.
 * `previousVersion`: URL of the previous version of the document (the last one, if multiple are shown).
 * `latestVersion`: URL of the latest version of the document.
-* `editorIDs`: ID(s) of the editor(s) responsible for the document, necessarily matching the pattern `/\d+/`.
+* `editorIDs`: ID(s) of the editor(s) responsible for the document (an `Array` of `String`s, necessarily matching the pattern `/\d+/`).
 
 As an example, validating [`http://www.w3.org/TR/2014/REC-exi-profile-20140909/`](http://www.w3.org/TR/2014/REC-exi-profile-20140909/) (REC)
 emits these pairs of metadata:

--- a/lib/profiles/TR.js
+++ b/lib/profiles/TR.js
@@ -12,6 +12,5 @@ exports.rules = base.extendWithInserts({
                             ,   require("../rules/sotd/status")
                             ,   require("../rules/sotd/pp")
                             ,   require("../rules/sotd/process")
-                            ,   require("../rules/sotd/pp")
                             ]
 });

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -158,7 +158,7 @@ exports.check = function (sr, done) {
     if (seenEditors) {
         sr.$('dd[data-editor-id]').each(function() {
             if (/\d+/.test(sr.$(this).attr('data-editor-id'))) {
-                editorIDs.push(sr.$(this).attr('data-editor-id'));
+                editorIDs.push(parseInt(sr.$(this).attr('data-editor-id')));
             }
         });
         sr.metadata('editorIDs', editorIDs);

--- a/lib/rules/heuristic/group.js
+++ b/lib/rules/heuristic/group.js
@@ -15,9 +15,16 @@ exports.check = function (sr, done) {
 
         if (patterns.exec(item.text())) {
             candidate = {homepage: item.attr('href'), name: item.text()};
+
+            /* Temporarily disabled; see
+               https://github.com/w3c/specberus/pull/131#issuecomment-69811565
+               and
+               https://github.com/w3c/specberus/issues/130#issuecomment-69754763
+
             if (item.attr('data-deliverer-id') && /\d+/.test(item.attr('data-deliverer-id'))) {
                 candidate.id = item.attr('data-deliverer-id');
-            }
+            } */
+
             candidates.push(candidate);
         }
     });

--- a/lib/rules/heuristic/group.js
+++ b/lib/rules/heuristic/group.js
@@ -4,16 +4,21 @@
 exports.name = 'heuristic.group';
 
 exports.check = function (sr, done) {
-    var patterns = /.+ interest group$|.+ community group$|.+ working group$/i;
-    var candidates = [];
-    var item;
-    var i;
+    var patterns = /.+ interest group$|.+ community group$|.+ working group$/i
+    ,   candidates = []
+    ,   candidate
+    ,   item
+    ,   i;
 
     sr.$('a').each(function () {
         item = sr.$(this);
 
         if (patterns.exec(item.text())) {
-            candidates.push({homepage: item.attr('href'), name: item.text()});
+            candidate = {homepage: item.attr('href'), name: item.text()};
+            if (item.attr('data-deliverer-id') && /\d+/.test(item.attr('data-deliverer-id'))) {
+                candidate.id = item.attr('data-deliverer-id');
+            }
+            candidates.push(candidate);
         }
     });
 
@@ -28,5 +33,6 @@ exports.check = function (sr, done) {
     }
 
     return done();
+
 };
 

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -1,6 +1,8 @@
 
+'use strict';
 
 function buildWanted (sr) {
+
     var config = sr.config
     ,   wanted
     ,   isPP2002 = (config.patentPolicy === "pp2002");
@@ -43,6 +45,10 @@ function findPP ($candidates, sr) {
 
 exports.name = "sotd.pp";
 exports.check = function (sr, done) {
+
+    // Pseudo-constants:
+    var DELIVERER_ID_REGEX = /pp-impl\/(\d+)\/status/;
+
     var $sotd = sr.getSotDSection();
     if (!$sotd || !$sotd.length) {
         sr.error(exports.name, "no-sotd");
@@ -64,17 +70,25 @@ exports.check = function (sr, done) {
         var $a = sr.$(this)
         ,   href = $a.attr("href")
         ,   text = sr.norm($a.text())
+        ,   ids
         ;
         if (href === "http://www.w3.org/Consortium/Patent-Policy-20040205/" &&
             text === "5 February 2004 W3C Patent Policy") {
             foundFeb5 = true;
             return;
         }
-        if (/^http:\/\/www\.w3\.org\/2004\/01\/pp-impl\/\d+\/status$/.test(href) &&
-            text === "public list of any patent disclosures" &&
-            $a.attr("rel") === "disclosure") {
-            foundPublicList = true;
-            return;
+        if (/^http:\/\/www\.w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/.test(href) &&
+            text === "public list of any patent disclosures") {
+            ids = DELIVERER_ID_REGEX.exec(href);
+            console.log (href + ' - ' + DELIVERER_ID_REGEX);
+            console.dir(ids);
+            if (ids && 2 === ids.length) {
+                sr.metadata('delivererID', ids[1]);
+            }
+            if ($a.attr("rel") === "disclosure") {
+                foundPublicList = true;
+                return;
+            }
         }
         if (href === "http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential" &&
             text === "Essential Claim(s)") {
@@ -109,3 +123,4 @@ exports.check = function (sr, done) {
         sr.error(exports.name, "no-section6");
     done();
 };
+

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -80,10 +80,8 @@ exports.check = function (sr, done) {
         if (/^http:\/\/www\.w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/.test(href) &&
             text === "public list of any patent disclosures") {
             ids = DELIVERER_ID_REGEX.exec(href);
-            console.log (href + ' - ' + DELIVERER_ID_REGEX);
-            console.dir(ids);
             if (ids && 2 === ids.length) {
-                sr.metadata('delivererID', ids[1]);
+                sr.metadata('delivererIDs', parseInt(ids[1]));
             }
             if ($a.attr("rel") === "disclosure") {
                 foundPublicList = true;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -3,23 +3,28 @@
 // the most useful source:
 //  http://services.w3.org/xslt?xmlfile=http://www.w3.org/2005/07/13-pubrules-src.html&xslfile=http://www.w3.org/2005/07/13-pubrules-compare.xsl
 
+// Pseudo-constants:
+var DELIVERER_IDS_KEY = 'delivererIDs';
+
 var whacko = require("whacko")
 ,   fs = require("fs")
 ,   sua = require("./throttled-ua")
 ,   version = require("../package.json").version
 ;
 
-
 var Specberus = function () {
     this.version = version;
     this.clearCache();
 };
+
 Specberus.prototype.clearCache = function () {
     this.docDate = null;
     this.sotdSection = null;
     this.url = null;
     this.source = null;
+    this.delivererIDs = [];
 };
+
 Specberus.prototype.validate = function (options) {
     // accepted options:
     //  - url: URL for a document to load
@@ -69,6 +74,7 @@ Specberus.prototype.validate = function (options) {
             rule.check(self, function () {
                 done++;
                 if (!seenErrors[this.name]) self.sink.emit("ok", this.name);
+                self.sink.emit('metadata', DELIVERER_IDS_KEY, self.delivererIDs);
                 self.sink.emit("done", this.name);
                 if (done === total) self.sink.emit("end-all", profile.name);
             }.bind(rule));
@@ -94,7 +100,13 @@ Specberus.prototype.info = function (rule, key, extra) {
 };
 
 Specberus.prototype.metadata = function (key, value) {
-    this.sink.emit('metadata', key, value);
+
+    if (key === DELIVERER_IDS_KEY) {
+        this.delivererIDs.push (value);
+    } else {
+        this.sink.emit('metadata', key, value);
+    }
+
 };
 
 Specberus.prototype.throw = function (msg) {
@@ -237,3 +249,4 @@ Specberus.prototype.loadDocument = function (doc, cb) {
 };
 
 exports.Specberus = Specberus;
+

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
         <button type="button" class="close" onclick="$('#infoLink').show(); $('#about').hide();"><span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>
-        This alternative pubules checker is <strong>experimental</strong>, and provided only for early testing. <br />
+        This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br />
         Continue using the <a href="http://www.w3.org/2005/07/pubrules">official pubrules checker</a> for publishing;
         only that one is considered authoritative. <br />
         Contribute and submit issues <a href="https://github.com/w3c/specberus">on GitHub</a>; send comments to


### PR DESCRIPTION
We haven't reached consensus in #130. But @deniak and I favoured reading a new attribute `data-deliverer-id` on documents, and it's the quickest solution for the issue. So here is that solution.

For more info about how those IDs are being returned now, see [the updated documentation](https://github.com/w3c/specberus/blob/tripu/issue-130-deliverers-metadata/README.md#emitting-metadata-about-the-document).

Also, notice that the new attribute **is not required** by Specberus, ie not finding it on the document will *not* throw an error.