### PR TITLE
Set up REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The interface you get when you `require("specberus")` is that from `lib/validato
 `Specberus` instance that is properly configured for operation in the Node.js environment
 (there is nominal support for running Specberus under other environments, but it isn't usable at this time).
 
-(See also [the REST API](#rest-api).)
+(See also [the REST API](#5-rest-api).)
 
 ### `validate(options)`
 
@@ -132,7 +132,7 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 
 ## 5. REST API
 
-Similar to the [JS API](#js-api), Specberus exposes a REST API via HTTP too.
+Similar to the [JS API](#4-js-api), Specberus exposes a REST API via HTTP too.
 
 The endpoint is `<host>/api/`.
 Use either `url` or `file` to pass along the document (neither `source` nor `document` are allowed).

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Extract all known metadata from document; [returns a JSON object with inferred p
 
 Check the document ([syntax](#validateoptions)); fails and returns an array of errors, or succeeds and returns the profile.
 
+The special profile `auto` is also available.
+
 ### Examples
 
 * `<host>/api/version`

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 
 ## REST API
 
-Similar to the [JS API](#js-api), Specberus exposes a REST API too.
+Similar to the [JS API](#js-api), Specberus exposes a REST API via HTTP too.
 
 The endpoint is `<host>/api/`.
-Use either `url` or `file` to pass along the document (`source` and `document` are not allowed).
+Use either `url` or `file` to pass along the document (neither `source` nor `document` are allowed).
 
 There are three `GET` methods available.
 
@@ -136,11 +136,12 @@ Returns the version string, eg `1.5.3`.
 
 ### `metadata`
 
-Extract all known metadata from document; [returns a JSON object with inferred properties](#extractmetadataoptions).
+Extract all known metadata from a document; see [below](#return-values) for information about the return value.
 
 ### `validate`
 
-Check the document ([syntax](#validateoptions)); fails and returns an array of errors, or succeeds and returns the profile.
+Check the document ([syntax](#validateoptions)).
+Many of [the options understood by the JS method `validate`](#validateoptions) are accepted.
 
 The special profile `auto` is also available.
 
@@ -150,6 +151,57 @@ The special profile `auto` is also available.
 * `<host>/api/metadata?url=http://example.com/doc.html`
 * `<host>/api/validate?file=/home/me/docs/spec.html`
 * `<host>/api/validate?file=draft2.html&profile=WD&validation=simple-validation&processDocument=2015`
+
+### Return values
+
+Methods `metadata` and `validate` return a JSON object with these properties:
+
+* `success` (`boolean`): whether the operation succeeded, or not.
+* `errors` (`array`): all errors found.
+* `warnings` (`array`): all warnings.
+* `info` (`array`): additional, informative messages.
+* `metadata` (`object`):
+
+If there is an internal error, the document cannot be retrieved or is not recognised, or validation fails, both methods would return HTTP status code `400`.
+Also, in the case of `validate`, `success` would be `false`, and `errors.length > 0`.
+
+This is an example of a successful validation of a document, with profile `auto`:
+
+```json
+{ "success": true,
+  "errors": [],
+  "warnings":
+   [ "headers.ol-toc",
+     "links.linkchecker",
+     "links.compound",
+     "headers.dl" ],
+  "info":
+   [ "sotd.diff",
+     "structure.display-only",
+     "structure.display-only",
+     "structure.display-only",
+     "validation.wcag" ],
+  "metadata":
+   { "profile": "WD",
+     "title": "Character Model for the World Wide Web: String Matching and Searching",
+     "docDate": "2016-4-7",
+     "thisVersion": "http://www.w3.org/TR/2016/WD-charmod-norm-20160407/",
+     "latestVersion": "http://www.w3.org/TR/charmod-norm/",
+     "previousVersion": "http://www.w3.org/TR/2015/WD-charmod-norm-20151119/",
+     "editorsDraft": "http://w3c.github.io/charmod-norm/",
+     "delivererIDs": [ 32113 ],
+     "editorIDs": [ 33573 ],
+     "rectrack": false,
+     "informative": false,
+     "process": "http://www.w3.org/2015/Process-20150901/",
+     "url": "https://www.w3.org/TR/2016/WD-charmod-norm-20160407/"
+  }
+}
+```
+
+When the profile is given by the user, fewer items of metadata are returned.
+
+`metadata` returns a similar structure, where all values are empty arrays, except for the key `metadata` which contains the metadata object.
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,26 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 
 ## REST API
 
