### PR TITLE
Make the version be more prominent in the UI

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -209,7 +209,7 @@ Specberus.prototype.loadURL = function (url, cb) {
     if (!cb) return this.throw("Missing callback to loadURL.");
     var self = this;
     sua.get(url)
-        .set("User-Agent", "Specberus/" + require("../package.json").version + " Node/" + process.version + " by sexy Robin")
+        .set("User-Agent", "Specberus/" + version + " Node/" + process.version + " by sexy Robin")
         .end(function (err, res) {
             if (err) return self.throw(err.message);
             if (!res.text) return self.throw("Body of " + url + " is empty.");

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -51,11 +51,8 @@ jQuery.extend({
     socket.on("handshake", function (data) {
         console.log("Using version", data.version);
         $(".navbar-brand small").remove();
-        $("<small></small>")
-            .css({ fontSize: "0.5em", opacity: "0.5" })
-            .text(" (" + data.version + ")")
-            .appendTo($(".navbar-brand"))
-            ;
+        $('head title').text($('head title').text() + ' ' + data.version);
+        $('.navbar-brand').append(' ' + data.version);
     });
 
     // show errors


### PR DESCRIPTION
Now that Echidna and Specberus are live, and as we fix bugs and deploy new versions (hopefully at a good pace), it becomes more important that users see clearly what versions of both pieces of software they are using. Someone reporting an issue, or asking for help, should be able to tell easily the exact versions that aren't working for her.

Specberus is already exposing its version through its API (and I plan to read that from Echidna soon, to append that info to the logs). However, on the web interface this information appears small and dim.

This PR makes it more visible, and adds the version to the `<title>` element too.