### PR TITLE
Quickfix #178: filter out URLs from paragraphs when checking for well-formed dates

### DIFF
--- a/lib/rules/heuristic/date-format.js
+++ b/lib/rules/heuristic/date-format.js
@@ -20,7 +20,7 @@ exports.check = function (sr, done) {
     ,   elem;
 
     for (i in boilerplateSections) {
-        elem = sr.$(boilerplateSections[i]).text().match(POSSIBLE_DATE);
+        elem = sr.$(boilerplateSections[i]).text().replace(/(?:https?|ftp):\/\/\S+/g, '').match(POSSIBLE_DATE);
         for (j in elem) {
             candidateDates.push(elem[j]);
         }

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -164,7 +164,8 @@ var tests = {
 ,   heuristic:   {
         'date-format':  [
             { doc: "heuristic/dates.html" }
-        ,   { doc: "heuristic/bad-dates.html", errors: ['heuristic.date-format', 'heuristic.date-format', 'heuristic.date-format'] }
+        ,   { doc: "heuristic/bad-dates.html", errors: ['heuristic.date-format', 'heuristic.date-format', 'heuristic.date-format'] },
+            { doc: "heuristic/dated-url.html" }
         ]
     }
 };

--- a/test/docs/heuristic/dated-url.html
+++ b/test/docs/heuristic/dated-url.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Dummy Test</title>
+  </head>
+  <body>
+    <h1>Has an h1</h1>
+    <h2 class='foo'>Has an h2.foo</h2>
+    <div>
+      <h2 id="abstract">Abstract</h2>
+      <p>This document does not have wrong dates but a URL to http://example.com/2014/05/22/.</p>
+    </div>
+    <article id='bar'>
+      <section class='inner'>
+        <div>
+          <p>bad</p>
+          <p data-foo>Has #bar > section.inner p[data-foo] containing "DAHUT" as a string</p>
+        </div>
+      </section>
+    </article>
+  </body>
+</html>


### PR DESCRIPTION
This doesn't fix everything, in particular it doesn't solve[@darobin's last comment on the subject](https://github.com/w3c/specberus/issues/178#issuecomment-91503953), but this provides a quick fix for #178 until something better shows up, featuring [this weird trick that will make your URLs disappear](http://stackoverflow.com/questions/23571013/how-to-remove-url-from-a-string-completely-in-javascript).