### PR TITLE
Bugfix: check that the document date is valid before using it

### DIFF
--- a/lib/rules/echidna/todays-date.js
+++ b/lib/rules/echidna/todays-date.js
@@ -3,7 +3,11 @@
 exports.name = "echidna.todays-date";
 
 exports.check = function (sr, done) {
-    function getDate(date) { return date.setHours(0, 0, 0, 0); }
+
+    function getDate(date) {
+        if (date) return date.setHours(0, 0, 0, 0);
+        else return null;
+    }
 
     if (getDate(sr.getDocumentDate()) !== getDate(new Date())) {
         sr.error(exports.name, 'wrong-date');


### PR DESCRIPTION
When trying to validate a bogus document, eg `http://foo.bar`, a `TypeError` crashes Specberus: `cannot call method "setHours" of null`. It happens at least when reloading the page after the first attempt, ie when the document is a parameter in the URL.

The error is in `todays-date.js:6`: `sr.getDocumentDate()` isn't a `Date`, so we can't do `.setHours(0, 0, 0, 0)` with it.