### PR TITLE
mailing list: the text content of `<a>` doesn't need to match the name of the mailing list

### DIFF
--- a/lib/rules/sotd/mailing-list.js
+++ b/lib/rules/sotd/mailing-list.js
@@ -26,8 +26,7 @@ exports.check = function (sr, done) {
         ,   text = sr.norm($a.text())
         ;
         if (/^mailto:.+@w3\.org(?:\?subject=.*)?$/i.test(href) &&
-            !/.+-request@/.test(href) &&
-            text === href.replace("mailto:", "").replace(/\?subject=.*/i, "")) {
+            !/.+-request@/.test(href)) {
             foundML = true;
             return;
         }


### PR DESCRIPTION
Fix #174