### PR TITLE
implement insafe instead of safe-url-input-checker module

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,7 +96,7 @@ io.sockets.on("connection", function (socket) {
             url: data.url,
             statusCodesAccepted: ["301"]
         }).then(function(res){
-            if(res.status == true) {
+            if(res.status) {
                 try {
                     validator.validate({
                         url:                res.url

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compression": "1.x.x",
     "express": "4.x.x",
     "morgan": "1.x.x",
-    "safe-url-input-checker": "0.0.x",
+    "insafe": "0.3.x",
     "socket.io": "0.9.x",
     "superagent": "0.17.x",
     "whacko": "0.17.x"


### PR DESCRIPTION
Hi,

Specberus was using the safe url input checker module (to check if an url is well formed on the server side) which is deprecated.
Instead, I wrote a new Promise based API more efficient: [insafe](http://github.com/w3c/insafe) and implemented it in Specberus.

 