### PR TITLE
Reset Specberus.docDateEl when clearing the cache

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -20,6 +20,7 @@ var Specberus = function () {
 
 Specberus.prototype.clearCache = function () {
     this.docDate = null;
+    this.docDateEl = null;
     this.sotdSection = null;
     this.url = null;
     this.source = null;

--- a/test/docs/headers/h2-comma.html
+++ b/test/docs/headers/h2-comma.html
@@ -1,2 +1,6 @@
 <title>Ohai!</title>
-<h2>W3C Working Draft, 01 January 1970</h2>
+<body>
+    <div class="head">
+        <h2>W3C Working Draft, 01 January 1970</h2>
+    </div>
+</body>


### PR DESCRIPTION
[This test](https://github.com/w3c/specberus/blob/master/test/all-rules.js#L82) passes (wrongly) just because [`Specberus.docDateEl` keeps its value from the last validation](https://github.com/w3c/specberus/blob/master/lib/validator.js#L168-L189) (wrongly).

This PR makes sure that property is reset every time Specberus' cache is cleared, and updates the test document to make it valid.