### PR TITLE
Improvements over #361

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Specberus is a checker used at [W3C](http://www.w3.org/) to validate the complia
 Specberus is a [Node.js](https://nodejs.org/en/) application, [distributed through npm](https://www.npmjs.com/package/specberus).
 Alternatively, you can clone [the repository](https://github.com/w3c/specberus) and run:
 
-    npm install -d
+```bash
+$ npm install -d
+```
 
 In order to get all the dependencies installed. Naturally, this requires that you have a reasonably
 recent version of Node.js installed.
@@ -56,7 +58,7 @@ $ API_KEY="<YOUR W3C API KEY>" npm start 3001
 Set the environment variable `DEBUG` to run in *debug mode* instead:
 
 ```bash
-$ DEBUG=true npm start
+$ DEBUG=true API_KEY="<YOUR W3C API KEY>" npm start
 ```
 
 This modifies the behaviour of certain parts of the application to facilitate debugging.
@@ -67,16 +69,22 @@ eg, CSS and JS resources will *not* be loaded in their minified/uglified forms
 
 Testing is done using mocha. Simply run:
 
-    API_KEY="<YOUR W3C API KEY>" mocha
+```bash
+$ API_KEY="<YOUR W3C API KEY>" mocha
+```
 
 from the root and you will be running the test suite. Mocha can be installed with:
 
-    npm install -g mocha
+```bash
+$ npm install -g mocha
+```
 
 Some of the tests can on occasion take a long time, or fail outright because a remote service is
 unavailable. To work around this, you can set SKIP_NETWORK:
 
-    SKIP_NETWORK=1 API_KEY="<YOUR W3C API KEY>" mocha
+```bash
+$ SKIP_NETWORK=1 API_KEY="<YOUR W3C API KEY>" mocha
+```
 
 ## 4. JS API
 

--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -133,7 +133,8 @@ exports.messages = {
 ,   "sotd.group-homepage.no-response":  "The connection to the API failed: HTTP ${status}"
 ,   "sotd.group-homepage.no-homepage":  "The homepage ${homepage} should appear in the SotD"
 ,   "sotd.group-homepage.no-group":     "Unable to find the deliverer"
-,   "sotd.group-homepage.no-key":       "Missing API key: contact sysreq@w3.org"
+,   "sotd.group-homepage.no-key":       `This instance of Specberus is missing a valid <a href="https://w3c.github.io/w3c-api/#apikeys">key
+        for the W3C API</a>; contact <a href="mailto:sysreq@w3.org"><code>sysreq@w3.org</code></a> for help.`
     // sotd/processDocument
 ,   "sotd.processDocument.deprecated":        "It seems the document attemps to follow process 1 Aug 2014, which is deprecated in favour of <a href='http://www.w3.org/2015/Process-20150901/'>1 September 2015</a>."
 ,   "sotd.processDocument.multiple-times":    "The governing process statement has been found multiple times."

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -128,10 +128,13 @@ exports.messages = {
 ,   "sotd.mailing-list.no-list":    "No mailing list link."
 ,   "sotd.mailing-list.no-sub":     "No mailing list subscription link."
 ,   "sotd.mailing-list.no-arch":    "No mailing list archives link."
-// sotd/group-homepage
+    // sotd/group-homepage
 ,   "sotd.group-homepage.no-sotd":      "No SotD section."
 ,   "sotd.group-homepage.no-response":  "The connection to the API failed: HTTP ${status}"
 ,   "sotd.group-homepage.no-homepage":  "The homepage ${homepage} should appear in the SotD"
+,   "sotd.group-homepage.no-group":     "Unable to find the deliverer"
+,   "sotd.group-homepage.no-key":       `This instance of Specberus is missing a valid <a href="https://w3c.github.io/w3c-api/#apikeys">key
+        for the W3C API</a>; contact <a href="mailto:sysreq@w3.org"><code>sysreq@w3.org</code></a> for help.`
     // sotd/processDocument
 ,   "sotd.processDocument.deprecated":        "It seems the document attemps to follow process 1 Aug 2014, which is deprecated in favour of <a href='http://www.w3.org/2015/Process-20150901/'>1 September 2015</a>."
 ,   "sotd.processDocument.multiple-times":    "The governing process statement has been found multiple times."

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -21,7 +21,7 @@ exports.check = function (sr, done) {
     }
     if (!apikey) {
         // Omitting 'section' & 'rule' on purpose: the error is not about the rule, but about local config.
-        sr.error({name: self.name}, "no-key");
+        sr.warning({name: self.name}, "no-key");
         return done();
     }
     for (var i = 0; i < deliverers.length; i++) {

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -1,7 +1,11 @@
-
 var sua = require("../../throttled-ua");
 
-exports.name = "sotd.group-homepage";
+const self = {
+    name: 'sotd.group-homepage'
+,   section: 'document-status'
+,   rule: 'WGLinkTest'
+};
+
 exports.check = function (sr, done) {
 
     var deliverers = sr.getDelivererIDs()
@@ -12,11 +16,11 @@ exports.check = function (sr, done) {
     ;
 
     if (deliverers.length === 0) {
-        sr.error(exports.name, "no-group");
+        sr.error(self, "no-group");
         return done();
     }
     if (!apikey) {
-        sr.warning(exports.name, "no-key");
+        sr.error(self, "no-key");
         return done();
     }
     for (var i = 0; i < deliverers.length; i++) {
@@ -28,7 +32,7 @@ exports.check = function (sr, done) {
         req.query({apikey: apikey});
         req.end(function(err, res) {
           if (err || !res.ok) {
-              sr.warning(exports.name, "no-response", {status: res.status});
+              sr.warning(self, "no-response", {status: res.status});
           } else {
               var homepage = res.body._links.homepage.href
                   found = false;
@@ -41,7 +45,7 @@ exports.check = function (sr, done) {
                   }
               });
               if (!found) {
-                  sr.warning(exports.name, "no-homepage", { homepage: homepage });
+                  sr.warning(self, "no-homepage", { homepage: homepage });
               }
           }
           count++;

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -20,7 +20,8 @@ exports.check = function (sr, done) {
         return done();
     }
     if (!apikey) {
-        sr.error(self, "no-key");
+        // Omitting 'section' & 'rule' on purpose: the error is not about the rule, but about local config.
+        sr.error({name: self.name}, "no-key");
         return done();
     }
     for (var i = 0; i < deliverers.length; i++) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -407,4 +407,9 @@ Specberus.prototype.transition = function (options) {
     else options.doMeanwhile();
 }
 
-exports.Specberus = Specberus;
+if (!process || !process.env || !process.env.API_KEY || process.env.API_KEY.length < 1) {
+    throw new Error('Specberus is missing a valid key for the W3C API; define environment variable “API_KEY”');
+    exports = undefined;
+}
+else
+    exports.Specberus = Specberus;


### PR DESCRIPTION
* Readapt rule `sotd.group-homepage` to the new way of throwing messages.
* Enforce requirement of new env var `API_KEY`: Specberus throws an exception if not defined. Works both as Node.js module and as an independent application. Only checks that the variable exists and that it is not an empty string. I have added [a bogus value in Travis](https://travis-ci.org/w3c/specberus/jobs/133116201#L142) so that tests pass there.
* More informative error message (I think). &hellip;that should never appear because of the enforcement above. Also, unify both L10n files (even if we plan to discard one of them anyway).
* Small fixes in README; formatting and env vars.