### PR TITLE
Only deploy to npm when the 0.12 build ends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ deploy:
   api_key:
     secure: AyNgkrx7wfcH5ao3sfLBcB6puq5IW/kgiZput5Cj7CLp6rkR26XNmVH7MG0AgX1kGil/wAthzPJctvG8A5oc/bNsHMMttXjO6pP13VFU6Bv3IKSJF4mKUNXix0pt5ana93KEOXtN4F+66tHbmROsrLTdwnH3ehFd0zSa7Vs2Kwg=
   on:
+    node: '0.12'
     tags: true
     repo: w3c/specberus


### PR DESCRIPTION
This doesn't fix [your recent issue](https://github.com/travis-ci/travis-ci/issues/4197#issuecomment-123582302) but at least it makes sure that the deployment is not run twice each time, the second one always failing.