### PR TITLE
fix extractHeaders on the same day publication check

### DIFF
--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -44,7 +44,7 @@ exports.check = function (sr, done) {
     if (subType === "member") topLevel = "Submission";
     else if (subType === "team") topLevel = "TeamSubmission";
 
-    var dts = sr.extractHeaders();
+    var dts = sr.extractHeaders(sr.$("body div.head dl").first());
     if (!dts.This) err("this-version");
     if (!dts.Latest) err("latest-version");
     if (prevRequired && !dts.Previous) err("previous-version");
@@ -155,7 +155,7 @@ exports.check = function (sr, done) {
           // check same day publication
           var $         = require("whacko").load(bodies[1])
           ,   $latestDl = $("body div.head dl").first()
-          ,   latestDts = extractHeaders($latestDl);
+          ,   latestDts = sr.extractHeaders($latestDl);
           if (latestDts.This &&
               latestDts.This.dd.find("a").first().attr("href") === thisURI &&
               latestDts.Previous &&

--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -5,8 +5,8 @@
 exports.name = 'metadata.dl';
 
 exports.check = function(sr, done) {
-
-    var dts = sr.extractHeaders()
+    var $dl = sr.$("body div.head dl").first()
+    ,   dts = sr.extractHeaders($dl)
     ,   result = {};
 
     var $linkThis = (dts.This) ? dts.This.dd.find("a").first() : null;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -257,10 +257,9 @@ Specberus.prototype.getSotDSection = function () {
     return this.sotdSection;
 };
 
-Specberus.prototype.extractHeaders = function () {
+Specberus.prototype.extractHeaders = function ($dl) {
   var $ = this.$
   ,   self = this
-  ,   $dl = $("body div.head dl").first()
   ,   dts = {}
   ,   EDITORS_DRAFT = /Latest\ editor's\ draft/i;
   $dl.find("dt").each(function (idx) {


### PR DESCRIPTION
That PR fixes the same day publication check as `extractHeaders` is now defined in `Specberus`.