### PR TITLE
Retrieve the hierarchy of tracks and profiles in the UI from a new JSON file

### DIFF
--- a/public/data/profiles.json
+++ b/public/data/profiles.json
@@ -1,27 +1,27 @@
 {"tracks": [
     {"name": "Recommendations",
      "profiles": [
-         {"id": "WD", "name": "Working draft"},
-         {"id": "FPWD", "name": "First public working draft"},
-         {"id": "FPLC", "name": "First public and last call working draft"},
-         {"id": "LC", "name": "Last call working draft"},
-         {"id": "CR", "name": "Candidate recommendation"},
-         {"id": "PR", "name": "Proposed recommendation"},
-         {"id": "PER", "name": "Proposed edited recommendation"},
+         {"id": "WD", "name": "Working Draft"},
+         {"id": "FPWD", "name": "First Public Working Draft"},
+         {"id": "FPLC", "name": "First Public and Last Call Working Draft"},
+         {"id": "LC", "name": "Last Call Working Draft"},
+         {"id": "CR", "name": "Candidate Recommendation"},
+         {"id": "PR", "name": "Proposed Recommendation"},
+         {"id": "PER", "name": "Proposed Edited Recommendation"},
          {"id": "REC", "name": "Recommendation"},
-         {"id": "RSCND", "name": "Rescinded recommendation"}
+         {"id": "RSCND", "name": "Rescinded Recommendation"}
      ]},
     {"name": "Notes",
      "profiles": [
-         {"id": "FPWG-NOTE", "name": "First public working group note"},
-         {"id": "WG-NOTE", "name": "Working group note"},
-         {"id": "FPIG-NOTE", "name": "First public interest group note"},
-         {"id": "IG-NOTE", "name": "Intrest group note"},
-         {"id": "CG-NOTE", "name": "Coordination group note"}
+         {"id": "FPWG-NOTE", "name": "First Public Working Group Note"},
+         {"id": "WG-NOTE", "name": "Working Group Note"},
+         {"id": "FPIG-NOTE", "name": "First Public Interest Group Note"},
+         {"id": "IG-NOTE", "name": "Interest Group Note"},
+         {"id": "CG-NOTE", "name": "Coordination Group Note"}
      ]},
     {"name": "Submissions",
      "profiles": [
-         {"id": "MEM-SUBM", "name": "Member submission"},
-         {"id": "TEAM-SUBM", "name": "Team submission"}
+         {"id": "MEM-SUBM", "name": "Member Submission"},
+         {"id": "TEAM-SUBM", "name": "Team Submission"}
      ]}
 ]}

--- a/public/data/profiles.json
+++ b/public/data/profiles.json
@@ -1,0 +1,27 @@
+{"tracks": [
+    {"name": "Recommendations",
+     "profiles": [
+         {"id": "WD", "name": "Working draft"},
+         {"id": "FPWD", "name": "First public working draft"},
+         {"id": "FPLC", "name": "First public and last call working draft"},
+         {"id": "LC", "name": "Last call working draft"},
+         {"id": "CR", "name": "Candidate recommendation"},
+         {"id": "PR", "name": "Proposed recommendation"},
+         {"id": "PER", "name": "Proposed edited recommendation"},
+         {"id": "REC", "name": "Recommendation"},
+         {"id": "RSCND", "name": "Rescinded recommendation"}
+     ]},
+    {"name": "Notes",
+     "profiles": [
+         {"id": "FPWG-NOTE", "name": "First public working group note"},
+         {"id": "WG-NOTE", "name": "Working group note"},
+         {"id": "FPIG-NOTE", "name": "First public interest group note"},
+         {"id": "IG-NOTE", "name": "Intrest group note"},
+         {"id": "CG-NOTE", "name": "Coordination group note"}
+     ]},
+    {"name": "Submissions",
+     "profiles": [
+         {"id": "MEM-SUBM", "name": "Member submission"},
+         {"id": "TEAM-SUBM", "name": "Team submission"}
+     ]}
+]}

--- a/public/index.html
+++ b/public/index.html
@@ -62,30 +62,8 @@
                 <div class="form-group input-sm">
                   <label for="profile" class="col-sm-2 control-label">Profile</label>
                   <div class="col-sm-10">
-                    <select class="form-control input-sm" id="profile" required>
-                      <option value="">Select an option</option>
-                      <optgroup label="Recommendation Track">
-                        <option value="WD">WD — Working Draft</option>
-                        <option value="FPWD">FPWD — First Public Working Draft</option>
-                        <option value="FPLC">FPLC — First Public and Last Call Working Draft</option>
-                        <option value="LC">LC — Last Call Working Draft</option>
-                        <option value="CR">CR — Candidate Recommendation</option>
-                        <option value="PR">PR — Proposed Recommendation</option>
-                        <option value="PER">PER — Proposed Edited Recommendation</option>
-                        <option value="REC">REC — Recommendation</option>
-                        <option value="RSCND">RSCND — Rescinded Recommendation</option>
-                      </optgroup>
-                      <optgroup label="Notes">
-                        <option value="FPWG-NOTE">FPWG-NOTE — First Public Working Group Note</option>
-                        <option value="WG-NOTE">WG-NOTE — Working Group Note</option>
-                        <option value="FPIG-NOTE">FPIG-NOTE — First Public Interest Group Note</option>
-                        <option value="IG-NOTE">IG-NOTE — Interest Group Note</option>
-                        <option value="FPWG-NOTE">CG-NOTE — Coordination Group Note</option>
-                      </optgroup>
-                      <optgroup label="Submissions">
-                        <option value="MEM-SUBM">MEM-SUBM — Member Submission</option>
-                        <option value="TEAM-SUBM">TEAM-SUBM — Team Submission</option>
-                      </optgroup>
+                    <select class="form-control" id="profile" required>
+                      <option value disabled="disabled">Select an option</option>
                     </select>
                   </div>
                 </div>

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -296,4 +296,18 @@ jQuery.extend({
         $informativeOnly.prop("disabled", isPP2002);
     });
 
+    $(document).ready(function() {
+        $.getJSON('data/profiles.json', function(data) {
+            var optgroup;
+            $.each(data.tracks, function(foo, track) {
+                optgroup = $('<optgroup label="' + track.name + '"></optgroup>');
+                $.each(track.profiles, function(bar, profile) {
+                    var option = $('<option value="' + profile.id + '">' + profile.id + '&nbsp;&mdash;&nbsp;' + profile.name + '</option>');
+                    optgroup.append(option);
+                });
+                $('select#profile').append(optgroup);
+            });
+        });
+    });
+
 }(jQuery));


### PR DESCRIPTION
Fixes #51. (Necessary/convenient to tackle the addition of `status` to the metadata returned by Specberus.)

* Tracks and profiles are now loaded using a `GET` request for a new local JSON file, and the `<select>` input gets populated from that data.
* Fixed a bug: the value of CG notes was `FPWG-NOTE` by mistake.
* The *prompt* message of the `<select>` input is now non-selectable.