### PR TITLE
Fix copy removed accidentally around PR #160

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -151,13 +151,13 @@ exports.messages = {
     // structure/display-only
 ,   'structure.display-only.broken-links': 'The document <strong>must not</strong> have any broken internal links or broken links to other resources at <code>w3.org</code>. The document <strong>should not</strong> have any other broken links.'
 ,   'structure.display-only.customised-paragraph': 'The document <strong>must</strong> include at least one customized paragraph. \
- section <strong>should</strong> include the title page date (i.e., the one next to the maturity level at the top of the document). \
-e paragraphs <strong>should</strong> explain the publication context, including rationale and relationships to other work. \
-<a href="http://www.w3.org/2001/06/manual/#Status">examples and more discussion in the Manual of Style</a>.'
+This section <strong>should</strong> include the title page date (i.e., the one next to the maturity level at the top of the document). \
+These paragraphs <strong>should</strong> explain the publication context, including rationale and relationships to other work. \
+See <a href="http://www.w3.org/2001/06/manual/#Status">examples and more discussion in the Manual of Style</a>.'
 ,   'structure.display-only.known-disclosures': 'It <strong>must not</strong> indicate the number of known disclosures at the time of publication.'
 ,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
-se refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
-extended information about the publication rules.'
+Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
+for extended information about the publication rules.'
     // style/sheet
 ,   "style.sheet.last":         "W3C TR style sheet must be last."
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -151,13 +151,13 @@ exports.messages = {
     // structure/display-only
 ,   'structure.display-only.broken-links': 'The document <strong>must not</strong> have any broken internal links or broken links to other resources at <code>w3.org</code>. The document <strong>should not</strong> have any other broken links.'
 ,   'structure.display-only.customised-paragraph': 'The document <strong>must</strong> include at least one customized paragraph. \
- section <strong>should</strong> include the title page date (i.e., the one next to the maturity level at the top of the document). \
-e paragraphs <strong>should</strong> explain the publication context, including rationale and relationships to other work. \
-<a href="http://www.w3.org/2001/06/manual/#Status">examples and more discussion in the Manual of Style</a>.'
+This section <strong>should</strong> include the title page date (i.e., the one next to the maturity level at the top of the document). \
+These paragraphs <strong>should</strong> explain the publication context, including rationale and relationships to other work. \
+See <a href="http://www.w3.org/2001/06/manual/#Status">examples and more discussion in the Manual of Style</a>.'
 ,   'structure.display-only.known-disclosures': 'It <strong>must not</strong> indicate the number of known disclosures at the time of publication.'
 ,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
-se refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
-extended information about the publication rules.'
+Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
+for extended information about the publication rules.'
     // style/sheet
 ,   "style.sheet.last":         "W3C TR style sheet must be last."
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."


### PR DESCRIPTION
[The beginnings of five lines in two files were truncated by accident](https://github.com/w3c/specberus/pull/160/files#diff-641584ec6af0da9aefd9d3d07cfcf2d1L150), possibly during merges and rebases of that branch.