### PR TITLE
Remove “process 2014” from the options in the UI

### DIFF
--- a/lib/rules/sotd/process.js
+++ b/lib/rules/sotd/process.js
@@ -13,9 +13,9 @@ exports.check = function (sr, done) {
         return done();
     }
 
-    if ('2015' === processDocument) {
-        proc = '1 September 2015';
-        procUri = 'http://www.w3.org/2015/Process-20150901/';
+    if (processDocument === "2015") {
+        proc = "1 September 2015";
+        procUri = "http://www.w3.org/2015/Process-20150901/";
     }
     else if (processDocument === "2005") {
         proc = "14 October 2005";

--- a/public/index.html
+++ b/public/index.html
@@ -92,10 +92,6 @@
                         <input type="radio" name="processDocument" class="input-sm">
                         1 September 2015
                       </label>
-                      <label id="2014" class="btn btn-primary input-sm">
-                        <input type="radio" name="processDocument" class="input-sm">
-                        1 August 2014
-                      </label>
                       <label id="2005" class="btn btn-primary input-sm">
                         <input type="radio" name="processDocument" class="input-sm">
                         14 October 2005


### PR DESCRIPTION
Fix something that I missed in #220: the 3 processes (2005, 2014, 2015) were visible on the UI by mistake. This PR removes 2014.