### PR TITLE
Make an Echidna-specific profile for WDs

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ var express = require("express")
 ;
 ("FPWD FPLC WD LC CR PR PER REC RSCND " +
 "CG-NOTE FPIG-NOTE IG-NOTE FPWG-NOTE WG-NOTE " +
+"WD-Echidna " +
 "MEM-SUBM TEAM-SUBM").split(" ")
          .forEach(function (p) {
              profiles[p] = require("./lib/profiles/" + p);

--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -179,6 +179,9 @@ for extended information about the publication rules.'
     ,   "heuristic.group.not-found":          "Could not identify a group behind this spec."
 	// heuristic/date-format
     ,   'heuristic.date-format.wrong':          'This date found on a boilerplate section of the document does not have the expected format (<code>DD Month YYYY</code>, with an optional leading zero in the day): <em>&ldquo;${text}&rdquo;</em>.'
+    // Echidna
+    ,   'echidna.editor-ids.no-editor-id': 'Editor IDs must be set for each editor, in the <code>data-editor-id</code> attribute.'
+    ,   'echidna.todays-date.wrong-date': 'The publication date of this document must be set to today.'
     }
 };
 

--- a/lib/profiles/WD-Echidna.js
+++ b/lib/profiles/WD-Echidna.js
@@ -2,14 +2,7 @@
 // Working Draft profile
 
 exports.name = "WD-Echidna";
