### PR TITLE
extractMetadata rectrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Once the [event `end-all`](#validation-events) is emitted, the metadata should b
 The `options` accepted are equal to those in `validate()`, except that a `profile` is not necessary and will be ignored (finding out the profile is one of the
 goals of this method).
 
-`this.meta` will be an `Object` and may include up to 2 properties: `profile` and `delivererIDs`.
+`this.meta` will be an `Object` and may include up to 3 properties: `profile`, `delivererIDs` and `rectrack`.
 If some of these pieces of metadata cannot be deduced, that key will not exist, or its value will not be defined.
 
 This is an example of the value of `Specberus.meta` after the execution of `Specberus.extractMetadata()`:
@@ -92,7 +92,8 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 ```json
 {
   "profile": "WD",
-  "delivererIDs": [47318, 43696]
+  "delivererIDs": [47318, 43696],
+  "rectrack": true
 }
 ```
 

--- a/lib/profiles/metadata.js
+++ b/lib/profiles/metadata.js
@@ -7,4 +7,5 @@ exports.name = 'Metadata';
 exports.rules = [
     require('../rules/metadata/profile')
 ,   require('../rules/metadata/deliverers')
+,   require('../rules/metadata/rectrack')
 ];

--- a/lib/rules/metadata/rectrack.js
+++ b/lib/rules/metadata/rectrack.js
@@ -1,0 +1,16 @@
+/**
+ * Pseudo-rule for metadata extraction: rectrack.
+ */
+
+exports.name = 'metadata.rectrack';
+
+exports.check = function(sr, done) {
+
+    var $sotd = sr.getSotDSection()
+    ,   expected = /The (group does|groups do) not expect this document to become a W3C Recommendation/;
+    if (!$sotd || !$sotd.length) {
+        return done();
+    }
+
+    return done({rectrack: !expected.test($sotd.text())});
+};

--- a/test/docs/metadata/charmod-norm.html
+++ b/test/docs/metadata/charmod-norm.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" typeof="bibo:Document w3p:WD" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
+<head><meta property="dc:language" content="en" lang="">
+    <meta content="text/html; charset=utf-8" http-equiv="content-type">
+    <title>Character Model for the World Wide Web: String Matching and Searching</title>
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"><link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet"></head>
+  <body id="respecDocument" role="document" class="h-entry toc-sidebar"><div id="respecHeader" role="contentinfo" class="head">
+  <p>
+            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height="48" width="72"></a>
+  </p>
+  <h1 class="title p-name" id="title" property="dcterms:title">Character Model for the World Wide Web: String Matching and Searching</h1>
+  <h2 id="w3c-working-draft-07-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-07">07 April 2016</time></h2>
+  <dl>
+      <dt>This version:</dt>
+      <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-charmod-norm-20160407/">http://www.w3.org/TR/2016/WD-charmod-norm-20160407/</a></dd>
+      <dt>Latest published version:</dt>
+      <dd><a href="http://www.w3.org/TR/charmod-norm/">http://www.w3.org/TR/charmod-norm/</a></dd>
+      <dt>Latest editor's draft:</dt>
+      <dd><a href="http://w3c.github.io/charmod-norm/">http://w3c.github.io/charmod-norm/</a></dd>
+      <dt>Bug tracker:</dt>
+      <dd><a href="https://github.com/w3c/charmod-norm/issues">file a bug</a> (<a href="https://github.com/w3c/charmod-norm/issues">open bugs</a>)</dd>
+      <dt>Previous version:</dt>
+      <dd><a rel="dcterms:replaces" href="http://www.w3.org/TR/2015/WD-charmod-norm-20151119/">http://www.w3.org/TR/2015/WD-charmod-norm-20151119/</a></dd>
+    <dt>Editor:</dt>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0" data-editor-id="33573"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Addison Phillips</span>, Invited Expert</span>
+<span property="rdf:rest" resource="rdf:nil"></span>
+</dd>
+
+          <dt>Github:</dt>
+                  <dd>
+                    <a href="https://github.com/w3c/charmod-norm/">
+                      repository
+                    </a>
+                  </dd>
+  </dl>
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        2004-2016
+
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+  <hr title="Separator for header">
+</div>
+    <section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+      <p>This document builds upon on <cite>Character Model for the World Wide
+          Web 1.0: Fundamentals </cite>[<cite><a href="#bib-CHARMOD" class="bibref">CHARMOD</a></cite>] to provide authors of
+        specifications, software developers, and content developers a common
+        reference on string identity matching on the World Wide Web and thereby
+        increase interoperability. </p>
+    </section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+        <p>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+        </p>
+
+      <div class="note"><div id="h-note1" role="heading" aria-level="3" class="note-title marker"><span>Note</span></div><div class="">
+        <p>This version of the document represents a significant change from the
+          <a href="http://www.w3.org/TR/2012/WD-charmod-norm-20120501/">earlier
+            editions</a>. Much of the content is changed and the recommendations
+          are significantly altered. This fact is reflected in a change to the
+          name of the document from "Character Model: Normalization".</p>
+      </div></div>
+      <div class="note"><div id="h-note2" role="heading" aria-level="3" class="note-title marker"><span>Note</span></div><div class="">
+        <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending
+          comments on this document</p>
+        <p data-lang="en">If you wish to make comments regarding this document,
+          please raise them as <a href="https://github.com/w3c/charmod-norm/issues" style="font-size: 120%;">github issues</a> against the <a href="http://www.w3.org/TR/2015/WD-charmod-norm-20151119/" style="font-size: 120%">latest dated version in /TR</a>. Only send
+          comments by email if you are unable to raise issues on github (see
+          links below). All comments are welcome.</p>
+        <p data-lang="en">To make it easier to track comments, please raise
+          separate issues or emails for each comment, and point to the section
+          you are commenting on&nbsp; using a URL for the dated version of the
+          document.</p>
+      </div></div>
+
+          <p>
+            This document was published by the <a href="http://www.w3.org/International/core/">Internationalization Working Group</a> as a Working Draft.
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:www-international@w3.org">www-international@w3.org</a>
+              (<a href="mailto:www-international-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/www-international/">archives</a>).
+
+              All comments are welcome.
+          </p>
+            <p>
+              Publication as a Working Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          <p>
+              This document was produced by
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+              The group does not expect this document to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/32113/status" rel="disclosure">public list of any patent
+                disclosures</a>
+              made in connection with the deliverables of
+              the group; that page also includes
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+          </p>
+            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+
+</section><nav id="toc"><h2 resource="#table-of-contents" id="table-of-contents" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#intro"><span class="secno">1. </span>Introduction</a></ul></li></ul></nav>
+<script src="https://www.w3.org/scripts/TR/2016/fixup.js" defer="" async=""></script></body></html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -6,6 +6,7 @@
 const DEBUG = false
 ,   META_PROFILE = 'profile'
 ,   META_DELIVERER_IDS = 'delivererIDs'
+,   META_RECTRACK = 'rectrack'
 ;
 
 // Native packages:
@@ -86,6 +87,15 @@ const compareMetadata = function(url, file, type, expectedValue) {
             specberus.extractMetadata(opts);
         });
     }
