### PR TITLE
Check new expected CSS location

### DIFF
--- a/lib/rules/style/sheet.js
+++ b/lib/rules/style/sheet.js
@@ -2,7 +2,7 @@
 exports.name = "style.sheet";
 exports.check = function (sr, done) {
     if (!sr.config.styleSheet) return done();
-    var url = "//www.w3.org/StyleSheets/TR/" + sr.config.styleSheet
+    var url = "//www.w3.org/StyleSheets/TR/2016/" + sr.config.styleSheet
     ,   sels = [
                 "head > link[rel=stylesheet][href='" + url + "']"
             ,   "head > link[rel=stylesheet][href='http:" + url + "']"

--- a/test/docs/echidna/automated-wg.html
+++ b/test/docs/echidna/automated-wg.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/dl-trailing-whitespace.html
+++ b/test/docs/headers/dl-trailing-whitespace.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/ig-note.html
+++ b/test/docs/headers/ig-note.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <title>Simple baseline headers valid document</title>
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-IG-NOTE'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-IG-NOTE'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/joint-publication-fail.html
+++ b/test/docs/headers/joint-publication-fail.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/joint-publication.html
+++ b/test/docs/headers/joint-publication.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/permissive-doc-license.html
+++ b/test/docs/headers/permissive-doc-license.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/simple-oxford.html
+++ b/test/docs/headers/simple-oxford.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/simple.html
+++ b/test/docs/headers/simple.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/headers/wrong-urls.html
+++ b/test/docs/headers/wrong-urls.html
@@ -5,7 +5,7 @@
     <title>Simple baseline headers valid document</title>
     <!-- remove the below when CSS Validator is fixed -->
     <style></style>
-    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   </head>
   <body>
     <div class='head'>

--- a/test/docs/style/style-not-last.html
+++ b/test/docs/style/style-not-last.html
@@ -1,5 +1,5 @@
 <head>
-  <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+  <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
   <link rel='stylesheet' href='http://berjon.com/'>
 </head>
 


### PR DESCRIPTION
Note it's `w3.org/StyleSheets/TR/2016/` (not `w3.org/TR/StyleSheets/2016/` like the original issue said). This final URL is taken from our latest exchanges by e-mail.

@TODO: **[the CSS files](https://github.com/w3c/tr-design/tree/gh-pages/src) have to be deployed to that location before this milestone** (29 Jan 2016).

cf. #267.