### PR TITLE
Add a transition period feature

### DIFF
--- a/lib/rules/headers/copyright.js
+++ b/lib/rules/headers/copyright.js
@@ -12,17 +12,20 @@ exports.check = function (sr, done) {
         ,   text = sr.norm($c.text())
         ,   startRex = "^Copyright © (?:(?:199\\d|20[01]\\d)-)?" + year + " .*?W3C® \\(MIT, ERCIM, Keio, Beihang\\)"
         ,   isDualLicensed = /CC-BY/.test(text)
-        ,   w3cOnlyStatement = ""
+        ,   w3cOnlyStatement
         ,   dualLicenseStatement = ", Some Rights Reserved: this document is dual-licensed, CC-BY and W3C Document License"
         ,   endRex = "\\. W3C liability, trademark,? and document use rules apply\\.$"
         ;
 
         // This takes care of old copyright statement forms and their transitions.
         // See https://lists.w3.org/Archives/Public/spec-prod/2015JanMar/0001.html
-        if (sr.getDocumentDate() < new Date(2015, 1, 7)) // Before 06 Feb 2015
-            w3cOnlyStatement = ", All Rights Reserved";
-        else if (sr.getDocumentDate() < new Date(2015, 2, 8)) // Between 06 Feb and 07 Mar 2015
-            w3cOnlyStatement = "(, All Rights Reserved)?";
+        sr.transition({
+            from:        new Date('2015-02-06')
+        ,   to:          new Date('2015-03-08')
+        ,   doBefore:    function () { w3cOnlyStatement = ', All Rights Reserved'; }
+        ,   doMeanwhile: function () { w3cOnlyStatement = '(, All Rights Reserved)?'; }
+        ,   doAfter:     function () { w3cOnlyStatement = ''; }
+        });
 
         var rex = new RegExp(startRex + (isDualLicensed ? dualLicenseStatement : w3cOnlyStatement) + endRex);
         if (!rex.test(text)) err("no-match");

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -249,5 +249,11 @@ Specberus.prototype.loadDocument = function (doc, cb) {
     cb(null, function (selector, context) { return whacko(selector, context, doc); });
 };
 
+Specberus.prototype.transition = function (options) {
+    if (this.getDocumentDate() < options.from) options.doBefore();
+    else if (this.getDocumentDate() > options.to) options.doAfter();
+    else options.doMeanwhile();
+}
+
 exports.Specberus = Specberus;
 


### PR DESCRIPTION
@darobin, does that match [what you meant](https://github.com/w3c/specberus/issues/155)?

I think I'd like to see this feature also handle changes that do not need a transition periods, if it ever happens. Do you see how we could adapt this wording to deal with that as well?

Also, do you think we need to add any check on the input, what's stored in `options` (`from` and `to` are `Date` objects, `do*` are `function` values, ...)?

Once this is final and merged, and you have reached a conclusion on spec-prod, I will use this for #155.