### PR TITLE
Adapt code to Superagent 1.2.0

### DIFF
--- a/lib/rules/links/compound.js
+++ b/lib/rules/links/compound.js
@@ -41,7 +41,7 @@ exports.check = function (sr, done) {
                          return;
                      });
 
-            req.end(function (res) {
+            req.end(function (err1, res) {
                 if (res.header['x-w3c-validator-status'] === 'Valid') isMarkupValid = true;
                 reqCSS = sua.get(cssService)
                         .set("User-Agent", ua)
@@ -51,7 +51,7 @@ exports.check = function (sr, done) {
                             count++;
                             return;
                         });
-                reqCSS.end(function (res) {
+                reqCSS.end(function (err2, res) {
                     if (res.header['x-w3c-validator-status'] === 'Valid') isCSSValid = true;
                     if (isMarkupValid && isCSSValid) {
                         sr.info(exports.name, "link", { file : l.split('/').pop(), link : l , markup : "\u2714", css : "\u2714" });

--- a/lib/rules/structure/name.js
+++ b/lib/rules/structure/name.js
@@ -32,8 +32,8 @@ exports.check = function (sr, done) {
             return done();
         }
         else {
-            superagent.get(sr.url).end(function(result1) {
-                superagent.get(sr.url + OVERVIEW).end(function(result2) {
+            superagent.get(sr.url).end(function(err1, result1) {
+                superagent.get(sr.url + OVERVIEW).end(function(err2, result2) {
                     if (!result1.ok || !result2.ok || result1.text !== result2.text) {
                         sr.warning(exports.name, 'wrong', {note: ''});
                     }

--- a/tools/fetch-groups-db.js
+++ b/tools/fetch-groups-db.js
@@ -24,7 +24,7 @@ function norm (str) {
               .replace(/\s+/g, " ");
 }
 
-function munge (res) {
+function munge (err, res) {
     var $ = w.load(res.text);
     $("tr.WG, tr.IG, tr.CG").each(function () {
         // console.log("### tr", $(this).attr("class"));
@@ -53,4 +53,4 @@ ua
     .buffer(true)
     .end(munge);
 
-// munge({ text: fs.readFileSync(pth.join(__dirname, "groups.html"), "utf8") });
+// munge(err, { text: fs.readFileSync(pth.join(__dirname, "groups.html"), "utf8") });


### PR DESCRIPTION
 Sorry, changes to adapt to the new version of Superagent weren't complete before&hellip;

In particular, this PR updates the signature of functions that are passed as callbacks to `Superagent#end()`.