### PR TITLE
Fix three deprecated packages

### DIFF
--- a/lib/rules/sotd/supersedable.js
+++ b/lib/rules/sotd/supersedable.js
@@ -15,8 +15,8 @@ exports.check = function (sr, done) {
         return done();
     }
     
-    var $em = $sotd.filter("p").find("> em").first();
-    if (!$em.length) $em = $sotd.find("p").find("> em").first();
+    var $em = $sotd.filter("p").children("em").first();
+    if (!$em.length) $em = $sotd.find("p").children("em").first();
     var txt = sr.norm($em.text())
     ,   wanted = "This section describes the status of this document at the time of its " +
                  "publication. Other documents may supersede this document. A list of current " +

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "request": "^2.58.0",
     "socket.io": "https://github.com/tripu/socket.io#master",
     "superagent": "^1.2.0",
-    "whacko": "^0.18.1"
+    "whacko": "^0.19.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
npm has been throwing these errors for a long time:

    npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
    npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^3.0.0.
    npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'

`CSSselect` and `CSSwhat` have not changed in ca. two years; `lodash` was stuck at a major version that is marked as deprecated. All these three are dependencies of `whacko`.

I submitted a couple of PRs for `whacko` to get this updated; those were promptly merged, and a new version of `whacko` published to npm (the previous one was eight months old). This PR incorporates that change in Specberus.

There was an issue with the new package `css-select`. My solution is to replace `$.find('> foo')` with `$.children('foo')`, more or less as suggested [here](https://stackoverflow.com/questions/33713139/cheerio-and-find-return-too-many-elements-compared-to-jquery/33714699#33714699) (see also cheeriojs/cheerio#780, cheeriojs/cheerio#728 and cheeriojs/cheerio#635).