+    else if (META_RECTRACK === type) {
+        it('Should find if ' + (url ? url : file) + ' is on REC track', function (done) {
+            handler.on('end-all', function () {
+                chai(specberus).to.have.property('meta').to.have.property('rectrack').equal(expectedValue);
+                done();
+            });
+            specberus.extractMetadata(opts);
+        });
+    }
 
 
 };
@@ -108,6 +118,9 @@ describe('Basics', function() {
             for(var i in samples) {
                 compareMetadata(samples[i].url, null, META_DELIVERER_IDS, samples[i].delivererIDs);
             }
+            for(var i in samples) {
+                compareMetadata(samples[i].url, null, META_RECTRACK, samples[i].rectrack);
+            }
         }
         else {
             for(var i in samples) {
@@ -115,6 +128,9 @@ describe('Basics', function() {
             }
             for(var i in samples) {
                 compareMetadata(null, samples[i].file, META_DELIVERER_IDS, samples[i].delivererIDs);
+            }
+            for(var i in samples) {
+                compareMetadata(null, samples[i].file, META_RECTRACK, samples[i].rectrack);
             }
         }
 

--- a/test/samples.json
+++ b/test/samples.json
@@ -10,6 +10,7 @@
             }
         ]
     ,   "delivererIDs": [83482]
+    ,   "rectrack": true
     }
 ,   {
         "url": "https://www.w3.org/TR/2016/PR-ttml-imsc1-20160308/"
@@ -22,6 +23,7 @@
             }
         ]
     ,   "delivererIDs": [34314]
+    ,   "rectrack": true
     }
 ,   {
         "url": "https://www.w3.org/TR/2016/NOTE-csvw-ucr-20160225/"
@@ -34,6 +36,7 @@
             }
         ]
     ,   "delivererIDs": [68238]
+    ,   "rectrack": true
     }
 ,   {
         "url": "https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/"
@@ -46,6 +49,7 @@
             }
         ]
     ,   "delivererIDs": [68238]
+    ,   "rectrack": true
     }
 ,   {
         "url": "https://www.w3.org/TR/2015/WD-tracking-compliance-20150714/"
@@ -58,6 +62,7 @@
             }
         ]
     ,   "delivererIDs": [49311]
+    ,   "rectrack": true
     }
 ,   {
         "url": "https://www.w3.org/TR/2016/WD-mediacapture-depth-20160226/"
@@ -74,5 +79,19 @@
             }
         ]
     ,   "delivererIDs": [47318, 43696]
+    ,   "rectrack": true
     }
+    ,   {
+            "url": "https://www.w3.org/TR/2016/WD-charmod-norm-20160407/"
+        ,   "file": "charmod-norm"
+        ,   "profile": "WD"
+        ,   "deliverers": [
+                {
+                    "name": "Internationalization Working Group"
+                ,   "homepage":"http://www.w3.org/International/core/"
+                }
+            ]
+        ,   "delivererIDs": [32113]
+        ,   "rectrack": false
+        }
 ]


### PR DESCRIPTION
`extractMetadata` now detects whether the document is on REC-track or not.
The goal is to pass that information to Echidna so it can also publish document on Note-track.