### PR TITLE
IG Notes stability and pp checks

### DIFF
--- a/lib/profiles/IG-NOTE.js
+++ b/lib/profiles/IG-NOTE.js
@@ -9,9 +9,14 @@ exports.config = {
 ,   noteStatus:         true
 };
 
-var base = require("./base");
-exports.rules = base.insertAfter(
+var base = require("./base")
+,   rules = base.insertAfter(
                         require("./TR").rules
                     ,   "sotd.pp"
                     ,   require("../rules/sotd/charter-disclosure")
-);
+)
+,   index = rules.map(function (r) { return r.name; }).indexOf("sotd.pp");
+// No patent policy for IG Notes
+rules.splice(index, 1);
+
+exports.rules = rules;

--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -10,7 +10,8 @@ function findSW ($candidates, sr) {
     $candidates.each(function () {
         var $p = sr.$(this)
         ,   text = sr.norm($p.text())
-        ,   wanted = "Publication as a " + sr.config.longStatus + " does not imply endorsement " +
+        ,   article = (sr.config.longStatus == "Interest Group Note") ? "an" : "a"
+        ,   wanted = "Publication as " + article + " " + sr.config.longStatus + " does not imply endorsement " +
                      "by the W3C Membership. This is a draft document and may be updated, " +
                      "replaced or obsoleted by other documents at any time. It is inappropriate " +
                      "to cite this document as other than work in progress."

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -142,14 +142,24 @@ var tests = {
             }
         ,   { doc: "sotd/pp-cpp2002.html", options: { patentPolicy: "pp2002" } }
         ]
+    ,   "charter-disclosure":  [
+            { doc: "headers/ig-note.html" }
+        ]
     ,   stability:  [
             { doc: "headers/simple.html", config: { longStatus: "Working Draft", stabilityWarning: true } }
         ,   { doc: "headers/simple.html"
-            , config: { longStatus: "Rock And Roll", stabilityWarning: true }
-            , errors: ["sotd.stability"]
+              , config: { longStatus: "Rock And Roll", stabilityWarning: true }
+              , errors: ["sotd.stability"]
             }
         ,   { doc: "sotd/supersedable.html"
-            , config: { longStatus: "Rock And Roll", stabilityWarning: false }
+              , config: { longStatus: "Rock And Roll", stabilityWarning: false }
+            }
+        ,   { doc: "headers/ig-note.html"
+              , config: { longStatus: "Interest Group Note" , stabilityWarning: true }
+            }
+        ,   { doc: "headers/ig-note.html"
+              , config: { longStatus: "Working Draft" , stabilityWarning: true }
+              , errors: ["sotd.stability"]
             }
         ]
     ,   implementation:  [

--- a/test/docs/headers/ig-note.html
+++ b/test/docs/headers/ig-note.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <style></style>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-IG-NOTE'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="http://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="http://www.w3.org/Icons/w3c_home">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Interest Group Note 15 March 2017, edited in place 01 April 2014</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/NOTE-specberus-20170315/'>http://www.w3.org/TR/2017/NOTE-specberus-20170315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='http://www.w3.org/TR/specberus/'>http://www.w3.org/TR/specberus/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
+        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>,
+        <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+      <hr>
+    </div>
+    <h2>Abstract</h2>
+    <p>
+      We are the internets!
+    </p>
+    <h2>Status of This Document</h2>
+    <p><em>This section describes the status of this document at the time of its publication.
+    Other documents may supersede this document. A list of current W3C publications and the
+    latest revision of this technical report can be found in the
+    <a href="http://www.w3.org/TR/">W3C technical reports index</a> at
+    http://www.w3.org/TR/.</em></p>
+    <p>
+      If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-html@w3.org">public-html@w3.org</a>
+      (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-html/">archives</a>).
+    </p>
+    <p>
+      It's a valid test!
+    </p>
+    <p>
+      Publication as an Interest Group Note does not imply endorsement by the W3C Membership. This is a
+      draft document and may be updated, replaced or obsoleted by other documents at any time. It is
+      inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      The disclosure obligations of the Participants of this group are described in the 
+      <a href="http://www.w3.org/charter">charter</a>.
+    </p>
+    <h2>Table of Contents</h2>
+    <ul>
+      <li>Nothing</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
That PR:
- fixes the stability check for IG Notes
- removes the PP check for IG Notes as specified in
  [pubrules](http://www.w3.org/2005/07/pubrules?year=2015&uimode=filter&filter=Filter+pubrules&filterValues=form&docstatus=ig-note-tr&rectrack=no&prevrec=doesnotapply&normative=doesnotapply&patpol=w3c#docreqs)
- adds related tests

Fix #191