### PR TITLE
Read and write, and pass parameter “echidnaReady” to the validator, too

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,6 +105,7 @@ io.sockets.on("connection", function (socket) {
                     ,   validation:         data.validation
                     ,   noRecTrack:         data.noRecTrack
                     ,   informativeOnly:    data.informativeOnly
+                    ,   echidnaReady:       data.echidnaReady
                     ,   patentPolicy:       data.patentPolicy
                     ,   processDocument:    data.processDocument
                     });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -36,6 +36,7 @@ Specberus.prototype.validate = function (options) {
     //  - validation: whether to skip CSS and HTML validation
     //  - noRecTrack: document uses a Rec-track status but isn't on Rec-track
     //  - informativeOnly: document is informative only
+    //  - echidnaReady: document is intended for automatic publication
     //  - patentPolicy: Working Group Patent Policy
     //  - processDocument: process document to be used
 
@@ -54,8 +55,9 @@ Specberus.prototype.validate = function (options) {
     self.config.validation = options.validation;
     self.config.htmlValidator = options.htmlValidator;
     self.config.cssValidator = options.cssValidator;
-    self.config.noRecTrack = (options.noRecTrack === "true") ? true : false;
-    self.config.informativeOnly = (options.informativeOnly === "true") ? true : false;
+    self.config.noRecTrack = ('true' === options.noRecTrack);
+    self.config.informativeOnly = ('true' === options.informativeOnly);
+    self.config.echidnaReady = ('true' === options.echidnaReady);
     self.config.patentPolicy = options.patentPolicy;
     self.config.processDocument = options.processDocument;
     self.config.lang = 'en_GB';

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -88,8 +88,9 @@ jQuery.extend({
             url:                decodeURIComponent(options.url)
         ,   profile:            options.profile
         ,   validation:         options.validation
-        ,   noRecTrack:         options.noRecTrack
-        ,   informativeOnly:    options.informativeOnly
+        ,   noRecTrack:         ('true' === options.noRecTrack)
+        ,   informativeOnly:    ('true' === options.informativeOnly)
+        ,   echidnaReady:       ('true' === options.echidnaReady)
         ,   patentPolicy:       options.patentPolicy
         ,   processDocument:    options.processDocument
         });
@@ -279,12 +280,20 @@ jQuery.extend({
     }
 
     function setFormParams(options) {
+        // Option "echidnaReady" processed first, as it may restrict the list of enabled profiles.
+        if (options.echidnaReady === "true") $echidnaReady.prop('checked', true);
         if (options.url) $url.val(decodeURIComponent(options.url));
-        if (options.profile) $profile.find('option[value=' + options.profile+ ']').prop('selected', true);
+        // "profile" might be eg "WD-Echidna". Normalise.
+        if (options.profile) {
+          var newProfile = options.profile;
+          if (newProfile.indexOf('-') > -1) {
+            newProfile = newProfile.substring(0, newProfile.indexOf('-'));
+          }
+          $profile.find('option[value=' + newProfile + ']').prop('selected', true);
+        }
         if (options.validation) $validation.val(options.validation);
         if (options.noRecTrack === "true") $noRecTrack.prop('checked', true);
         if (options.informativeOnly === "true") $informativeOnly.prop('checked', true);
-        if (options.echidnaReady === "true") $echidnaReady.prop('checked', true);
         if (options.processDocument) {
           $processDocument.find('label').removeClass('active');
           $processDocument.find('label#' + options.processDocument).addClass('active');

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -286,8 +286,8 @@ jQuery.extend({
         // "profile" might be eg "WD-Echidna". Normalise.
         if (options.profile) {
           var newProfile = options.profile;
-          if (newProfile.indexOf('-') > -1) {
-            newProfile = newProfile.substring(0, newProfile.indexOf('-'));
+          if (newProfile.indexOf('-Echidna') > -1) {
+            newProfile = newProfile.substring(0, newProfile.indexOf('-Echidna'));
           }
           $profile.find('option[value=' + newProfile + ']').prop('selected', true);
         }


### PR DESCRIPTION
While reviewing #229, I noticed that [the UI parameter `echidnaReady`](https://github.com/w3c/specberus/commit/b84e3f74a4d7a7f9298c3df01e751a01516e6eee) isn't treated like the others (it isn't read and written, and passed along to the validator in the same way). This may be intentional, as `Specberus` doesn't really need that chunk of information at the moment. But for consistency, and to ensure the validator has access to that too should it need it in the future, I think it's best to pass it along.

(While at it, I also simplified [@deniak's boolean expressions](https://github.com/w3c/specberus/commit/13ef49b372c3defb390ddc8831b6f5756bc93c61), keeping his fix.)