### PR TITLE
Travis: build (and publish) always with latest stable Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.1"
+  - node
 script:
   - npm test
   - npm run nsp
@@ -20,6 +20,5 @@ deploy:
   api_key:
     secure: qPx+fMzf0AOVP1aIKGUrTTHcpoTkyYpsUq20rnDiqQbrNeMo44esOs4szPKtkwQYdM3iVY8AXMDBxej60g5dl4ZN2dy2FiuJnu9zy8ldsXJjEVTbMZT+nhQirJ17zczvP/AmBBY2s/MY5KUK69apgSuIa5nZNkfPjf1sBjfbnus=
   on:
-    node: '0.12'
     tags: true
     repo: w3c/specberus


### PR DESCRIPTION
The latest tag [wasn't published automatically to npm](https://travis-ci.org/w3c/specberus/builds/94616761#L1702) because `.travis.yml` has an outdated Node.js version.

Replacing that with `node` [as recommended in the docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Choosing-Node-versions-to-test-against) &ldquo;to run using the latest stable releases&rdquo;