### PR TITLE
Add JSDoc and set up output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ NOTES.txt
 
 pubruleschecker
 scratch
+
+# JSDoc output
+doc/api/

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "coveralls": "^2.11.2",
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.17",
+    "jsdoc": "^3.3.2",
     "mocha": "^2.2.5",
     "nsp": "^1.0.3"
   },
   "scripts": {
     "coverage": "istanbul cover _mocha",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
+    "jsdoc": "jsdoc -a all -d doc/api/ -e utf8 -r app.js lib/ test/ tools/",
     "nsp": "nsp package",
     "start": "node app.js",
     "test": "mocha"


### PR DESCRIPTION
Add [JSDoc](http://usejsdoc.org/) `3.3.2` to `devDependencies`, and a script to run it. JSDoc output is not included in version control.

Usage: `npm run jsdoc`; then open `doc/api/index.html`.