### PR TITLE
W3C prefix: make regex as strict as possible

### DIFF
--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -86,7 +86,7 @@ exports.check = function (sr, done) {
         var $linkThis = dts.This.dd.find("a").first();
         if (!$linkThis || !$linkThis.length || $linkThis.attr("href") !== $linkThis.text()) err("this-link");
 
-        var vThisRex = "^https?:\\/\\/www\\.w3\\.org\\/" +
+        var vThisRex = "^http:\\/\\/www\\.w3\\.org\\/" +
                        topLevel +
                        "\\/(\\d{4})\\/" +
                        (sr.config.status || "[A-Z]+") +


### PR DESCRIPTION
See [@astorije's comment](https://github.com/w3c/echidna/pull/39#issuecomment-71855010).

Here I could only restrict it to HTTP (no SSL). It's already requiring `www.`, and it's case-sensitive. Comments welcome.