### PR TITLE
Make “insafe” accept HTTP code 406 as valid

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,7 +94,7 @@ io.sockets.on("connection", function (socket) {
         });
         insafe.check({
             url: data.url,
-            statusCodesAccepted: ["301"]
+            statusCodesAccepted: ["301", "406"]
         }).then(function(res){
             if(res.status) {
                 try {


### PR DESCRIPTION
Apparently, some new TLDs aren't accepted by [insafe](https://github.com/w3c/insafe) because they return HTTP `406` (?). See w3c/insafe#8 and w3c/Mobile-Checker#115.

Lacking a better explanation, this patch tells `insafe` to accept that HTTP code.