### PR TITLE
Improve #185

### DIFF
--- a/lib/rules/heuristic/date-format.js
+++ b/lib/rules/heuristic/date-format.js
@@ -20,7 +20,7 @@ exports.check = function (sr, done) {
     ,   elem;
 
     for (i in boilerplateSections) {
-        elem = sr.$(boilerplateSections[i]).text().replace(/(?:https?|ftp):\/\/\S+/g, '').match(POSSIBLE_DATE);
+        elem = sr.$(boilerplateSections[i]).text().replace(/(?:https?|ftp):\/\/\S+/gi, '').match(POSSIBLE_DATE);
         for (j in elem) {
             candidateDates.push(elem[j]);
         }

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -164,8 +164,8 @@ var tests = {
 ,   heuristic:   {
         'date-format':  [
             { doc: "heuristic/dates.html" }
-        ,   { doc: "heuristic/bad-dates.html", errors: ['heuristic.date-format', 'heuristic.date-format', 'heuristic.date-format'] },
-            { doc: "heuristic/dated-url.html" }
+        ,   { doc: "heuristic/bad-dates.html", errors: ['heuristic.date-format', 'heuristic.date-format', 'heuristic.date-format'] }
+        ,   { doc: "heuristic/dated-url.html" }
         ]
     }
 };

--- a/test/docs/heuristic/dated-url.html
+++ b/test/docs/heuristic/dated-url.html
@@ -9,7 +9,11 @@
     <h2 class='foo'>Has an h2.foo</h2>
     <div>
       <h2 id="abstract">Abstract</h2>
-      <p>This document does not have wrong dates but a URL to http://example.com/2014/05/22/.</p>
+      <p>
+        This document does not have wrong dates but a URL to http://example.com/2014/05/22/ ,
+        another dated URL in a pre element ( <pre>ftp://foo/2015-04-28/bar</pre> ),
+        and even an instance of HTTPS in uppercase! &rarrow; HTTPS://example.com/2014/05/22/ .
+      </p>
     </div>
     <article id='bar'>
       <section class='inner'>


### PR DESCRIPTION
Suggesting tiny improvements over #185:

* Exclude URLs in uppercase, too (eg `HTTP://...`).
* Add to sample doc more varied examples of excluded dates in URLs.
* Fix coding style (move comma to the beginning of next line).