-Similar to the [Node.js API](#js-api), Specberus exposes a REST API too.
+Similar to the [JS API](#js-api), Specberus exposes a REST API too.
 
 The endpoint is `<host>/api/`.
+Use either `url` or `file` to pass along the document (`source` and `document` are not allowed).
 
-There are three `GET` methods available:
+There are three `GET` methods available.
 
-* `version`: returns the version string, eg `1.5.3`.
-* `metadata`: extract all known metadata from document; [returns JSON object with inferred properties](#extractmetadataoptions).
-* `validate`: check the document ([syntax](#validateoptions)); fails and returns an array of errors, or succeeds and returns the profile.
+### `version`
 
-Examples:
+Returns the version string, eg `1.5.3`.
+
+### `metadata`
+
+Extract all known metadata from document; [returns a JSON object with inferred properties](#extractmetadataoptions).
+
+### `validate`
+
+Check the document ([syntax](#validateoptions)); fails and returns an array of errors, or succeeds and returns the profile.
+
+### Examples
 
 * `<host>/api/version`
 * `<host>/api/metadata?url=http://example.com/doc.html`

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ unavailable. To work around this, you can set SKIP_NETWORK:
 
     SKIP_NETWORK=1 mocha
 
-## API
+## JS API
 
 The interface you get when you `require("specberus")` is that from `lib/validator`. It returns a
 `Specberus` instance that is properly configured for operation in the Node.js environment
 (there is nominal support for running Specberus under other environments, but it isn't usable at this time).
+
+(See also [the REST API](#rest-api).)
 
 ### `validate(options)`
 
@@ -118,6 +120,25 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
   "process": "http://www.w3.org/2015/Process-20150901/" }
 }
 ```
+
+## REST API
+
+Similar to the [Node.js API](#js-api), Specberus exposes a REST API too.
+
+The endpoint is `<host>/api/`.
+
+There are three `GET` methods available:
+
+* `version`: returns the version string, eg `1.5.3`.
+* `metadata`: extract all known metadata from document; [returns JSON object with inferred properties](#extractmetadataoptions).
+* `validate`: check the document ([syntax](#validateoptions)); fails and returns an array of errors, or succeeds and returns the profile.
+
+Examples:
+
+* `<host>/api/version`
+* `<host>/api/metadata?url=http://example.com/doc.html`
+* `<host>/api/validate?file=/home/me/docs/spec.html`
+* `<host>/api/validate?file=draft2.html&profile=WD&validation=simple-validation&processDocument=2015`
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@
 
 Specberus is a checker used at [W3C](http://www.w3.org/) to validate the compliance of [Technical Reports](http://www.w3.org/TR/) with publication rules.
 
-## Installation
+1. [Installation](#1-installation)
+1. [Running](#2-running)
+1. [Testing](#3-testing)
+1. [JS API](#4-js-api)
+1. [REST API](#5-rest-api)
+1. [Profiles](#6-profiles)
+1. [Validation events](#7-validation-events)
+1. [Writing rules](#8-writing-rules)
+
+## 1. Installation
 
 Specberus is a [Node.js](https://nodejs.org/en/) application, [distributed through npm](https://www.npmjs.com/package/specberus).
 Alternatively, you can clone [the repository](https://github.com/w3c/specberus) and run:
@@ -19,7 +28,7 @@ Alternatively, you can clone [the repository](https://github.com/w3c/specberus) 
 In order to get all the dependencies installed. Naturally, this requires that you have a reasonably
 recent version of Node.js installed.
 
-## Running
+## 2. Running
 
 Currently there is no shell to run Specberus. Later we will add both Web and CLI interfaces based
 on the same core library.
@@ -42,7 +51,7 @@ $ npm start
 $ npm start 3001
 ```
 
-## Testing
+## 3. Testing
 
 Testing is done using mocha. Simply run:
 
@@ -57,7 +66,7 @@ unavailable. To work around this, you can set SKIP_NETWORK:
 
     SKIP_NETWORK=1 mocha
 
-## JS API
+## 4. JS API
 
 The interface you get when you `require("specberus")` is that from `lib/validator`. It returns a
 `Specberus` instance that is properly configured for operation in the Node.js environment
@@ -121,7 +130,7 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 }
 ```
 
-## REST API
+## 5. REST API
 
 Similar to the [JS API](#js-api), Specberus exposes a REST API via HTTP too.
 
@@ -160,10 +169,10 @@ Methods `metadata` and `validate` return a JSON object with these properties:
 * `errors` (`array`): all errors found.
 * `warnings` (`array`): all warnings.
 * `info` (`array`): additional, informative messages.
-* `metadata` (`object`):
+* `metadata` (`object`): extracted metadata; [see structure here](#extractmetadataoptions).
 
 If there is an internal error, the document cannot be retrieved or is not recognised, or validation fails, both methods would return HTTP status code `400`.
-Also, in the case of `validate`, `success` would be `false`, and `errors.length > 0`.
+Also, in the case of `validate`, `success` would be `false` and `errors.length > 0`.
 
 This is an example of a successful validation of a document, with profile `auto`:
 
@@ -199,11 +208,11 @@ This is an example of a successful validation of a document, with profile `auto`
 }
 ```
 
-When the profile is given by the user, fewer items of metadata are returned.
+When the profile is given by the user (instead of being set to `auto`), fewer items of metadata are returned.
 
 `metadata` returns a similar structure, where all values are empty arrays, except for the key `metadata` which contains the metadata object.
 
-## Profiles
+## 6. Profiles
 
 Profiles are simple objects that support the following API:
 
@@ -238,7 +247,7 @@ Profiles that are identical to its parent profile, ie that do not add any new ru
     * `LC`
 * `dummy`
 
-## Validation events
+## 7. Validation events
 
 For a given checking run, the event sink you specify will be receiving a bunch of events as
 indicated below. Events are shown as having parameters since those are passed to the event handler.
@@ -262,7 +271,7 @@ indicated below. Events are shown as having parameters since those are passed to
   contains details about this error. All exceptions are displayed on the error console in addition to
   this event being fired.
 
-## Writing rules
+## 8. Writing rules
 
 Rules are simple modules that just expose a `check(sr, cb)` method. They receive a Specberus object
 and a callback, use the Specberus object to fire validation events and call the callback when

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ const package = require('./package.json')
 ,   api = require('./lib/api')
 ,   l10n = require('./lib/l10n')
 ,   sink = require('./lib/sink')
-,   util = require('./lib/util');
+,   util = require('./lib/util')
 ,   validator = require('./lib/validator')
 ;
 

--- a/app.js
+++ b/app.js
@@ -19,27 +19,19 @@ const bodyParser = require('body-parser')
 
 // Internal packages:
 const package = require('./package.json')
+,   api = require('./lib/api')
 ,   l10n = require('./lib/l10n')
 ,   sink = require('./lib/sink')
+,   util = require('./lib/util');
 ,   validator = require('./lib/validator')
-,   api = require('./lib/api')
 ;
 
 const app = express()
 ,   server = http.createServer(app)
 ,   io = socket.listen(server)
-,   profiles = {}
+,   profiles = util.profiles
 ,   Sink = sink.Sink
 ,   version = package.version
-;
-
-("FPWD FPLC FPCR WD LC CR PR PER REC RSCND " +
-"CG-NOTE FPIG-NOTE IG-NOTE FPWG-NOTE WG-NOTE " +
-"WD-Echidna WG-NOTE-Echidna " +
-"MEM-SUBM TEAM-SUBM").split(" ")
-         .forEach(function (p) {
-             profiles[p] = require("./lib/profiles/" + p);
-         })
 ;
 
 // middleware

--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ const package = require('./package.json')
 ,   l10n = require('./lib/l10n')
 ,   sink = require('./lib/sink')
 ,   validator = require('./lib/validator')
+,   api = require('./lib/api')
 ;
 
 const app = express()
@@ -46,6 +47,7 @@ app.use(morgan('combined'));
 app.use(compression());
 app.use(bodyParser.json());
 app.use(express.static("public"));
+api.setUp(app);
 
 // listen up
 server.listen(process.argv[2] || process.env.PORT || DEFAULT_PORT);

--- a/lib/api.js
+++ b/lib/api.js
@@ -33,7 +33,7 @@ const buildAndSendResult = function(err, warn, inf, res, metadata) {
     ,   metadata: metadata
     };
 
-    res.status(wrapper.success ? 200 : 400).send(wrapper);
+    res.status(wrapper.success ? 200 : 400).json(wrapper);
 
 };
 
@@ -72,7 +72,7 @@ const processRequest = function(req, res) {
             );
         }
         catch (err) {
-            return res.status(400).send(err.toString());
+            return buildAndSendResult([err.toString()], [], [], res, []);
         }
         if (validate && 'auto' === options.profile) {
             errors = [];
@@ -81,7 +81,7 @@ const processRequest = function(req, res) {
                 errors.push(data);
             }, function(data) {
                 if (errors.length > 0)
-                    res.status(400).send(errors);
+                    buildAndSendResult(errors, [], [], res, []);
                 else {
                     if (options.url)
                         data.url = options.url;
@@ -95,7 +95,7 @@ const processRequest = function(req, res) {
                         );
                     }
                     catch (err) {
-                        return res.status(400).send(err.toString());
+                        return buildAndSendResult([err.toString()], [], [], res, []);
                     }
                     options2.validation = 'simple-validation';
                     options2.processDocument = 'http://www.w3.org/2015/Process-20150901/' === data.process ? '2015' : '2005';

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,10 +5,12 @@
 // Internal packages:
 const package = require('../package.json')
 ,   sink = require('./sink')
+,   util = require('./util')
 ,   validator = require('./validator')
 ;
 
 const Sink = sink.Sink
+,   profiles = util.profiles
 ,   version = package.version
 ;
 
@@ -20,11 +22,19 @@ const Sink = sink.Sink
  */
 
 const parseSource = function(query) {
-    var result;
-    if (query.url) result = {url: query.url};
-    else if (query.source) result = {source: query.source};
-    else if (query.file) result = {file: query.file};
-    else if (query.document) result = {document: query.document};
+    const result = {};
+    if (query.url) result.url = query.url;
+    else if (query.source) result.source =uery.source;
+    else if (query.file) result.file = query.file;
+    else if (query.document) result.document = query.document;
+    if (query.profile) {
+        if (profiles[query.profile])
+            result.profile = profiles[query.profile];
+        else
+            throw new Error('Cannot retrieve profile “' + query.profile + '”');
+    }
+    if (query.validation) result.validation = query.validation;
+    if (query.processDocument) result.processDocument = query.processDocument;
     return result;
 };
 
@@ -37,63 +47,45 @@ const parseSource = function(query) {
 
 const parseRequest = function(req, res) {
 
-    var options
-    ,   v
-    ,   handler
-    ;
-
     if ('/api/version' === req.path) {
         res.status(200).send(version);
     }
-
-    else if (!req.query) {
-        res.status(400).send('Missing parameters.');
-    }
-
-    else if ('/api/metadata' === req.path) {
-        options = parseSource(req.query);
+    else if ('/api/metadata' === req.path || '/api/validate' === req.path) {
+        const validate = ('/api/validate' === req.path)
+        ,   options = parseSource(req.query)
+        ;
         if (0 === Object.keys(options).length) {
             res.status(400).send('At least one of "url", "source", "file" or "document" must be specified.');
         }
         else {
-            v = new validator.Specberus
-            handler = new Sink(function(data) {
-                res.status(500).send(data);
-            }, function(data) {
-                res.status(200).send(v.meta);
-            })
+            var errors = [];
+            const v = new validator.Specberus
+            ,   handler = new Sink(function(data) {
+                    errors.push(data);
+                }, function(data) {
+                    if (errors.length > 0)
+                        res.status(400).send(errors);
+                    else if (validate)
+                        res.status(200).send(data);
+                    else
+                        res.status(200).send(v.meta);
+                })
             ;
             options.events = handler;
-            v.extractMetadata(options);
+            if (validate)
+                v.validate(options);
+            else
+                v.extractMetadata(options);
         }
     }
-
-    else if ('/api/validate' === req.path) {
-        options = parseSource(req.query);
-        if (0 === Object.keys(options).length) {
-            res.status(400).send('At least one of "url", "source", "file" or "document" must be specified.');
-        }
-        else {
-            v = new validator.Specberus
-            handler = new Sink(function(data) {
-                res.status(500).send(data);
-            }, function(data) {
-                res.status(200).end();
-            })
-            ;
-            options.events = handler;
-            v.validate(options);
-        }
-    }
-
     else {
-        res.status(404).send('Wrong API method.');
+        res.status(400).send('Wrong API method.');
     }
 
 };
 
 const setUp = function(app) {
-    app.post('/api/*', parseRequest);
+    app.get('/api/*', parseRequest);
 };
 
 exports.setUp = setUp;

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,99 @@
+/**
+ * Specberus REST API.
+ */
+
+// Internal packages:
+const package = require('../package.json')
+,   sink = require('./sink')
+,   validator = require('./validator')
+;
+
+const Sink = sink.Sink
+,   version = package.version
+;
+
+/**
+ * Build an "options" object based on an HTTP query string.
+ *
+ * @param {Object} query - an HTTP request query.
+ * @returns {Object} an "options" object that can be used by Specberus.
+ */
+
+const parseSource = function(query) {
+    var result;
+    if (query.url) result = {url: query.url};
+    else if (query.source) result = {source: query.source};
+    else if (query.file) result = {file: query.file};
+    else if (query.document) result = {document: query.document};
+    return result;
+};
+
+/**
+ * Handle an API request: parse method and parameters; handle common errors.
+ *
+ * @param {Object} req - HTTP request.
+ * @param {Object} res - HTTP result.
+ */
+
+const parseRequest = function(req, res) {
+
+    var options
+    ,   v
+    ,   handler
+    ;
+
+    if ('/api/version' === req.path) {
+        res.status(200).send(version);
+    }
+
+    else if (!req.query) {
+        res.status(400).send('Missing parameters.');
+    }
+
+    else if ('/api/metadata' === req.path) {
+        options = parseSource(req.query);
+        if (0 === Object.keys(options).length) {
+            res.status(400).send('At least one of "url", "source", "file" or "document" must be specified.');
+        }
+        else {
+            v = new validator.Specberus
+            handler = new Sink(function(data) {
+                res.status(500).send(data);
+            }, function(data) {
+                res.status(200).send(v.meta);
+            })
+            ;
+            options.events = handler;
+            v.extractMetadata(options);
+        }
+    }
+
+    else if ('/api/validate' === req.path) {
+        options = parseSource(req.query);
+        if (0 === Object.keys(options).length) {
+            res.status(400).send('At least one of "url", "source", "file" or "document" must be specified.');
+        }
+        else {
+            v = new validator.Specberus
+            handler = new Sink(function(data) {
+                res.status(500).send(data);
+            }, function(data) {
+                res.status(200).end();
+            })
+            ;
+            options.events = handler;
+            v.validate(options);
+        }
+    }
+
+    else {
+        res.status(404).send('Wrong API method.');
+    }
+
+};
+
+const setUp = function(app) {
+    app.post('/api/*', parseRequest);
+};
+
+exports.setUp = setUp;

--- a/lib/api.js
+++ b/lib/api.js
@@ -117,6 +117,9 @@ const processRequest = function(req, res) {
                     v2.validate(options2);
                 }
             });
+            handler.on('exception', function(data) {
+                buildAndSendResult([data.message ? data.message : data], [], [], res, []);
+            });
             options.events = handler;
             v.extractMetadata(options);
         }
@@ -133,6 +136,9 @@ const processRequest = function(req, res) {
                 warnings.push(data);
             }, function(data) {
                 info.push(data);
+            });
+            handler.on('exception', function(data) {
+                buildAndSendResult([data.message ? data.message : data], [], [], res, []);
             });
             options.events = handler;
             if (validate)

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,10 +14,34 @@ const Sink = sink.Sink
 ;
 
 /**
+ * Build a JSON response, and send it to the client.
+ *
+ * @param {Array} err - errors.
+ * @param {Array} warn - warnings.
+ * @param {Array} inf - informative messages.
+ * @param {Object} res - Express HTTP response.
+ * @param {Object} metadata - dictionary with some found metadata.
+ */
+
+const buildAndSendResult = function(err, warn, inf, res, metadata) {
+
+    const wrapper = {
+        success: 0 === err.length
+    ,   errors: err
+    ,   warnings: warn
+    ,   info: inf
+    ,   metadata: metadata
+    };
+
+    res.status(wrapper.success ? 200 : 400).send(wrapper);
+
+};
+
+/**
  * Handle an API request: parse method and parameters, handle common errors and call the validator.
  *
- * @param {Object} req - HTTP request.
- * @param {Object} res - HTTP result.
+ * @param {Object} req - Express HTTP request.
+ * @param {Object} res - Express HTTP response.
  */
 
 const processRequest = function(req, res) {
@@ -33,6 +57,10 @@ const processRequest = function(req, res) {
         ,   options2
         ,   errors
         ,   errors2
+        ,   warnings
+        ,   warnings2
+        ,   info
+        ,   info2
         ,   handler
         ,   handler2
         ;
@@ -73,14 +101,17 @@ const processRequest = function(req, res) {
                     options2.processDocument = 'http://www.w3.org/2015/Process-20150901/' === data.process ? '2015' : '2005';
                     options2.noRecTrack = !data.rectrack;
                     errors2 = [];
+                    warnings2 = [];
+                    info2 = [];
                     v2 = new validator.Specberus
                     handler2 = new Sink(function(data2) {
                         errors2.push(data2);
-                    }, function(data2) {
-                        if (errors2.length > 0)
-                            res.status(400).send(errors2);
-                        else
-                            res.status(200).send(data2);
+                    }, function() {
+                        buildAndSendResult(errors2, warnings2, info2, res, data);
+                    }, function(data) {
+                        warnings2.push(data);
+                    }, function(data) {
+                        info2.push(data);
                     });
                     options2.events = handler2;
                     v2.validate(options2);
@@ -91,16 +122,17 @@ const processRequest = function(req, res) {
         }
         else {
             errors = [];
+            warnings = [];
+            info = [];
             v = new validator.Specberus
             handler = new Sink(function(data) {
                 errors.push(data);
             }, function(data) {
-                if (errors.length > 0)
-                    res.status(400).send(errors);
-                else if (validate)
-                    res.status(200).send(data);
-                else
-                    res.status(200).send(v.meta);
+                buildAndSendResult(errors, warnings, info, res, data);
+            }, function(data) {
+                warnings.push(data);
+            }, function(data) {
+                info.push(data);
             });
             options.events = handler;
             if (validate)

--- a/lib/api.js
+++ b/lib/api.js
@@ -24,7 +24,7 @@ const Sink = sink.Sink
 const parseSource = function(query) {
     const result = {};
     if (query.url) result.url = query.url;
-    else if (query.source) result.source =uery.source;
+    else if (query.source) result.source = query.source;
     else if (query.file) result.file = query.file;
     else if (query.document) result.document = query.document;
     if (query.profile) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,5 @@
 /**
- * Specberus REST API.
+ * REST API.
  */
 
 // Internal packages:
@@ -10,67 +10,98 @@ const package = require('../package.json')
 ;
 
 const Sink = sink.Sink
-,   profiles = util.profiles
 ,   version = package.version
 ;
 
 /**
- * Build an "options" object based on an HTTP query string.
- *
- * @param {Object} query - an HTTP request query.
- * @returns {Object} an "options" object that can be used by Specberus.
- */
-
-const parseSource = function(query) {
-    const result = {};
-    if (query.url) result.url = query.url;
-    else if (query.source) result.source = query.source;
-    else if (query.file) result.file = query.file;
-    else if (query.document) result.document = query.document;
-    if (query.profile) {
-        if (profiles[query.profile])
-            result.profile = profiles[query.profile];
-        else
-            throw new Error('Cannot retrieve profile “' + query.profile + '”');
-    }
-    if (query.validation) result.validation = query.validation;
-    if (query.processDocument) result.processDocument = query.processDocument;
-    return result;
-};
-
-/**
- * Handle an API request: parse method and parameters; handle common errors.
+ * Handle an API request: parse method and parameters, handle common errors and call the validator.
  *
  * @param {Object} req - HTTP request.
  * @param {Object} res - HTTP result.
  */
 
-const parseRequest = function(req, res) {
+const processRequest = function(req, res) {
 
     if ('/api/version' === req.path) {
         res.status(200).send(version);
     }
     else if ('/api/metadata' === req.path || '/api/validate' === req.path) {
-        const validate = ('/api/validate' === req.path)
-        ,   options = parseSource(req.query)
+        const validate = ('/api/validate' === req.path);
+        var v
+        ,   v2
+        ,   options
+        ,   options2
+        ,   errors
+        ,   errors2
+        ,   handler
+        ,   handler2
         ;
-        if (0 === Object.keys(options).length) {
-            res.status(400).send('At least one of "url", "source", "file" or "document" must be specified.');
+        try {
+            options = util.processParams(
+                req.query,
+                undefined,
+                {required: (validate ? ['profile'] : []), forbidden: ['document', 'source']}
+            );
+        }
+        catch (err) {
+            return res.status(400).send(err.toString());
+        }
+        if (validate && 'auto' === options.profile) {
+            errors = [];
+            v = new validator.Specberus
+            handler = new Sink(function(data) {
+                errors.push(data);
+            }, function(data) {
+                if (errors.length > 0)
+                    res.status(400).send(errors);
+                else {
+                    if (options.url)
+                        data.url = options.url;
+                    else
+                        data.file = options.file;
+                    try {
+                        options2 = util.processParams(
+                            data,
+                            undefined,
+                            {allowUnknownParams: true}
+                        );
+                    }
+                    catch (err) {
+                        return res.status(400).send(err.toString());
+                    }
+                    options2.validation = 'simple-validation';
+                    options2.processDocument = 'http://www.w3.org/2015/Process-20150901/' === data.process ? '2015' : '2005';
+                    options2.noRecTrack = !data.rectrack;
+                    errors2 = [];
+                    v2 = new validator.Specberus
+                    handler2 = new Sink(function(data2) {
+                        errors2.push(data2);
+                    }, function(data2) {
+                        if (errors2.length > 0)
+                            res.status(400).send(errors2);
+                        else
+                            res.status(200).send(data2);
+                    });
+                    options2.events = handler2;
+                    v2.validate(options2);
+                }
+            });
+            options.events = handler;
+            v.extractMetadata(options);
         }
         else {
-            var errors = [];
-            const v = new validator.Specberus
-            ,   handler = new Sink(function(data) {
-                    errors.push(data);
-                }, function(data) {
-                    if (errors.length > 0)
-                        res.status(400).send(errors);
-                    else if (validate)
-                        res.status(200).send(data);
-                    else
-                        res.status(200).send(v.meta);
-                })
-            ;
+            errors = [];
+            v = new validator.Specberus
+            handler = new Sink(function(data) {
+                errors.push(data);
+            }, function(data) {
+                if (errors.length > 0)
+                    res.status(400).send(errors);
+                else if (validate)
+                    res.status(200).send(data);
+                else
+                    res.status(200).send(v.meta);
+            });
             options.events = handler;
             if (validate)
                 v.validate(options);
@@ -85,7 +116,7 @@ const parseRequest = function(req, res) {
 };
 
 const setUp = function(app) {
-    app.get('/api/*', parseRequest);
+    app.get('/api/*', processRequest);
 };
 
 exports.setUp = setUp;

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -12,9 +12,11 @@ const util = require('util')
  *
  * @param {Function} error - function to call in case of exception or error.
  * @param {Function} done - function to call at the very end of the process.
+ * @param {Function} warn - function to call in case of warning.
+ * @param {Function} inf - function to call in case of informative message.
  */
 
-var Sink = function(error, done) {
+var Sink = function(error, done, warn, inf) {
 
     this.ok = 0;
     this.errors = [];
@@ -22,23 +24,20 @@ var Sink = function(error, done) {
     this.done = 0;
 
     if(error) {
-
-        this.on('exception', function (data) {
-            error(data);
-        });
-
-        this.on('err', function (data) {
-            error(data);
-        });
-
+        this.on('exception', function (data) { error(data); });
+        this.on('err', function (data) { error(data); });
     }
 
     if(done) {
+        this.on('end-all', function (data) { done(data); });
+    }
 
-        this.on('end-all', function (data) {
-            done(data);
-        });
+    if(warn) {
+        this.on('warning', function (data) { warn(data); });
+    }
 
+    if(inf) {
+        this.on('info', function (data) { inf(data); });
     }
 
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,30 +1,17 @@
 /**
- * Miscellaneous utilities, mostly String-related routines.
+ * Miscellaneous utilities.
  */
 
-const REGEX_URI = /https?:\/\/(www\.)?((.+)[^\ \/])\/?$/i;
+const profiles = {};
 
-/**
- * Reduce a URI to its minimum expression, for easier comparison.
- *
- * This works heuristically; it strips a URI of the usual variants and converts it to lowercase
- * ("www." at the beginning, "/" at the end)
- *
- * @param {String} uri - Original URI.
- * @returns {String} The "normalised", (probably) equivalent URI.
- */
+// @TODO: retrieve this list of filenames from the filesystem, instead of hard-coding them here.
+("FPWD FPLC FPCR WD LC CR PR PER REC RSCND " +
+"CG-NOTE FPIG-NOTE IG-NOTE FPWG-NOTE WG-NOTE " +
+"WD-Echidna WG-NOTE-Echidna " +
+"MEM-SUBM TEAM-SUBM").split(" ")
+    .forEach(function (p) {
+        profiles[p] = require('./profiles/' + p);
+    })
+;
 
-const normaliseURI = function(uri) {
-
-    var result = uri.trim().toLowerCase();
-    const matches = REGEX_URI.exec(result);
-
-    if (matches && matches.length > 2) {
-        result = matches[2];
-    }
-
-    return result;
-
-};
-
-exports.normaliseURI = normaliseURI;
+exports.profiles = profiles;

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,4 +14,82 @@ const profiles = {};
     })
 ;
 
+/**
+ * Build an “options” object based on an HTTP query string or a similar object containing options.
+ *
+ * An example of <code>constraints</code>:
+ * <blockquote><pre>{
+ *     "required": ["processDocument"],
+ *     "forbidden": ["echidnaReady", "bogusParam"],
+ *     "allowUnknownParams": true
+ * }</pre>/blockquote>
+ *
+ * @param {Object} params - an HTTP request query, or a similar object.
+ * @param {Object} base - (<strong>optional</strong>) a template or “base” object to build from.
+ * @param {Object} constraints - (<strong>optional</strong>) an object listing “required” and/or “forbidden” parameters.
+ *
+ * @returns {Object} an “options” object that can be used by Specberus.
+ *
+ * @throws {Error} if there is an error in the parameters.
+ */
+
+const processParams = function(params, base, constraints) {
+    const result = base ? JSON.parse(JSON.stringify(base)): {};
+    var originFound = false;
+    for (var p in params) {
+        if ('url' === p || 'source' === p || 'file' === p || 'document' === p) {
+            // Origins: only one allowed.
+            if (originFound)
+                throw new Error('Only one of parameters {“url”, “source”, “file”, “document”} is allowed');
+            originFound = true;
+            result[p] = params[p];
+        }
+        else if ('profile' === p) {
+            // Profile: if it's a string, load the corresponding object.
+            if (result.hasOwnProperty(p))
+                throw new Error('Parameter “' + p + '” is used more than once');
+            else if ('string' === typeof params[p]) {
+                if (profiles.hasOwnProperty(params[p]))
+                    result[p] = profiles[params[p]];
+                else if ('auto' === params[p])
+                    result[p] = 'auto';
+                else
+                    throw new Error('Unknown profile “' + params[p] + '”');
+            }
+            else
+                result[p] = params[p];
+        }
+        else if ('validation' === p || 'htmlValidator' === p || 'cssValidator' === p ||
+            'patentPolicy' === p || 'processDocument' === p || 'noRecTrack' === p ||
+            'informativeOnly' === p || 'echidnaReady' === p || 'events' === p) {
+            // Other params:
+            if (result.hasOwnProperty(p))
+                throw new Error('Parameter “' + p + '” is used more than once');
+            result[p] = params[p];
+        }
+        else if (!constraints || !constraints.allowUnknownParams)
+            // Illegal params:
+            throw new Error('Illegal parameter “' + p + '”');
+    }
+    if (!originFound)
+        // Origin: one required.
+        throw new Error('One parameter of {“url”, “source”, “file”, “document”} is required');
+    else {
+        if(constraints && constraints.required) {
+            // Extra required params:
+            for (var c in constraints.required)
+                if (!result.hasOwnProperty(constraints.required[c]))
+                    throw new Error('Parameter “' + constraints.required[c] + '” is required in this context');
+        }
+        if(constraints && constraints.forbidden) {
+            // Forbidden params:
+            for (var c in constraints.forbidden)
+                if (result.hasOwnProperty(constraints.forbidden[c]))
+                    throw new Error('Parameter “' + constraints.forbidden[c] + '” is not allowed in this context');
+        }
+    }
+    return result;
+};
+
 exports.profiles = profiles;
+exports.processParams = processParams;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,30 @@
+/**
+ * Miscellaneous utilities, mostly String-related routines.
+ */
+
+const REGEX_URI = /https?:\/\/(www\.)?((.+)[^\ \/])\/?$/i;
+
+/**
+ * Reduce a URI to its minimum expression, for easier comparison.
+ *
+ * This works heuristically; it strips a URI of the usual variants and converts it to lowercase
+ * ("www." at the beginning, "/" at the end)
+ *
+ * @param {String} uri - Original URI.
+ * @returns {String} The "normalised", (probably) equivalent URI.
+ */
+
+const normaliseURI = function(uri) {
+
+    var result = uri.trim().toLowerCase();
+    const matches = REGEX_URI.exec(result);
+
+    if (matches && matches.length > 2) {
+        result = matches[2];
+    }
+
+    return result;
+
+};
+
+exports.normaliseURI = normaliseURI;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -11,6 +11,7 @@ var whacko = require("whacko")
 ,   version = require("../package.json").version
 ,   Exceptions = require("./exceptions").Exceptions
 ,   profileMetadata = require('./profiles/metadata')
+,   util = require('./util')
 ;
 
 var Specberus = function () {
@@ -72,19 +73,6 @@ Specberus.prototype.extractMetadata = function (options) {
 };
 
 Specberus.prototype.validate = function (options) {
-    // accepted options:
-    //  - url: URL for a document to load
-    //  - source: source of a document to parse
-    //  - file: file name of a document to load
-    //  - document: the document, directly available
-    //  - profile: the profile against which to validate
-    //  - events: where to send the various events
-    //  - validation: whether to skip CSS and HTML validation
-    //  - noRecTrack: document uses a Rec-track status but isn't on Rec-track
-    //  - informativeOnly: document is informative only
-    //  - echidnaReady: document is intended for automatic publication
-    //  - patentPolicy: Working Group Patent Policy
-    //  - processDocument: process document to be used
 
     this.clearCache();
     var self = this;
@@ -97,15 +85,12 @@ Specberus.prototype.validate = function (options) {
 
     if (!options.profile) return this.throw("Without a profile there is nothing to check.");
     var profile = options.profile;
-    self.config = profile.config || {};
-    self.config.validation = options.validation;
-    self.config.htmlValidator = options.htmlValidator;
-    self.config.cssValidator = options.cssValidator;
-    self.config.noRecTrack = (true === options.noRecTrack);
-    self.config.informativeOnly = (true === options.informativeOnly);
-    self.config.echidnaReady = (true === options.echidnaReady);
-    self.config.patentPolicy = options.patentPolicy;
-    self.config.processDocument = options.processDocument;
+    try {
+        self.config = util.processParams(options, profile.config);
+    }
+    catch (err) {
+        return this.throw(err.toString());
+    }
     self.config.lang = 'en_GB';
     var seenErrors = {};
     self.sink.on("err", function (name) { seenErrors[name] = true; });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -109,7 +109,9 @@ Specberus.prototype.validate = function (options) {
                 done++;
                 if (!seenErrors[this.name]) self.sink.emit("ok", this.name);
                 self.sink.emit("done", this.name);
-                if (done === total) self.sink.emit("end-all", profile.name);
+                if (done === total) {
+                    self.sink.emit("end-all", {profile: profile.name});
+                }
             }.bind(rule));
         });
     };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "chai": "3.5",
+    "chai-as-promised": "5.3.0",
     "coveralls": "2.11",
     "expect.js": "0.3",
     "istanbul": "0.4",

--- a/test/api.js
+++ b/test/api.js
@@ -77,74 +77,75 @@ const get = function (suffix, post) {
     });
 };
 
-if (!process || !process.env || !process.env.SKIP_NETWORK) {
+describe('API', function() {
 
-    describe('API', function() {
+    var query;
 
-        var query;
-
-        before(function() {
-            launchServer();
-            setUp();
-        });
-
-        describe('Endpoint', function() {
-            it('Should exist and listen to GET requests', function() {
-                query = get('');
-                return expect(query).to.eventually.be.rejectedWith(/wrong\ api\ method/i);
-            });
-            it('Should not accept POST requests', function() {
-                query = get('', true);
-                return expect(query).to.eventually.be.rejectedWith(/cannot\ post/i);
-            });
-        });
-
-        describe('Method “version”', function() {
-            it('Should return the right version string', function() {
-                query = get('version');
-                return expect(query).to.eventually.become(package.version);
-            });
-        });
-
-        describe('Method “metadata”', function() {
-            it('Should accept the parameter “file”, and return the right profile and date', function() {
-                query = get('metadata?file=test/docs/metadata/ttml-imsc1.html');
-                return expect(query).to.eventually.match(/"profile":\s*"pr"/i)
-                    .and.to.eventually.match(/"docDate":\s*"2016\-3\-8"/i);
-            });
-        });
-
-        describe('Method “validate”', function() {
-            it('Should 404 and return an array of errors when validation fails', function() {
-                query = get('validate?file=test/docs/metadata/ttml-imsc1.html&profile=REC&validation=simple-validation&processDocument=2047');
-                return expect(query).to.eventually.be.rejectedWith(/"headers\.\w+/i);
-            });
-            it('Should accept the parameter “url”, and succeed returning the profile when the document is valid', function() {
-                query = get('validate?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FWD-charmod-norm-20160407%2F&' +
-                    'profile=WD&validation=simple-validation&processDocument=2015&noRecTrack=true');
-                return expect(query).to.eventually.become('WD');
-            });
-            it('Special profile “auto”: should detect the right profile and validate the document', function() {
-                query = get('validate?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FWD-charmod-norm-20160407%2F&profile=auto');
-                return expect(query).to.eventually.become('WD');
-            });
-        });
-
-        describe('Parameter restrictions', function() {
-            it('Should reject the parameter “document”', function() {
-                query = get('metadata?document=foo');
-                return expect(query).to.eventually.be.rejectedWith('Parameter “document” is not allowed in this context');
-            });
-            it('Should reject the parameter “source”', function() {
-                query = get('metadata?source=foo');
-                return expect(query).to.eventually.be.rejectedWith('Parameter “source” is not allowed in this context');
-            });
-        });
-
-        after(function() {
-            server.close();
-        });
-
+    before(function() {
+        launchServer();
+        setUp();
     });
 
-}
+    describe('Endpoint', function() {
+        it('Should exist and listen to GET requests', function() {
+            query = get('');
+            return expect(query).to.eventually.be.rejectedWith(/wrong\ api\ method/i);
+        });
+        it('Should not accept POST requests', function() {
+            query = get('', true);
+            return expect(query).to.eventually.be.rejectedWith(/cannot\ post/i);
+        });
+    });
+
+    describe('Method “version”', function() {
+        it('Should return the right version string', function() {
+            query = get('version');
+            return expect(query).to.eventually.become(package.version);
+        });
+    });
+
+    describe('Method “metadata”', function() {
+        it('Should accept the parameter “file”, and return the right profile and date', function() {
+            query = get('metadata?file=test/docs/metadata/ttml-imsc1.html');
+            // @TODO: parse result as an Object (it's JSON) instead of a String.
+            return expect(query).to.eventually.match(/"profile":\s*"pr"/i)
+                .and.to.eventually.match(/"docDate":\s*"2016\-3\-8"/i);
+        });
+    });
+
+    describe('Method “validate”', function() {
+        it('Should 404 and return an array of errors when validation fails', function() {
+            query = get('validate?file=test/docs/metadata/ttml-imsc1.html&profile=REC&validation=simple-validation&processDocument=2047');
+            return expect(query).to.eventually.be.rejectedWith(/"headers\.\w+/i);
+        })
+        it('Should accept the parameter “url”, and succeed returning the profile when the document is valid', function() {
+            query = get('validate?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FWD-charmod-norm-20160407%2F&' +
+                'profile=WD&validation=simple-validation&processDocument=2015&noRecTrack=true');
+            // @TODO: parse result as an Object (it's JSON) instead of a String.
+            return expect(query).to.eventually.match(/"success":\s*true/i)
+                .and.to.eventually.match(/"profile":\s*"WD"/i);
+        });
+        it('Special profile “auto”: should detect the right profile and validate the document', function() {
+            query = get('validate?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FWD-charmod-norm-20160407%2F&profile=auto');
+            // @TODO: parse result as an Object (it's JSON) instead of a String.
+            return expect(query).to.eventually.match(/"success":\s*true/i)
+                .and.to.eventually.match(/"profile":\s*"WD"/i);
+        });
+    });
+
+    describe('Parameter restrictions', function() {
+        it('Should reject the parameter “document”', function() {
+            query = get('metadata?document=foo');
+            return expect(query).to.eventually.be.rejectedWith('Parameter “document” is not allowed in this context');
+        });
+        it('Should reject the parameter “source”', function() {
+            query = get('metadata?source=foo');
+            return expect(query).to.eventually.be.rejectedWith('Parameter “source” is not allowed in this context');
+        });
+    });
+
+    after(function() {
+        server.close();
+    });
+
+});

--- a/test/api.js
+++ b/test/api.js
@@ -2,63 +2,132 @@
  * Test the REST API.
  */
 
+// Settings:
+const DEFAULT_PORT = 8000
+,   PORT = process.env.PORT || DEFAULT_PORT
+,   ENDPOINT = 'http://localhost:' + PORT + '/api/'
+,   TIMEOUT = 30000
+;
+
+// Native packages:
+const http = require('http');
+
 // External packages:
-const expect = require('expect.js')
+const chai = require('chai')
+,   chaiAsPromised = require('chai-as-promised')
+,   express = require('express')
 ,   superagent = require('superagent')
 ;
 
 // Internal packages:
-const samples = require('./samples')
-,   package = require('../package')
+const package = require('../package')
+,   api = require('../lib/api')
+;
+
+var expect
+,   server
 ;
 
 /**
- * Assert that the profile detected in a spec is equal to the known profile.
- *
- * @param {String} url - public URL of a spec.
- * @param {String} profile - profile that should be detected.
+ * Launch an HTTP server for tests.
  */
 
-const detect = function(url, profile) {
-    it('Should detect a ' + profile, function () {
-        // @TODO; submit URL to endpoint and check profiles.
+const launchServer = function () {
+    const app = express();
+    server = http.createServer(app);
+    api.setUp(app);
+    server.listen(PORT).on('error', function(err) {
+        throw new Error(err);
+    });
+};
+
+/**
+ * Set up the testing framework.
+ */
+
+const setUp = function() {
+    chai.use(chaiAsPromised);
+    expect = chai.expect;
+};
+
+/**
+ * Query the API.
+ */
+
+const get = function (suffix, post) {
+    const method = post ? superagent.post : superagent.get;
+    return new Promise(function (resolve, reject) {
+        method(ENDPOINT + suffix, {
+            timeout: TIMEOUT,
+            encoding: null
+        }, function (error, response, body) {
+            if (error) {
+                if (error.response && error.response.error && error.response.error.text)
+                    reject(new Error(error.response.error.text));
+                else
+                    reject(new Error('Fetching “' + ENDPOINT + suffix + '” triggered a network error: ' + error.message));
+            }
+            else if (response.statusCode !== 200)
+                reject(new Error('Fetching “' + ENDPOINT + suffix + '” triggered an HTTP error: code ' + response.statusCode));
+            else if (response.res && response.res.text)
+                resolve(response.res.text);
+            else
+                resolve(body);
+        });
     });
 };
 
 if (!process || !process.env || !process.env.SKIP_NETWORK) {
 
-    // @TODO: launch Specberus locally as a server, listening to HTTP requests.
-
     describe('API', function() {
 
-/*        it('The endpoint should exist', function() {
-            // @TODO
+        var suffix;
+
+        before(function() {
+            launchServer();
+            setUp();
+            suffix = '?file=test/docs/metadata/ttml-imsc1.html'
         });
 
-        describe('Method "version"', function() {
-            it('Should exist'), function() {
-                // @TODO
-            };
-            it('Should return the right version string'), function() {
-                // @TODO; query method and compare with "package.version".
-            };
+        describe('Endpoint', function() {
+            it('Should exist and listen to GET requests', function() {
+                const bogus = get('');
+                return expect(bogus).to.eventually.be.rejectedWith(/wrong\ api\ method/i);
+            });
+            it('Should not accept POST requests', function() {
+                const bogus = get('', true);
+                return expect(bogus).to.eventually.be.rejectedWith(/cannot\ post/i);
+            });
         });
 
-        describe('Method "metadata"', function() {
-            it('Should exist'), function(done) {
-                // @TODO
-            };
-            for(var i in samples) {
-                detect(samples[i].url, samples[i].profile);
-            }
+        describe('Method “version”', function() {
+            it('Should return the right version string', function() {
+                const version = get('version');
+                return expect(version).to.eventually.become(package.version);
+            });
         });
 
-        describe('Method "validate"', function() {
-            it('Should exist'), function(done) {
-                // @TODO
-            };
-            // @TODO; submit a few sample specs for validation; check results.
-        }); */
+        describe('Method “metadata”', function() {
+            it('Should return the expected profile', function() {
+                const meta = get('metadata' + suffix);
+                return expect(meta).to.eventually.match(/"profile":\s*"pr"/i);
+            });
+        });
+
+        describe('Method “validate”', function() {
+            it('Should 404 and return an array of errors when validation fails', function() {
+                const check = get('validate' + suffix + '&profile=REC&validation=simple-validation&processDocument=2047');
+                return expect(check).to.eventually.be.rejectedWith(/"headers\.\w+/i);
+            });
+            it('Should succeed and return the profile when the document is valid', function() {
+                const check = get('validate' + suffix + '&profile=PR&validation=simple-validation&processDocument=2015');
+                return expect(check).to.eventually.become('PR');
+            });
+        });
+
+        after(function() {
+            server.close();
+        });
 
     });
 

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,65 @@
+/**
+ * Test the REST API.
+ */
+
+// External packages:
+const expect = require('expect.js')
+,   superagent = require('superagent')
+;
+
+// Internal packages:
+const samples = require('./samples')
+,   package = require('../package')
+;
+
+/**
+ * Assert that the profile detected in a spec is equal to the known profile.
+ *
+ * @param {String} url - public URL of a spec.
+ * @param {String} profile - profile that should be detected.
+ */
+
+const detect = function(url, profile) {
+    it('Should detect a ' + profile, function () {
+        // @TODO; submit URL to endpoint and check profiles.
+    });
+};
+
+if (!process || !process.env || !process.env.SKIP_NETWORK) {
+
+    // @TODO: launch Specberus locally as a server, listening to HTTP requests.
+
+    describe('API', function() {
+
+/*        it('The endpoint should exist', function() {
+            // @TODO
+        });
+
+        describe('Method "version"', function() {
+            it('Should exist'), function() {
+                // @TODO
+            };
+            it('Should return the right version string'), function() {
+                // @TODO; query method and compare with "package.version".
+            };
+        });
+
+        describe('Method "metadata"', function() {
+            it('Should exist'), function(done) {
+                // @TODO
+            };
+            for(var i in samples) {
+                detect(samples[i].url, samples[i].profile);
+            }
+        });
+
+        describe('Method "validate"', function() {
+            it('Should exist'), function(done) {
+                // @TODO
+            };
+            // @TODO; submit a few sample specs for validation; check results.
+        }); */
+
+    });
+
+}


### PR DESCRIPTION
This PR sets up a REST API using Express, with 3 methods:

* `version`
* `metadata`
* `validate`

And adds a test file for Mocha with placeholders for API tests.

Because this functionality was moved here from branch `tripu/metadata`, there are a few files in common (`sink.js`, `util.js`, `samples.json`). Those should be OK when we merge the branches.

As the API relies on the new method `Specberus.extractMetadata()`, **do *not* merge this before #299**; it won't work.

**TO-DO:** [Updated 3/May/2016]

* ~~Write the tests. My plan is to launch the Specberus server locally first, then use `superagent` to throw a few requests at it, and check the results.~~ :ballot_box_with_check:
* ~~POST or GET? Method `version` should be GET. I'm not sure about the other two.~~ :ballot_box_with_check: All are GET.
* ~~Refactor if/else block for `api/metadata` and `api/validate`: the signature and checks are almost identical for both.~~ :ballot_box_with_check: