### PR TITLE
Check against inconsistencies in URLs of this/previous/latest versions

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -48,7 +48,10 @@ exports.messages = {
 ,   "headers.dl.latest-rescinds-order":     "Latest Version must be before Rescinds this Recommendation."
 ,   "headers.dl.rescinds-link":             "Link href and text differ for Rescinds this Recommendation."
 ,   "headers.dl.this-rescinds-shortname":   "Short names differ between This Version and Rescinds this Recommendation."
-,   "headers.dl.rescinds-syntax":           "Wrong syntax for Rescinds this Recommendation link."
+,   "headers.dl.rescinds-syntax":           "Wrong syntax for Rescinds this Recommendation link.",
+,   "headers.dl.cant-retrieve":             "Could not retrieve URI for previous version or for latest version.",
+,   "headers.dl.latest-is-not-previous":    "Retrieved \"previous\" and \"latest\" documents, but their contents don't match.",
+,   "headers.dl.same-this-and-previous":    "\"This\" version and \"previous\" version have the same URL."
     // headers/errata
 ,   "headers.errata.not-found":             "Errata paragraph not found."
     // headers/translations

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -48,7 +48,10 @@ exports.messages = {
 ,   "headers.dl.latest-rescinds-order":     "Latest Version must be before Rescinds this Recommendation."
 ,   "headers.dl.rescinds-link":             "Link href and text differ for Rescinds this Recommendation."
 ,   "headers.dl.this-rescinds-shortname":   "Short names differ between This Version and Rescinds this Recommendation."
-,   "headers.dl.rescinds-syntax":           "Wrong syntax for Rescinds this Recommendation link."
+,   "headers.dl.rescinds-syntax":           "Wrong syntax for Rescinds this Recommendation link.",
+,   "headers.dl.cant-retrieve":             "Could not retrieve URI for previous version or for latest version.",
+,   "headers.dl.latest-is-not-previous":    "Retrieved \"previous\" and \"latest\" documents, but their contents don't match.",
+,   "headers.dl.same-this-and-previous":    "\"This\" version and \"previous\" version have the same URL."
     // headers/errata
 ,   "headers.errata.not-found":             "Errata paragraph not found."
     // headers/translations

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -8,6 +8,9 @@
 //  h2 date and this version date must match
 //  dt for editor or author
 
+var Request = require('request')
+,   Promise = require('promise');
+
 exports.name = "headers.dl";
 
 exports.check = function (sr, done) {
@@ -21,10 +24,27 @@ exports.check = function (sr, done) {
     ,   subType = sr.config.submissionType
     ,   topLevel = "TR"
     ,   dts = {}
+    ,   thisURI = ''
+    ,   previousURI = ''
+    ,   latestURI = ''
     ,   err = function (str, extra) {
             sr.error(exports.name, str, extra);
         }
     ;
+
+    var fetch = function(uri) {
+      return new Promise(function (resolve, reject) {
+        Request.get(uri, {}, function (error, response, body) {
+          if (error) {
+            reject(new Error('Fetching ' + uri + ' triggered a network error: ' + error.message));
+          }
+          else if (response.statusCode !== 200) {
+            reject(new Error('Fetching ' + uri + ' triggered and HTTP error: code ' + response.statusCode));
+          }
+          else resolve(body);
+        });
+      });
+    };
 
     if (subType === "member") topLevel = "Submission";
     else if (subType === "team") topLevel = "TeamSubmission";
@@ -73,6 +93,7 @@ exports.check = function (sr, done) {
         ,   docDate = sr.getDocumentDate()
         ;
         if (matches) {
+            thisURI = matches[0];
             sr.metadata('thisVersion', matches[0]);
             var year = matches[1] * 1
             ,   year2 = matches[3] * 1
@@ -100,6 +121,7 @@ exports.check = function (sr, done) {
         ,   matches = ($linkLate.attr("href") || "").match(new RegExp(lateRex));
         if (matches) {
             var sn = matches[1];
+            latestURI = $linkLate.text();
             sr.metadata('latestVersion', $linkLate.text());
             if (sn !== shortname) err("this-latest-shortname");
         }
@@ -115,6 +137,7 @@ exports.check = function (sr, done) {
         ;
         if (matches) {
             var sn = matches[1];
+            previousURI = $linkPrev.text();
             sr.metadata('previousVersion', $linkPrev.text());
             if (sn !== shortname) err("this-previous-shortname");
         }
@@ -131,6 +154,21 @@ exports.check = function (sr, done) {
             if (sn !== shortname) err("this-rescinds-shortname");
         }
         else err("rescinds-syntax");
+    }
+
+    Promise.all([fetch(previousURI), fetch(latestURI)]).then(function (bodies) {
+      if (!bodies || 2 !== bodies.length) {
+        err('cant-retrieve');
+      }
+      else if (bodies[0] !== bodies[1]) {
+        err('latest-is-not-previous');
+      }
+    }, function() {
+      err('cant-retrieve');
+    });
+
+    if (thisURI.toLowerCase() === previousURI.toLowerCase()) {
+      err('same-this-and-previous');
     }
 
     done();

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -156,21 +156,28 @@ exports.check = function (sr, done) {
         else err("rescinds-syntax");
     }
 
-    Promise.all([fetch(previousURI), fetch(latestURI)]).then(function (bodies) {
-      if (!bodies || 2 !== bodies.length) {
-        err('cant-retrieve');
-      }
-      else if (bodies[0] !== bodies[1]) {
-        err('latest-is-not-previous');
-      }
-    }, function() {
-      err('cant-retrieve');
-    });
-
-    if (thisURI.toLowerCase() === previousURI.toLowerCase()) {
+    if (thisURI && previousURI && thisURI.toLowerCase() === previousURI.toLowerCase()) {
       err('same-this-and-previous');
     }
 
-    done();
+    if (!previousURI || !latestURI || previousURI.toLowerCase() === latestURI.toLowerCase()) {
+      done();
+    }
+    else {
+      Promise.all([fetch(previousURI), fetch(latestURI)]).then(function (bodies) {
+        if (!bodies || 2 !== bodies.length) {
+          err('cant-retrieve');
+        }
+        else if (bodies[0] !== bodies[1]) {
+          err('latest-is-not-previous');
+        }
+        done();
+      }, function() {
+        err('cant-retrieve');
+        done();
+      }
+    );
+  }
+
 };
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "body-parser": "1.x.x",
     "compression": "1.x.x",
     "express": "4.x.x",
-    "morgan": "1.x.x",
     "insafe": "0.3.x",
+    "morgan": "1.x.x",
+    "promise": "6.x.x",
+    "request": "2.x.x",
     "socket.io": "0.9.x",
     "superagent": "0.17.x",
     "whacko": "0.17.x"

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -68,15 +68,15 @@ var tests = {
         ]
     ,   dl:  [
             { doc: "headers/simple.html", config: { previousVersion: true, status: "WD" } }
-        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl"] }
+        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl", "headers.dl"] }
         ,   { doc: "headers/fails.html"
             , config: { previousVersion: true }
-            , errors: ["headers.dl", "headers.dl", "headers.dl"] }
+            , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl"] }
         ,   { doc: "headers/dl-order.html", errors: ["headers.dl", "headers.dl"], warnings: ["headers.dl"] }
         ,   { doc: "headers/dl-mismatch.html"
             , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl"]
-            , warnings: ["headers.dl"]
-            }
+            , warnings: ["headers.dl"] }
+        ,   { doc: "headers/wrong-urls.html", errors: ["headers.dl"], config: { previousVersion: true, status: "WD" } }
         ]
     ,   "h2-status":  [
             { doc: "headers/simple.html", config: { longStatus: "Working Draft" } }

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -67,16 +67,14 @@ var tests = {
         ,   { doc: "headers/h1-title.html", errors: ["headers.h1-title"] }
         ]
     ,   dl:  [
-            { doc: "headers/simple.html", config: { previousVersion: true, status: "WD" } }
-        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl", "headers.dl"] }
-        ,   { doc: "headers/fails.html"
-            , config: { previousVersion: true }
-            , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl"] }
-        ,   { doc: "headers/dl-order.html", errors: ["headers.dl", "headers.dl"], warnings: ["headers.dl"] }
+            { doc: "headers/simple.html", config: { previousVersion: true, status: "WD" }, errors: ["headers.dl"] }
+        ,   { doc: "headers/fails.html", errors: ["headers.dl", "headers.dl"] }
+        ,   { doc: "headers/fails.html", config: { previousVersion: true }, errors: ["headers.dl", "headers.dl", "headers.dl"] }
+        ,   { doc: "headers/dl-order.html", errors: ["headers.dl", "headers.dl", "headers.dl"], warnings: ["headers.dl"] }
         ,   { doc: "headers/dl-mismatch.html"
             , errors: ["headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl", "headers.dl"]
             , warnings: ["headers.dl"] }
-        ,   { doc: "headers/wrong-urls.html", errors: ["headers.dl"], config: { previousVersion: true, status: "WD" } }
+        ,   { doc: "headers/wrong-urls.html", errors: ["headers.dl", "headers.dl"], config: { previousVersion: true, status: "WD" } }
         ]
     ,   "h2-status":  [
             { doc: "headers/simple.html", config: { longStatus: "Working Draft" } }

--- a/test/docs/headers/wrong-urls.html
+++ b/test/docs/headers/wrong-urls.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="http://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="http://www.w3.org/Icons/w3c_home">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 15 March 2017, edited in place 01 April 2014</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170315/'>http://www.w3.org/TR/2017/WD-specberus-20170315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='http://www.w3.org/TR/specberus/'>http://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170315/'>http://www.w3.org/TR/2017/WD-specberus-20170315/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
+        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>,
+        <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+      <hr>
+    </div>
+    <h2>Abstract</h2>
+    <p>
+      We are the internets!
+    </p>
+    <h2>Status of This Document</h2>
+    <p><em>This section describes the status of this document at the time of its publication.
+    Other documents may supersede this document. A list of current W3C publications and the
+    latest revision of this technical report can be found in the
+    <a href="http://www.w3.org/TR/">W3C technical reports index</a> at
+    http://www.w3.org/TR/.</em></p>
+    <p>
+      If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-html@w3.org">public-html@w3.org</a>
+      (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-html/">archives</a>).
+    </p>
+    <p>
+      It's a valid test!
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the W3C Membership. This is a
+      draft document and may be updated, replaced or obsoleted by other documents at any time. It is
+      inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" about="" rel="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+      <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of
+      any patent disclosures</a> made in connection with the deliverables of the group; that page
+      also includes instructions for disclosing a patent. An individual who has actual knowledge of
+      a patent which the individual believes contains
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      Claim(s)</a> must disclose the information in accordance with
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    </p>
+    <h2>Table of Contents</h2>
+    <ul>
+      <li>Nothing</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
I'm comparing the *contents* (the actual documents) of "previous" vs. "latest"
&hellip;but just the *URLs* of "this" vs. "previous".

I understand that is what will guarantee that we're catching all those tricky situations explained in issue #29&hellip;? I have also extended the tests to try to catch these cases.

(@plehegar, it'd be great if you want to extend the Echidna test suite to cover these cases, once/if this is merged :¬)