### PR TITLE
Use 'published' rather than 'produced' to align with current respec-g…

### DIFF
--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -11,7 +11,7 @@ function buildWanted (groups, sr) {
         wanted = "This document is governed by the 24 January 2002 CPP as amended by the W3C Patent " +
                  "Policy Transition Procedure. ";
     else {
-        wanted = "This document was published by " +
+        wanted = "This document was produced by " +
                  ((groups.length == 2) ? "groups " : "a group ") +
                  "operating under the 5 February 2004 W3C Patent Policy. ";
         if (config.recTrackStatus && config.noRecTrack)

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -11,7 +11,7 @@ function buildWanted (groups, sr) {
         wanted = "This document is governed by the 24 January 2002 CPP as amended by the W3C Patent " +
                  "Policy Transition Procedure. ";
     else {
-        wanted = "This document was produced by " +
+        wanted = "This document was published by " +
                  ((groups.length == 2) ? "groups " : "a group ") +
                  "operating under the 5 February 2004 W3C Patent Policy. ";
         if (config.recTrackStatus && config.noRecTrack)
@@ -46,7 +46,7 @@ function findPP ($candidates, sr) {
         var $p = sr.$(this)
         ,   text = sr.norm($p.text())
         ,   wanted = buildWanted(groups, sr)
-        ,   jointRegex = /This document was produced by the (.+) Working Group and the (.+) Working Group./;
+        ,   jointRegex = /This document was published by the (.+) Working Group and the (.+) Working Group./;
         ;
         expected=wanted;
         if (jointRegex.test(text)) {
@@ -149,4 +149,3 @@ exports.check = function (sr, done) {
         sr.error(exports.name, "no-section6");
     done();
 };
-

--- a/test/docs/headers/joint-publication.html
+++ b/test/docs/headers/joint-publication.html
@@ -65,7 +65,7 @@
       inappropriate to cite this document as other than work in progress.
     </p>
     <p>
-        This document was produced by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a>
+        This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a>
       and the <a href="http://www.w3.org/Style/CSS/member">CSS Working Group</a>.
     </p>
     <p>


### PR DESCRIPTION
…enerated sotd

(I'll fix the rest of the text in ReSpec, but this one doesn't seem particularly warranted)