### PR TITLE
Added more flexibility in exceptions

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -6,26 +6,24 @@ function compareValue(data, ref) {
     return (ref === undefined) || (data === ref);
 }
 
-function findSet(shortname) {
-    var count = 0;
-    function _findSet(name) {
-        if (count > 10)
-           return undefined;
-        var set = records[name];
-        count++;
-        if (typeof set === "String")
-            return _findSet(set);
-        return set;
+// from all of the arrays in the set of rules, find the ones applicable
+// according to a shortname
+function getApplicableSet(shortname) {
+    var set = [];
+    for (var key in records) {
+      if (shortname.startsWith(key)) {
+        set = set.concat(records[key]);
+      }
     }
-    return _findSet(shortname);
+    return set;
 }
 
 var Exceptions = function () {
 };
 
+// returns true if one of the rules matches the shortname, rule, and extra.type
 Exceptions.prototype.has = function (shortname, rule, key, extra) {
-    var set = findSet(shortname);
-    if (set === undefined) return false;
+    var set = getApplicableSet(shortname);
     for (var i = set.length - 1; i >= 0; i--) {
         var exception = set[i];
 

--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -24,14 +24,12 @@ var Exceptions = function () {
 // returns true if one of the rules matches the shortname, rule, and extra.type
 Exceptions.prototype.has = function (shortname, rule, key, extra) {
     var set = getApplicableSet(shortname);
-    for (var i = set.length - 1; i >= 0; i--) {
-        var exception = set[i];
-
+    var find = set.find(function (exception) {
         return (rule === exception.rule
                 && (extra === undefined
                     || compareValue(extra.type, exception.type)));
-    }
-    return false;
+    });
+    return (find !== undefined);
 };
 
 exports.Exceptions = Exceptions;


### PR DESCRIPTION
This allows the following definitions:

```json
{
  "css-": [
    {
      "rule": "validation.css",
      "type": "at-rule"
    }
  ],
  "css-ui-3": [
    {
      "rule": "validation.css",
      "type": "generator.unrecognize"
    }
  ]
}
```

Based on startsWith comparison, any shortname starting with "css-" will match the set of rules, and
css-ui-3 will take into account both set of rules (so both errors will be excluded in that case). 