### PR TITLE
Generic exceptions

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -11,7 +11,13 @@ function findSet(shortname) {
     function _findSet(name) {
         if (count > 10)
            return undefined;
-        var set = records[name];
+        var set = [];
+        for (var k in records) {
+          var regex = new RegExp(k);
+          if (records.hasOwnProperty(k) && regex.test(name)) {
+            set.push(records[k]);
+          }
+        }
         count++;
         if (typeof set === "String")
             return _findSet(set);
@@ -27,11 +33,16 @@ Exceptions.prototype.has = function (shortname, rule, key, extra) {
     var set = findSet(shortname);
     if (set === undefined) return false;
     for (var i = set.length - 1; i >= 0; i--) {
-        var exception = set[i];
+        for (var y = set[i].length - 1; y >= 0; y--) {
+          var exception = set[i][y];
 
-        return (rule === exception.rule
-                && (extra === undefined
-                    || compareValue(extra.type, exception.type)));
+          if (rule === exception.rule
+              && (extra === undefined
+                  || (compareValue(extra.type, exception.type)
+                      && compareValue(extra.source, exception.source)))) {
+                            return true;
+          }
+        }
     }
     return false;
 };

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -1,15 +1,27 @@
 {
-  "webrtc": [
+  ".*": [
+    {
+      "rule": "validation.css",
+      "type": "generator.unrecognize",
+      "source": "https://www.w3.org/2016/01/base.css"
+    },
+    {
+      "rule": "validation.css",
+      "type": "generator.unrecognize",
+      "source": "https://www.w3.org/StyleSheets/TR/2016/base.css"
+    }
+  ],
+  "^webrtc$": [
     {
       "rule": "headers.copyright"
     }
   ],
-  "mediacapture-streams": [
+  "^mediacapture-streams$": [
     {
       "rule": "headers.copyright"
     }
   ],
-  "css-ui-3": [
+  "^css-ui-3$": [
     {
       "rule": "validation.css",
       "type": "at-rule"

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -3,11 +3,6 @@
     {
       "rule": "validation.css",
       "type": "generator.unrecognize",
-      "source": "https://www.w3.org/2016/01/base.css"
-    },
-    {
-      "rule": "validation.css",
-      "type": "generator.unrecognize",
       "source": "https://www.w3.org/StyleSheets/TR/2016/base.css"
     }
   ],


### PR DESCRIPTION
`exceptions.json` now takes regexp for shortnames.