### PR TITLE
Check new expected script, “fixup.js”

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -170,6 +170,8 @@ for extended information about the publication rules.'
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."
     // style/meta
 ,   "meta.not-found":           "The viewport meta tag is required (<code>&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\"&gt;</code>)."
+    // style/script
+,   "style.script.not-found":   "A link to the script <code>fixup.js</code> is required (<code>&lt;script src=\"//www.w3.org/scripts/TR/2016/fixup.js\"&gt;&lt;/script&gt;</code>)."
     // validation/css
 ,   "validation.css.skipped":       "CSS validation was skipped."
 ,   "validation.css.no-source":     "No CSS source to validate."

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -170,6 +170,8 @@ for extended information about the publication rules.'
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."
     // style/meta
 ,   "meta.not-found":           "The viewport meta tag is required (<code>&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\"&gt;</code>)."
+    // style/script
+,   "style.script.not-found":   "A link to the script <code>fixup.js</code> is required (<code>&lt;script src=\"//www.w3.org/scripts/TR/2016/fixup.js\"&gt;&lt;/script&gt;</code>)."
     // validation/css
 ,   "validation.css.skipped":       "CSS validation was skipped."
 ,   "validation.css.no-source":     "No CSS source to validate."

--- a/lib/profiles/base.js
+++ b/lib/profiles/base.js
@@ -36,6 +36,7 @@ exports.rules = [
 
 ,   require("../rules/style/sheet")
 ,   require("../rules/style/meta")
+,   require("../rules/style/script")
 
 ,   require("../rules/sotd/supersedable")
 ,   require("../rules/sotd/diff")

--- a/lib/rules/style/script.js
+++ b/lib/rules/style/script.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Check whether the script <code>fixup.js</code> is linked in the page.
+ */
+
+exports.name = 'style.script';
+
+exports.check = function (sr, done) {
+
+    var candidates = sr.$("script[src='//www.w3.org/scripts/TR/2016/fixup.js']");
+
+    if (1 !== candidates.length) {
+        sr.error(this.name, 'not-found');
+    }
+
+    done();
+
+};

--- a/test/all-rules.js
+++ b/test/all-rules.js
@@ -111,6 +111,10 @@ var tests = {
         ,   { doc: "style/simple.html" }
         ,   { doc: "style/wrong-meta.html", errors: ["style.meta"] }
         ]
+    ,   script:  [
+            { doc: "headers/simple.html", errors: ["style.script"] }
+        ,   { doc: "headers/fixup.html" }
+        ]
     }
 ,   links:   {
         internal:  [

--- a/test/docs/headers/fixup.html
+++ b/test/docs/headers/fixup.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/W3C-WD'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="http://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="http://www.w3.org/Icons/w3c_home">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 15 March 2017, edited in place 01 April 2014</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170315/'>http://www.w3.org/TR/2017/WD-specberus-20170315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='http://www.w3.org/TR/specberus/'>http://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20170312/'>http://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
+        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>,
+        <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+      <hr>
+    </div>
+    <h2>Abstract</h2>
+    <p>
+      We are the internets!
+    </p>
+    <h2>Status of This Document</h2>
+    <p><em>This section describes the status of this document at the time of its publication.
+    Other documents may supersede this document. A list of current W3C publications and the
+    latest revision of this technical report can be found in the
+    <a href="http://www.w3.org/TR/">W3C technical reports index</a> at
+    http://www.w3.org/TR/.</em></p>
+    <p>
+      If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-html@w3.org">public-html@w3.org</a>
+      (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="http://lists.w3.org/Archives/Public/public-html/">archives</a>).
+    </p>
+    <p>
+      It's a valid test!
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the W3C Membership. This is a
+      draft document and may be updated, replaced or obsoleted by other documents at any time. It is
+      inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" about="" rel="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+      <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of
+      any patent disclosures</a> made in connection with the deliverables of the group; that page
+      also includes instructions for disclosing a patent. An individual who has actual knowledge of
+      a patent which the individual believes contains
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      Claim(s)</a> must disclose the information in accordance with
+      <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    </p>
+    <h2>Table of Contents</h2>
+    <ul>
+      <li>Nothing</li>
+    </ul>
+    <script src="//www.w3.org/scripts/TR/2016/fixup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Notes/questions (don't merge until these are addressed):

- [x] **About the rule**: this rule *checks that the script is linked on the spec already*, ie it does *not* add a link to the script. This follows what we usually do with documents (we don't alter them, but point editors to errors and ask them to fix). Let's discuss if this is is going to pose a problem and we really need to append the `<script>` element ourselves.  
&rarr; **Update (19 Jan)**: confirmed after chatting with @deniak and @plehegar that we're *checking* this, not *adding* it to the spec.
- [x] **About the URL of the script**: @plehegar mentioned `https://www.w3.org/scripts/fixup.js` in the last e-mail thread. But I'd prefer not to have scripts directly under that directory (`scripts`). Since we'll deploy the new CSS at `w3.org/StyleSheets/TR/2016/`, this PR suggests we put this script at the analogous location, `w3.org/scripts/TR/2016/fixup.js` (so, `w3.org/scripts/TR/` will be used only for TR scripts going forward). Sounds good?  
&rarr; **Update (16 Feb)**: confirmed the location; cf. [`tabatkins/bikeshed#569#issuecomment-184607100`](https://github.com/tabatkins/bikeshed/issues/569#issuecomment-184607100).

@TODO: **[the script](https://github.com/w3c/tr-design/blob/gh-pages/src/fixup.js) has to be deployed to that location before this milestone** (29 Jan 2016).

cf. #267.