### PR TITLE
Fix the today's date check

### DIFF
--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -181,6 +181,7 @@ for extended information about the publication rules.'
     ,   'heuristic.date-format.wrong':          'This date found on a boilerplate section of the document does not have the expected format (<code>DD Month YYYY</code>, with an optional leading zero in the day): <em>&ldquo;${text}&rdquo;</em>.'
     // Echidna
     ,   'echidna.editor-ids.no-editor-id': 'Editor IDs must be set for each editor, in the <code>data-editor-id</code> attribute.'
+    ,   'echidna.todays-date.date-not-detected': 'The publication date of this document could not be detected.'
     ,   'echidna.todays-date.wrong-date': 'The publication date of this document must be set to today.'
     }
 };

--- a/lib/rules/echidna/todays-date.js
+++ b/lib/rules/echidna/todays-date.js
@@ -3,9 +3,18 @@
 exports.name = "echidna.todays-date";
 
 exports.check = function (sr, done) {
-    function getDate(date) { return date.setHours(0, 0, 0, 0); }
+    /**
+     * Get the timestamp of a day, regardless the time of the day.
+     * This function creates a new `Date` to avoid modifying the original one.
+     *
+     * @param {Date} date - The date to extract the day, month and year from
+     * @returns {number} number of milliseconds between 1 January 1970 and `date`
+     */
+    function getDateTime(date) {
+      return new Date(date.getTime()).setHours(0, 0, 0, 0);
+    }
 
-    if (getDate(sr.getDocumentDate()) !== getDate(new Date())) {
+    if (getDateTime(sr.getDocumentDate()) !== getDateTime(new Date())) {
         sr.error(exports.name, 'wrong-date');
     }
 

--- a/lib/rules/echidna/todays-date.js
+++ b/lib/rules/echidna/todays-date.js
@@ -14,7 +14,10 @@ exports.check = function (sr, done) {
       return new Date(date.getTime()).setHours(0, 0, 0, 0);
     }
 
-    if (getDateTime(sr.getDocumentDate()) !== getDateTime(new Date())) {
+    if (!(sr.getDocumentDate() instanceof Date)) {
+        sr.error(exports.name, 'date-not-detected');
+    }
+    else if (getDateTime(sr.getDocumentDate()) !== getDateTime(new Date())) {
         sr.error(exports.name, 'wrong-date');
     }
 


### PR DESCRIPTION
This extends #159 by leaving the function type safe, fixing the function as it was mutating the source `Date` object, and adding a check/error if the date cannot be extracted from the document.