### PR TITLE
Fix undeclared variable

### DIFF
--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -36,7 +36,7 @@ exports.check = function (sr, done) {
               sr.warning(self, "no-response", {status: res.status});
           } else {
               var homepage = res.body._links.homepage.href
-                  found = false;
+                  var found = false;
 
               $sotd.find("a[href]").each(function () {
                   var href = sr.$(this).attr("href");


### PR DESCRIPTION
Fix:

```
/specberus/lib/rules/sotd/group-homepage.js:39
                  found = false;
                        ^

ReferenceError: found is not defined
    at /specberus/lib/rules/sotd/group-homepage.js:39:25
    at Request.callback (/specberus/node_modules/superagent/lib/node/index.js:691:12)
    at IncomingMessage.<anonymous> (/specberus/node_modules/superagent/lib/node/index.js:922:12)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:926:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```