### PR TITLE
Add radix to parseInt calls

### DIFF
--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -158,7 +158,7 @@ exports.check = function (sr, done) {
     if (seenEditors) {
         sr.$('dd[data-editor-id]').each(function() {
             if (/\d+/.test(sr.$(this).attr('data-editor-id'))) {
-                editorIDs.push(parseInt(sr.$(this).attr('data-editor-id')));
+                editorIDs.push(parseInt(sr.$(this).attr('data-editor-id'), 10));
             }
         });
         sr.metadata('editorIDs', editorIDs);

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -81,7 +81,7 @@ exports.check = function (sr, done) {
             text === "public list of any patent disclosures") {
             ids = DELIVERER_ID_REGEX.exec(href);
             if (ids && 2 === ids.length) {
-                sr.metadata('delivererIDs', parseInt(ids[1]));
+                sr.metadata('delivererIDs', parseInt(ids[1], 10));
             }
             if ($a.attr("rel") === "disclosure") {
                 foundPublicList = true;


### PR DESCRIPTION
This adds a decimal base to calls to `parseInt`.

Rationale is explained at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt.