### PR TITLE
Replace cheerio's deprecated toArray() with get()

### DIFF
--- a/lib/rules/echidna/editor-ids.js
+++ b/lib/rules/echidna/editor-ids.js
@@ -8,7 +8,7 @@ exports.check = function (sr, done) {
 
         // If the ID is not a digit-only string, it gets filtered out
         if (/\d+/.test(strId)) return parseInt(strId, 10);
-    }).toArray();
+    }).get();
 
     sr.metadata('editorIDs', editorIDs);
 


### PR DESCRIPTION
I learned that `toArray()` is deprecated in favor of `get()` by [requesting its documentation](https://github.com/cheeriojs/cheerio/issues/684).

Internally, `toArray()` just calls `get()` so we are not gaining anything but avoiding potential deletion of `toArray()` in a soon future.