### PR TITLE
Update dependency versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,9 @@ var DEFAULT_PORT = 80;
 
 // The Express and Socket.io server interface
 var express = require("express")
+,   bodyParser = require('body-parser')
+,   compression = require('compression')
+,   morgan = require('morgan')
 ,   app = express()
 ,   server = require("http").createServer(app)
 ,   io = require("socket.io").listen(server)
@@ -25,9 +28,9 @@ var express = require("express")
 ;
 
 // middleware
-app.use(express.logger());
-app.use(express.compress());
-app.use(express.json());
+app.use(morgan('combined'));
+app.use(compression());
+app.use(bodyParser.json());
 app.use(express.static("public"));
 
 // listen up
@@ -111,6 +114,5 @@ io.sockets.on("connection", function (socket) {
                 }
             }
         });
-        
     });
 });

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "url": "https://github.com/w3c/specberus.git"
     },
     "dependencies": {
-        "whacko": "0.13.2",
-        "superagent": "0.17.0",
-        "express": "3.5.0",
-        "socket.io": "0.9.16",
-        "safe-url-input-checker": "0.0.2"
+        "express": "3.x.x",
+        "safe-url-input-checker": "0.0.x",
+        "socket.io": "0.9.x",
+        "superagent": "0.17.x",
+        "whacko": "0.13.x"
     },
     "devDependencies": {
         "expect.js": "0.3.x",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
         "url": "https://github.com/w3c/specberus.git"
     },
     "dependencies": {
-        "express": "3.x.x",
+        "body-parser": "1.x.x",
+        "compression": "1.x.x",
+        "express": "4.x.x",
+        "morgan": "1.x.x",
         "safe-url-input-checker": "0.0.x",
         "socket.io": "0.9.x",
         "superagent": "0.17.x",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "safe-url-input-checker": "0.0.2"
     },
     "devDependencies": {
-        "mocha": "1.18.2",
-        "expect.js": "0.3.1"
+        "expect.js": "0.3.x",
+        "mocha": "2.x.x"
     },
     "scripts": {
         "start": "node app.js",


### PR DESCRIPTION
I updated the version of mocha and fixed the patch versions as discussed in #148.

I didn't update the non-dev dependency versions as all of them raised errors.
For example, `superagent` > `0.17.x` raises this 3 times:

```bash
`Request#part()` is deprecated. Pass a readable stream in to `Request#attach()` instead.
The `Part()` constructor is deprecated. Pass a readable stream in to `Request#attach()` instead.

   Category validation Rule css should pass for validation/simple.html:
   Uncaught TypeError: setting custom form-data part headers is unsupported
    at deprecated.Part.set ([...]/specberus/node_modules/superagent/lib/node/part.js:58:9)
    at addPart ([...]/specberus/lib/rules/validation/css.js:26:14)
    at Object.exports.check ([...]/specberus/lib/rules/validation/css.js:39:9)
    at [...]/specberus/lib/validator.js:74:18
    at Array.forEach (native)
    at doValidation ([...]/specberus/lib/validator.js:70:23)
    at Specberus.loadSource ([...]/specberus/lib/validator.js:230:5)
    at [...]/specberus/lib/validator.js:240:18
    at fs.js:268:14
    at [...]/specberus/node_modules/mocha/node_modules/glob/node_modules/graceful-fs/graceful-fs.js:104:5
    at Object.oncomplete (fs.js:107:15)
```

`express` 4 is now shipped without the middle-wares, ...

I wasn't sure if you wanted to stay up-to-date with the dependencies, so I didn't investigate. @tripu, let me know if you expect me to work more on that!