### PR TITLE
Fix boolean conversion causing `"false"` to be converted to `true`

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -54,8 +54,8 @@ Specberus.prototype.validate = function (options) {
     self.config.validation = options.validation;
     self.config.htmlValidator = options.htmlValidator;
     self.config.cssValidator = options.cssValidator;
-    self.config.noRecTrack = !!options.noRecTrack;
-    self.config.informativeOnly = !!options.informativeOnly;
+    self.config.noRecTrack = (options.noRecTrack === "true") ? true : false;
+    self.config.informativeOnly = (options.informativeOnly === "true") ? true : false;
     self.config.patentPolicy = options.patentPolicy;
     self.config.processDocument = options.processDocument;
     self.config.lang = 'en_GB';


### PR DESCRIPTION
Loading specberus directly with query params wasn't checking the document with the right parameters.
The bug comes from a string to boolean conversion where `"false"` was converted to `true`.

Fix #206 