### PR TITLE
Fix: rule “links/compound” relies on “Specberus.url”

### DIFF
--- a/lib/rules/links/compound.js
+++ b/lib/rules/links/compound.js
@@ -14,11 +14,13 @@ exports.check = function (sr, done) {
         }
     };
 
-    sr.$('a[href]').each(function () {
-        var parsedLink = url.parse(url.resolve(sr.url, sr.$(this).attr("href"))),
-            l = parsedLink.protocol + '//' + parsedLink.host + parsedLink.pathname;
-        if (l.startsWith(sr.url) && l != sr.url) links.push(l);
-    });
+    if(sr.url) {
+        sr.$('a[href]').each(function () {
+            var parsedLink = url.parse(url.resolve(sr.url, sr.$(this).attr("href"))),
+                l = parsedLink.protocol + '//' + parsedLink.host + parsedLink.pathname;
+            if (l.startsWith(sr.url) && l != sr.url) links.push(l);
+        });
+    }
     // sort and remove duplicates
     links = links.sort().filter(function (item, pos) {return (!pos || item != links[pos - 1]);});
 


### PR DESCRIPTION
Fixes #347.