### PR TITLE
Changes to the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "0.12"
+  - "0.11"
   - "0.10"
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ notifications:
   email:
     - denis@w3.org
     - antonio@w3.org
-  irc: "irc.w3.org#pubrules"
+  irc:
+    channels:
+      - "irc.w3.org#pubrules"
+    skip_join: true


### PR DESCRIPTION
The `skip_join` part reflects [Echidna's `.travis.yml`](https://github.com/w3c/echidna/blob/master/.travis.yml) and saves us a few lines on IRC whenever someone pushes a commit...
If you're okay with that, I'll change the GitHub's bot configuration accordingly.