### PR TITLE
Make ToC detection more accurate

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -21,10 +21,11 @@ exports.messages = {
 ,   "headers.h2-status.no-h2":  "No status+date h2 element."
 ,   "headers.h2-status.bad-h2": "Incorrect status h2 header."
     // headers/h2-toc
-,   'headers.h2-toc.not-found':  'There is no table of contents inside a navigation element (<code>&lt;nav id="toc"&gt; &hellip; &lt;h2&gt;Table of Contents&lt;/h2&gt; &hellip; &lt;/nav&gt;</code>).'
-,   'headers.h2-toc.too-many':   'Found more than one navigation elements; possibly containing the table of contents. There should be just one <code>&lt;nav id="toc"&gt;</code>.'
-,   'headers.h2-toc.not-html5':  'Support for old HTML doctypes is deprecated and will be abandoned soon; please upgrade to HTML5. The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>.'
-,   'headers.h2-toc.missing':  'There is no table of contents after the status section, labeled with a <code>&lt;h2&gt;</code> element with content <em>&ldquo;Table of Contents&rdquo;</em>.'
+,   'headers.h2-toc.not-found': 'There is no table of contents inside a navigation element (<code>&lt;nav id="toc"&gt; &hellip; &lt;h2&gt;Table of Contents&lt;/h2&gt; &hellip; &lt;/nav&gt;</code>).'
+,   'headers.h2-toc.too-many':  'Found more than one navigation elements; possibly containing the table of contents. There should be just one <code>&lt;nav id="toc"&gt;</code>.'
+,   'headers.h2-toc.not-html5': 'Support for old HTML doctypes is deprecated and will be abandoned soon; please upgrade to HTML5. The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>.'
+,   'headers.h2-toc.mixed':     'The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>; remove older versions like <code>&lt;div id="toc"&gt;</code>.'
+,   'headers.h2-toc.missing':   'There is no table of contents after the status section, labeled with a <code>&lt;h2&gt;</code> element with content <em>&ldquo;Table of Contents&rdquo;</em>.'
     // headers/ol-toc
 ,   'headers.ol-toc.not-found':  'The TOC should be an <code>&lt;ol class="toc"&gt;</code> inside the main navigation element (<code>&lt;nav id="toc"&gt;</code>).'
     // headers/secno

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -21,10 +21,11 @@ exports.messages = {
 ,   "headers.h2-status.no-h2":  "No status+date h2 element."
 ,   "headers.h2-status.bad-h2": "Incorrect status h2 header."
     // headers/h2-toc
-,   'headers.h2-toc.not-found':  'There is no table of contents inside a navigation element (<code>&lt;nav id="toc"&gt; &hellip; &lt;h2&gt;Table of Contents&lt;/h2&gt; &hellip; &lt;/nav&gt;</code>).'
-,   'headers.h2-toc.too-many':   'Found more than one navigation elements; possibly containing the table of contents. There should be just one <code>&lt;nav id="toc"&gt;</code>.'
-,   'headers.h2-toc.not-html5':  'Support for old HTML doctypes is deprecated and will be abandoned soon; please upgrade to HTML5. The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>.'
-,   'headers.h2-toc.missing':  'There is no table of contents after the status section, labeled with a <code>&lt;h2&gt;</code> element with content <em>&ldquo;Table of Contents&rdquo;</em>.'
+,   'headers.h2-toc.not-found': 'There is no table of contents inside a navigation element (<code>&lt;nav id="toc"&gt; &hellip; &lt;h2&gt;Table of Contents&lt;/h2&gt; &hellip; &lt;/nav&gt;</code>).'
+,   'headers.h2-toc.too-many':  'Found more than one navigation elements; possibly containing the table of contents. There should be just one <code>&lt;nav id="toc"&gt;</code>.'
+,   'headers.h2-toc.not-html5': 'Support for old HTML doctypes is deprecated and will be abandoned soon; please upgrade to HTML5. The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>.'
+,   'headers.h2-toc.mixed':     'The expected navigation element is: <code>&lt;nav id="toc"&gt;</code>; remove older versions like <code>&lt;div id="toc"&gt;</code>.'
+,   'headers.h2-toc.missing':   'There is no table of contents after the status section, labeled with a <code>&lt;h2&gt;</code> element with content <em>&ldquo;Table of Contents&rdquo;</em>.'
     // headers/ol-toc
 ,   'headers.ol-toc.not-found':  'The TOC should be an <code>&lt;ol class="toc"&gt;</code> inside the main navigation element (<code>&lt;nav id="toc"&gt;</code>).'
     // headers/secno

--- a/lib/rules/headers/h2-toc.js
+++ b/lib/rules/headers/h2-toc.js
@@ -1,3 +1,6 @@
+/**
+ * Check the presence of a valid ToC.
+ */
 
 'use strict';
 
@@ -5,35 +8,35 @@ exports.name  = 'headers.h2-toc';
 
 exports.check = function (sr, done) {
 
-    var EXPECTED_HEADING = /table\s+of\s+contents/i;
+    const EXPECTED_HEADING = /^table\s+of\s+contents$/i;
     var toc = sr.$('nav#toc > h2');
 
-    if (1 === toc.length) {
-        if (!EXPECTED_HEADING.test(sr.$(toc[0]).text())) {
+    if (toc.length > 0) {
+        var matches = 0;
+        for (var i = 0; i < toc.length; i ++)
+            if (EXPECTED_HEADING.test(sr.$(toc[i]).text()))
+                matches ++;
+        if (matches > 1)
+            sr.error(exports.name, 'too-many');
+        else if (0 === matches)
             sr.error(exports.name, 'not-found');
-        }
     }
     else {
         toc = sr.$('div#toc > h2');
 
         if (1 === toc.length) {
-            if (EXPECTED_HEADING.test(sr.$(toc[0]).text())) {
+            if (EXPECTED_HEADING.test(sr.$(toc[0]).text()))
                 sr.warning(exports.name, 'not-html5');
-            }
-            else {
+            else
                 sr.error(exports.name, 'not-found');
-            }
         }
-        else if (0 === toc.length) {
+        else if (0 === toc.length)
             sr.error(exports.name, 'not-found');
-        }
-        else if (toc.length > 1) {
+        else if (toc.length > 1)
             sr.error(exports.name, 'too-many');
-        }
 
     };
 
     done();
 
 };
-

--- a/lib/rules/headers/h2-toc.js
+++ b/lib/rules/headers/h2-toc.js
@@ -8,10 +8,29 @@ exports.name  = 'headers.h2-toc';
 
 exports.check = function (sr, done) {
 
-    const EXPECTED_HEADING = /^table\s+of\s+contents$/i;
-    var toc = sr.$('nav#toc > h2');
+    const EXPECTED_HEADING = /^table\s+of\s+contents$/i
+    ,   tocNav = sr.$('nav#toc > h2')
+    ,   tocDiv = sr.$('div#toc > h2')
+    ;
 
-    if (toc.length > 0) {
+    var toc;
+
+    if(tocDiv.length > 0) {
+        if(tocNav.length > 0)
+            sr.error(exports.name, 'mixed');
+        else {
+            sr.warning(exports.name, 'not-html5');
+            toc = tocDiv;
+        }
+    }
+    else {
+        if(tocNav.length > 0)
+            toc = tocNav;
+        else
+            sr.error(exports.name, 'not-found');
+    }
+
+    if (toc && toc.length > 0) {
         var matches = 0;
         for (var i = 0; i < toc.length; i ++)
             if (EXPECTED_HEADING.test(sr.$(toc[i]).text()))
@@ -21,21 +40,6 @@ exports.check = function (sr, done) {
         else if (0 === matches)
             sr.error(exports.name, 'not-found');
     }
-    else {
-        toc = sr.$('div#toc > h2');
-
-        if (1 === toc.length) {
-            if (EXPECTED_HEADING.test(sr.$(toc[0]).text()))
-                sr.warning(exports.name, 'not-html5');
-            else
-                sr.error(exports.name, 'not-found');
-        }
-        else if (0 === toc.length)
-            sr.error(exports.name, 'not-found');
-        else if (toc.length > 1)
-            sr.error(exports.name, 'too-many');
-
-    };
 
     done();
 


### PR DESCRIPTION
More than one `<h2>` inside `<nav id="toc">` is now permitted, as long as exactly one matches `/^table\s+of\s+contents$/i`.

Fixes #351.