### PR TITLE
Process detection improvements

### DIFF
--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -124,6 +124,9 @@ var messages = {
     ,   "sotd.processDocument.no-sotd":           "No SotD section."
     ,   "sotd.processDocument.not-specified":     "No process document specified."
     ,   "sotd.processDocument.not-found":         "According to your selection, the document must mention the governing process: ${process}"
+    ,   "sotd.processDocument.wrong-process":     "The document specifies a governing process that does not match your selection (${process})."
+    ,   "sotd.processDocument.wrong-link":        "The link to the process rules specified in the document is erroneous."
+    ,   "sotd.processDocument.multiple-times":    "The governing process statement has been found multiple times."
         // sotd/implementation
     ,   "sotd.implementation.candidate":    "Found link to a preliminary interoperability/implementation report: <em><a href=\"${url}\">${text}</a></em>."
     ,   "sotd.implementation.no-report":    "Found a statement about a (missing) preliminary interoperability/implementation report: <em>“…${text}…”</em>."

--- a/lib/rules/sotd/process.js
+++ b/lib/rules/sotd/process.js
@@ -27,13 +27,22 @@ exports.check = function (sr, done) {
     }
     var found = false
     ,   boilerplate = BOILERPLATE_PREFIX + proc + BOILERPLATE_SUFFIX
+    ,   regex = new RegExp(BOILERPLATE_PREFIX + '.+' + BOILERPLATE_SUFFIX)
     ;
     $sotd.parent().find("p").each(function () {
         var $p = sr.$(this);
         if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") === procUri) {
-            sr.metadata('process', procUri);
-            found = true;
-            return;
+            if (found) sr.error(exports.name, "multiple-times", { process: proc });
+            else {
+                sr.metadata('process', procUri);
+                found = true;
+            }
+        }
+        else if (sr.norm($p.text()) !== boilerplate && regex.test($p.text())) {
+            sr.error(exports.name, "wrong-process", { process: proc });
+        }
+        else if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") !== procUri) {
+            sr.error(exports.name, "wrong-link");
         }
     });
     if (!found) sr.error(exports.name, "not-found", { process: proc });

--- a/lib/rules/sotd/process.js
+++ b/lib/rules/sotd/process.js
@@ -27,13 +27,11 @@ exports.check = function (sr, done) {
     }
     var found = false
     ,   boilerplate = BOILERPLATE_PREFIX + proc + BOILERPLATE_SUFFIX
-    ,   regex = new RegExp(BOILERPLATE_PREFIX + '.+' + BOILERPLATE_SUFFIX)
     ;
     $sotd.parent().find("p").each(function () {
         var $p = sr.$(this);
-        if (regex.test($p.text()))
-            sr.metadata('process', $p.text().replace(BOILERPLATE_PREFIX, '').replace(BOILERPLATE_SUFFIX, '').trim());
         if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") === procUri) {
+            sr.metadata('process', procUri);
             found = true;
             return;
         }


### PR DESCRIPTION
This fixes #126 by making Specberus return the URL for the process rules instead the text.

Since mentioning the process in the documents is rather new, I took the liberty to add the following things, based on what I could see when publishing:
- It checks that the governing process statement is specified only once
- It informs the user with more details when the process is not the right one
- It informs the user with more details when the link to the process is wrong

Do you plan to have the process detected automatically in the future (rather than through the options)? If so, then the `wrong-process` error will be pointless :)