### PR TITLE
Emit new informative messages regarding recommended markup

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -163,6 +163,9 @@ See <a href="http://www.w3.org/2001/06/manual/#Status">examples and more discuss
 ,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
 Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
 for extended information about the publication rules.'
+,   'structure.display-only.special-box-markup': 'Remember to use classes <code>example</code>, <code>def</code>, <code>note</code> and <code>marker</code>, and <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#boxes">other special box markup</a>.'
+,   'structure.display-only.index-list-tables':  'Remember to use class <code>index</code> for <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#indexing">index lists and tables</a>.'
+,   'structure.display-only.fit-in-a4':          'Make sure spec illustrations/tables fit within an A4 sheet of paper when printed; use class <code>overlarge</code> if needed to improve experience on-screen for things that overflow.'
     // style/sheet
 ,   "style.sheet.last":         "W3C TR style sheet must be last."
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -163,6 +163,9 @@ See <a href="http://www.w3.org/2001/06/manual/#Status">examples and more discuss
 ,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
 Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
 for extended information about the publication rules.'
+,   'structure.display-only.special-box-markup': 'Remember to use classes <code>example</code>, <code>def</code>, <code>note</code> and <code>marker</code>, and <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#boxes">other special box markup</a>.'
+,   'structure.display-only.index-list-tables':  'Remember to use class <code>index</code> for <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#indexing">index lists and tables</a>.'
+,   'structure.display-only.fit-in-a4':          'Make sure spec illustrations/tables fit within an A4 sheet of paper when printed; use class <code>overlarge</code> if needed to improve experience on-screen for things that overflow.'
     // style/sheet
 ,   "style.sheet.last":         "W3C TR style sheet must be last."
 ,   "style.sheet.not-found":    "Missing W3C TR style sheet."

--- a/lib/rules/structure/display-only.js
+++ b/lib/rules/structure/display-only.js
@@ -1,3 +1,6 @@
+/**
+ * @file Informative-only messages, advice and reminders.
+ */
 
 'use strict';
 
@@ -9,7 +12,9 @@ exports.check = function (sr, done) {
     sr.info(exports.name, 'customised-paragraph');
     sr.info(exports.name, 'known-disclosures');
     sr.info(exports.name, 'old-pubrules');
-    return done();
+    sr.info(exports.name, 'special-box-markup');
+    sr.info(exports.name, 'index-list-tables');
+    sr.info(exports.name, 'fit-in-a4');
+    done();
 
 };
-


### PR DESCRIPTION
NB: adds 3 new `info` messages to the output; this rule does *not* fail.

cf. #267.