### PR TITLE
Code coverage and automatic publishing on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 lib-cov
 *.seed
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
+after_script:
+  - npm run coveralls
 notifications:
   email:
     - denis@w3.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,11 @@ notifications:
     channels:
       - "irc.w3.org#pubrules"
     skip_join: true
+deploy:
+  provider: npm
+  email: web-human@w3.org
+  api_key:
+    secure: AyNgkrx7wfcH5ao3sfLBcB6puq5IW/kgiZput5Cj7CLp6rkR26XNmVH7MG0AgX1kGil/wAthzPJctvG8A5oc/bNsHMMttXjO6pP13VFU6Bv3IKSJF4mKUNXix0pt5ana93KEOXtN4F+66tHbmROsrLTdwnH3ehFd0zSa7Vs2Kwg=
+  on:
+    tags: true
+    repo: w3c/specberus

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/w3c/specberus.svg?branch=master)](https://travis-ci.org/w3c/specberus)
+[![Coverage Status](https://coveralls.io/repos/w3c/specberus/badge.svg)](https://coveralls.io/r/w3c/specberus)
 [![Dependency Status](https://david-dm.org/w3c/specberus.svg)](https://david-dm.org/w3c/specberus)
 [![devDependency Status](https://david-dm.org/w3c/specberus/dev-status.svg)](https://david-dm.org/w3c/specberus#info=devDependencies)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://img.shields.io/npm/v/specberus.svg)](https://npmjs.org/package/specberus)
+[![License](https://img.shields.io/npm/l/specberus.svg)](LICENSE)
 [![Build Status](https://travis-ci.org/w3c/specberus.svg?branch=master)](https://travis-ci.org/w3c/specberus)
 [![Coverage Status](https://coveralls.io/repos/w3c/specberus/badge.svg)](https://coveralls.io/r/w3c/specberus)
 [![Dependency Status](https://david-dm.org/w3c/specberus.svg)](https://david-dm.org/w3c/specberus)

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
         "whacko": "0.17.x"
     },
     "devDependencies": {
+        "coveralls": "2.x.x",
         "expect.js": "0.3.x",
         "istanbul": "0.3.x",
         "mocha": "2.x.x"
     },
     "scripts": {
         "coverage": "istanbul cover _mocha",
+        "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
         "start": "node app.js",
         "test": "mocha"
     },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     },
     "devDependencies": {
         "expect.js": "0.3.x",
+        "istanbul": "0.3.x",
         "mocha": "2.x.x"
     },
     "scripts": {
+        "coverage": "istanbul cover _mocha",
         "start": "node app.js",
         "test": "mocha"
     },


### PR DESCRIPTION
- Sorry @tripu, I took the liberty to merge #154 myself, but I had a good intention: it wasn't compatible with this current PR and I merged it only so that I could `rebase` this one before you woke up and so that you can merge and release without conflicts :-)
- Code coverage can be run via `npm run coverage`, thanks to `istanbul`.
- The README badge for code coverage is updated after Travis builds, via the command above and `coveralls`, so no need to worry about this :)
- Travis also takes care of automatically deploying on [npm](https://www.npmjs.com/~w3c) after a successful build, only when a new tag is pushed. To publish, [according to the doc](http://docs.travis-ci.com/user/deployment/npm/), one must:
  1. Have a clean repo (aka no changes that are uncommitted)
  2. Run `npm version (major|minor|patch)`¹ to (a) increment by 1 the according version number, (b) commit the change of version in `package.json`, and (c) create a tag in git, called `vx.y.z`.
  3. Run `git push --follow-tags` (do not run `git push --tags`) to push the commit and the tag altogether, and Travis will take it from there.
- If the npm password changes, the encrypted `api_key` must be regenerated with (the lines start with a whitespace on purpose to not appear in the bash history):
```bash
 echo -n "w3c:password" | base64
 travis encrypt (result_of_the_previous_command)
```

¹ For the next deployment, you'll want to jump directly from version `0.4.0` to `1.0.0`. That can be done by directly running `npm version 1.0.0`.