-exports.config = {
-    status:             "WD"
-,   longStatus:         "Working Draft"
-,   previousVersion:    true
-,   styleSheet:         "W3C-WD"
-,   stabilityWarning:   true
-,   recTrackStatus:     true
-};
+exports.config = require("./WD").config;
 
 var base = require("./base");
 exports.rules = base.insertAfter(

--- a/lib/profiles/WD-Echidna.js
+++ b/lib/profiles/WD-Echidna.js
@@ -1,0 +1,22 @@
+
+// Working Draft profile
+
+exports.name = "WD-Echidna";
+exports.config = {
+    status:             "WD"
+,   longStatus:         "Working Draft"
+,   previousVersion:    true
+,   styleSheet:         "W3C-WD"
+,   stabilityWarning:   true
+,   recTrackStatus:     true
+};
+
+var wd = require("./WD");
+exports.rules = wd.insertAfter(
+        require("./TR").rules
+    ,   "sotd.status"
+    ,   [
+            require("../echidna/editor-ids.js")
+        ]
+);
+

--- a/lib/profiles/WD-Echidna.js
+++ b/lib/profiles/WD-Echidna.js
@@ -17,6 +17,7 @@ exports.rules = wd.insertAfter(
     ,   "sotd.status"
     ,   [
             require("../echidna/editor-ids.js")
+        ,   require("../echidna/todays-date.js")
         ]
 );
 

--- a/lib/profiles/WD-Echidna.js
+++ b/lib/profiles/WD-Echidna.js
@@ -11,13 +11,13 @@ exports.config = {
 ,   recTrackStatus:     true
 };
 
-var wd = require("./WD");
-exports.rules = wd.insertAfter(
-        require("./TR").rules
+var base = require("./base");
+exports.rules = base.insertAfter(
+        require("./WD").rules
     ,   "sotd.status"
     ,   [
-            require("../echidna/editor-ids.js")
-        ,   require("../echidna/todays-date.js")
+            require("../rules/echidna/editor-ids.js")
+        ,   require("../rules/echidna/todays-date.js")
         ]
 );
 

--- a/lib/rules/echidna/editor-ids.js
+++ b/lib/rules/echidna/editor-ids.js
@@ -12,7 +12,7 @@ exports.check = function (sr, done) {
 
     sr.metadata('editorIDs', editorIDs);
 
-    if (editorIDs.length === 0) sr.error(exports.name, 'editor');
+    if (editorIDs.length === 0) sr.error(exports.name, 'no-editor-id');
 
     done();
 };

--- a/lib/rules/echidna/editor-ids.js
+++ b/lib/rules/echidna/editor-ids.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.name = "echidna.editor-ids";
+
+exports.check = function (sr, done) {
+    var editorIDs = sr.$('dd[data-editor-id]').map(function(index, element) {
+        var strId = sr.$(element).attr('data-editor-id');
+
+        // If the ID is not a digit-only string, it gets filtered out
+        if (/\d+/.test(strId)) return parseInt(strId, 10);
+    });
+
+    sr.metadata('editorIDs', editorIDs);
+
+    if (editorIDs.length === 0) sr.error(exports.name, 'editor');
+
+    done();
+};

--- a/lib/rules/echidna/todays-date.js
+++ b/lib/rules/echidna/todays-date.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.name = "echidna.todays-date";
+
+exports.check = function (sr, done) {
+    function getDate(date) { return date.setHours(0, 0, 0, 0); }
+
+    if (getDate(sr.getDocumentDate()) !== getDate(new Date())) {
+        sr.error(exports.name, 'wrong-date');
+    }
+
+    done();
+};

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -21,8 +21,6 @@ exports.check = function (sr, done) {
     ,   subType = sr.config.submissionType
     ,   topLevel = "TR"
     ,   dts = {}
-    ,   seenEditors = false
-    ,   editorIDs = []
     ,   err = function (str, extra) {
             sr.error(exports.name, str, extra);
         }
@@ -60,7 +58,6 @@ exports.check = function (sr, done) {
         ,   key = null
         ;
         if (!$dd) return err("no-dd", { dt: txt });
-        if (/^(editor|author)s?/.test(txt)) seenEditors = true;
         if (txt === "this version") key = "This";
         else if (txt === "latest version") key = "Latest";
         else if (/^previous version(?:s)?$/.test(txt)) key = "Previous";
@@ -155,17 +152,6 @@ exports.check = function (sr, done) {
         else err("rescinds-syntax");
     }
 
-    if (seenEditors) {
-        sr.$('dd[data-editor-id]').each(function() {
-            if (/\d+/.test(sr.$(this).attr('data-editor-id'))) {
-                editorIDs.push(parseInt(sr.$(this).attr('data-editor-id'), 10));
-            }
-        });
-        sr.metadata('editorIDs', editorIDs);
-    }
-    if (!seenEditors || editorIDs.length < 1) {
-        err("editor");
-    }
     done();
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -126,6 +126,15 @@
                   </div>
                 </div>
 
+                <div class="form-group checkbox input-sm">
+                  <div class="col-sm-12">
+                    <label class="control-label">
+                      <input type="checkbox" id="echidnaReady" name="echidnaReady" />
+                      Check that the document is valid for <a href="https://github.com/w3c/echidna/wiki">automatic publication with Echidna</a>
+                    </label>
+                  </div>
+                </div>
+
                 <div class="form-group">
                   <div class="col-sm-offset-2 col-sm-10">
                     <button type="submit" class="btn btn-primary pull-right">Run</button>

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
 <html lang="en-GB">
 
   <head>
-    <meta charset="utf-8" />
-    <meta name="application-name" content="Pubrules Checker" />
-    <meta name="description" content="Pubrules checker — reloaded" />
-    <meta name="keywords" content="pubrules,checker,specberus,w3c,publict" />
-    <meta name="author" content="W3C" />
+    <meta charset="utf-8">
+    <meta name="application-name" content="Pubrules Checker">
+    <meta name="description" content="Pubrules checker — reloaded">
+    <meta name="keywords" content="pubrules,checker,specberus,w3c,publict">
+    <meta name="author" content="W3C">
     <title>Pubrules Checker</title>
-    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css" />
-    <link rel="stylesheet" type="text/css" href="css/specberus.css" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="css/specberus.css">
   </head>
 
   <body>
@@ -19,8 +19,8 @@
       <div class="container">
         <div class="row">
           <div class="col-md-8 navbar-brand">
-            <a href="http://www.w3.org/"><img class="logo" src="img/logo-w3c.svg" alt="W3C logo" /></a>
-            <a href="/"><img src="img/logo.svg" alt="Logo for the Pubrules Checker" />Pubrules Checker</a>
+            <a href="http://www.w3.org/"><img class="logo" src="img/logo-w3c.svg" alt="W3C logo"></a>
+            <a href="/"><img src="img/logo.svg" alt="Logo for the Pubrules Checker">Pubrules Checker</a>
           </div>
           <div class="contribute col-md-4 text-right">
             <a id="infoLink" href="#" onclick="$('#about').show(); $('#infoLink').hide();">Important information about this tool</a>
@@ -35,9 +35,9 @@
         <button type="button" class="close" onclick="$('#infoLink').show(); $('#about').hide();"><span aria-hidden="true">&times;</span>
           <span class="sr-only">Close</span>
         </button>
-        This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br />
+        This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br>
         Continue using the <a href="http://www.w3.org/2005/07/pubrules">official pubrules checker</a> for publishing;
-        only that one is considered authoritative. <br />
+        only that one is considered authoritative.<br>
         Contribute and submit issues <a href="https://github.com/w3c/specberus">on GitHub</a>; send comments to
           <a href="mailto:public-pubrules-comments@w3.org"><code>public-pubrules-comments@w3.org</code></a>.
       </div>
@@ -73,11 +73,11 @@
                   <div class="col-sm-10">
                     <div id="patentPolicy" class="btn-group" data-toggle="buttons">
                       <label id="pp2004" class="btn btn-primary input-sm active">
-                        <input type="radio" name="patentPolicy" class="input-sm" />
+                        <input type="radio" name="patentPolicy" class="input-sm">
                         5 February 2004
                       </label>
                       <label id="pp2002" class="btn btn-primary input-sm">
-                        <input type="radio" name="patentPolicy" class="input-sm" />
+                        <input type="radio" name="patentPolicy" class="input-sm">
                         24 January 2002
                       </label>
                     </div>
@@ -88,11 +88,11 @@
                   <div class="col-sm-10">
                     <div id="processDocument" class="btn-group" data-toggle="buttons">
                       <label id="2014" class="btn btn-primary input-sm active">
-                        <input type="radio" name="processDocument" class="input-sm" />
+                        <input type="radio" name="processDocument" class="input-sm">
                         1 August 2014
                       </label>
                       <label id="2005" class="btn btn-primary input-sm">
-                        <input type="radio" name="processDocument" class="input-sm" />
+                        <input type="radio" name="processDocument" class="input-sm">
                         14 October 2005
                       </label>
                     </div>
@@ -111,7 +111,7 @@
                 <div class="form-group checkbox input-sm">
                   <div class="col-sm-12">
                     <label class="control-label">
-                      <input type="checkbox" id="noRecTrack" name="noRecTrack" />
+                      <input type="checkbox" id="noRecTrack" name="noRecTrack">
                       Rec-track status, but document is not really on Rec-track.
                     </label>
                   </div>
@@ -120,7 +120,7 @@
                 <div class="form-group checkbox input-sm">
                   <div class="col-sm-12">
                     <label class="control-label">
-                      <input type="checkbox" id="informativeOnly" name="informativeOnly" />
+                      <input type="checkbox" id="informativeOnly" name="informativeOnly">
                       Document is informative-only.
                     </label>
                   </div>
@@ -129,7 +129,7 @@
                 <div class="form-group checkbox input-sm">
                   <div class="col-sm-12">
                     <label class="control-label">
-                      <input type="checkbox" id="echidnaReady" name="echidnaReady" />
+                      <input type="checkbox" id="echidnaReady" name="echidnaReady">
                       Check that the document is valid for <a href="https://github.com/w3c/echidna/wiki">automatic publication with Echidna</a>
                     </label>
                   </div>

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -15,6 +15,7 @@ jQuery.extend({
 (function ($) {
     var $url = $("#url")
     ,   $profile = $("#profile")
+    ,   $profileOptions = $('#profile option')
     ,   $validation = $("#validation")
     ,   $noRecTrack = $("#noRecTrack")
     ,   $informativeOnly = $("#informativeOnly")
@@ -269,13 +270,13 @@ jQuery.extend({
 
     function disableProfilesIfNeeded(checkbox) {
         if (checkbox.prop('checked')) {
-            $('select#profile option').each(function (_, el) {
+            $profileOptions.each(function (_, el) {
         console.log(el);
                 if ($(el).val() !== 'WD') $(el).prop('disabled', true);
             });
-            if ($('select#profile').val() !== 'WD') $('select#profile').val('');
+            if ($profile.val() !== 'WD') $profile.val('');
         }
-        else $('select#profile option').each(function (_, el) {
+        else $profileOptions.each(function (_, el) {
             if ($(el).val() !== '') $(el).prop('disabled', false);
         });
     }
@@ -327,7 +328,7 @@ jQuery.extend({
                     var option = $('<option value="' + profile.id + '">' + profile.id + '&nbsp;&mdash;&nbsp;' + profile.name + '</option>');
                     optgroup.append(option);
                 });
-                $('select#profile').append(optgroup);
+                $profile.append(optgroup);
             });
         });
     });

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -18,6 +18,7 @@ jQuery.extend({
     ,   $validation = $("#validation")
     ,   $noRecTrack = $("#noRecTrack")
     ,   $informativeOnly = $("#informativeOnly")
+    ,   $echidnaReady = $("#echidnaReady")
     ,   $patentPolicy = $("#patentPolicy")
     ,   $processDocument = $("#processDocument")
     ,   $alert = $("#alert")
@@ -199,17 +200,20 @@ jQuery.extend({
         ,   validation = $validation.val()
         ,   noRecTrack = $noRecTrack.is(":checked") || false
         ,   informativeOnly = $informativeOnly.is(":checked") || false
+        ,   echidnaReady = $echidnaReady.is(":checked") || false
         ,   patentPolicy = $patentPolicy.find('label.active').attr('id')
         ,   processDocument = $processDocument.find('label.active').attr('id')
         ;
         if (!url) showError("Missing URL parameter.");
         if (!profile) showError("Missing profile parameter.");
+        if (echidnaReady) profile += '-Echidna';
         var options = {
                           "url"             : url
                         , "profile"         : profile
                         , "validation"      : validation
                         , "noRecTrack"      : noRecTrack
                         , "informativeOnly" : informativeOnly
+                        , "echidnaReady"    : echidnaReady
                         , "patentPolicy"    : patentPolicy
                         , "processDocument" : processDocument
                       };
@@ -263,12 +267,26 @@ jQuery.extend({
 
     }
 
+    function disableProfilesIfNeeded(checkbox) {
+        if (checkbox.prop('checked')) {
+            $('select#profile option').each(function (_, el) {
+        console.log(el);
+                if ($(el).val() !== 'WD') $(el).prop('disabled', true);
+            });
+            if ($('select#profile').val() !== 'WD') $('select#profile').val('');
+        }
+        else $('select#profile option').each(function (_, el) {
+            if ($(el).val() !== '') $(el).prop('disabled', false);
+        });
+    }
+
     function setFormParams(options) {
         if (options.url) $url.val(decodeURIComponent(options.url));
         if (options.profile) $profile.val(options.profile);
         if (options.validation) $validation.val(options.validation);
         if (options.noRecTrack === "true") $noRecTrack.prop('checked', true);
         if (options.informativeOnly === "true") $informativeOnly.prop('checked', true);
+        if (options.echidnaReady === "true") $echidnaReady.prop('checked', true);
         if (options.processDocument) {
           $processDocument.find('label').removeClass('active');
           $processDocument.find('label#' + options.processDocument).addClass('active');
@@ -294,6 +312,10 @@ jQuery.extend({
         var isPP2002 = ($(this).attr("id") === "pp2002");
         $noRecTrack.prop("disabled", isPP2002);
         $informativeOnly.prop("disabled", isPP2002);
+    });
+
+    $echidnaReady.change(function () {
+        disableProfilesIfNeeded($echidnaReady);
     });
 
     $(document).ready(function() {

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -30,6 +30,12 @@ var tests = {
         ,   { doc: "dummy/all.html", errors: ["dummy.h2-foo"] }
         ]
     }
+,   echidna:  {
+        "editor-ids":  [
+            { doc: "echidna/automated-wg.html" }
+        ,   { doc: "echidna/fails-missing-editorsid.html", errors: ["echidna.editor-ids"] }
+        ]
+    }
 ,   headers:   {
         "div.head":  [
             { doc: "headers/simple.html" }
@@ -57,10 +63,10 @@ var tests = {
         ]
     ,   dl:  [
             { doc: "headers/simple.html", config: { previousVersion: true, status: "WD" } }
-        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl", "headers.dl"] }
+        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl"] }
         ,   { doc: "headers/fails.html"
             , config: { previousVersion: true }
-            , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl"] }
+            , errors: ["headers.dl", "headers.dl", "headers.dl"] }
         ,   { doc: "headers/dl-order.html", errors: ["headers.dl", "headers.dl"], warnings: ["headers.dl"] }
         ,   { doc: "headers/dl-mismatch.html"
             , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl"]

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -35,6 +35,9 @@ var tests = {
             { doc: "echidna/automated-wg.html" }
         ,   { doc: "echidna/fails-missing-editorsid.html", errors: ["echidna.editor-ids"] }
         ]
+    ,   "todays-date":  [
+            { doc: "echidna/fails-future-date.html", errors: ["echidna.todays-date"] }
+        ]
     }
 ,   headers:   {
         "div.head":  [

--- a/test/docs/echidna/automated-wg.html
+++ b/test/docs/echidna/automated-wg.html
@@ -22,7 +22,7 @@
         <dt>Previous Version:</dt>
         <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170312/'>http://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
         <dt>Editor:</dt>
-        <dd>Specberus The Cranky</dd>
+        <dd data-editor-id="3902">Specberus The Cranky</dd>
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017

--- a/test/docs/echidna/fails-future-date.html
+++ b/test/docs/echidna/fails-future-date.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+  </head>
+  <body>
+    <div class='head'>
+      <h1>CSS Hologram Module</h1>
+      <h2>W3C Working Draft 8 October 2042</h2>
+    </div>
+  </body>
+</html>

--- a/test/docs/echidna/fails-missing-editorsid.html
+++ b/test/docs/echidna/fails-missing-editorsid.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+  </head>
+  <body>
+    <div class='head'>
+      <dl>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+    </div>
+  </body>
+</html>

--- a/test/docs/headers/dl-mismatch.html
+++ b/test/docs/headers/dl-mismatch.html
@@ -21,7 +21,7 @@
         <dt>Previous Version:</dt>
         <dd><a href='http://www.w3.org/TR/1977/WD-specberus-197703/'>http://www.w3.org/TR/1977/WD-specberus-19770312/</a></dd>
         <dt>Authors:</dt>
-        <dd data-editor-id="0">Specberus The Cranky</dd>
+        <dd>Specberus The Cranky</dd>
       </dl>
       <hr>
     </div>

--- a/test/docs/headers/dl-order.html
+++ b/test/docs/headers/dl-order.html
@@ -21,7 +21,7 @@
         <dt>This Version:</dt>
         <dd><a href='http://www.w3.org/TR/1977/WD-specberus-19770315/'>http://www.w3.org/TR/1977/WD-specberus-19770315/</a></dd>
         <dt>Editor:</dt>
-        <dd data-editor-id="3902">Specberus The Cranky</dd>
+        <dd>Specberus The Cranky</dd>
       </dl>
       <hr>
     </div>


### PR DESCRIPTION
This adds an Echidna-specific profile, checking that the document being checked:

- has `data-editor-id` attributes for the editors
- is set at today's date

It comes with a few tests. I couldn't find a way to automate tests that the current date passes the checker. If you have suggestions, I'm all ears, otherwise I tested manually and it passes...

On top of the usual review, let me know if names and file organization is fine as I am not used to Specberus (@darobin++ for the architecture, btw!) yet.

Once you are okay with the inner changes, I will add the UI part so that people can use Specberus with Echidna profile(s). Makes sense?