### PR TITLE
Temporary fix for https://nodesecurity.io/advisories/46

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "morgan": "^1.6.1",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "socket.io": "^1.3.7",
+    "socket.io": "https://github.com/tripu/socket.io#master",
     "superagent": "^1.2.0",
     "whacko": "^0.18.1"
   },


### PR DESCRIPTION
`master` builds [are broken](https://travis-ci.org/w3c/specberus/builds/90309652) because of [a vulnerability in package `ms`](https://nodesecurity.io/advisories/46).

This is a temporary fix so that Travis builds are again meaningful for us, until these PRs are reviewed:
* socketio/engine.io#365
* socketio/engine.io-client#433
* socketio/socket.io#2316
* socketio/socket.io-adapter#32