### PR TITLE
Integrate jscs and jshint into CI workflow

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,15 @@
+{
+    "disallowMultipleSpaces": {"allowEOLComments": true},
+    "disallowMultipleSpaces": false,
+    "disallowMultipleVarDecl": null,
+    "disallowTrailingWhitespace": true,
+    "disallowUnusedVariables": true,
+    "excludeFiles": ["lib/l10n-es_ES.js", "lib/l10n-en_GB.js"],
+    "fileExtensions": ".js",
+    "maximumLineLength": 160,
+    "requireCapitalizedConstructors": true,
+    "requireCapitalizedConstructorsNew": true,
+    "requireCurlyBraces": false,
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": false
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+    "esversion": 6,
+    "laxcomma": true,
+    "loopfunc": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,8 @@
 {
     "esversion": 6,
+    "globals": {"require": false, "console": false, "exports": false, "process": false},
     "laxcomma": true,
-    "loopfunc": true
+    "loopfunc": true,
+    "undef": true,
+    "unused": true
 }

--- a/app.js
+++ b/app.js
@@ -49,8 +49,8 @@ io.sockets.on("connection", function (socket) {
     socket.emit("handshake", { version: version });
     socket.on("extractMetadata", function (data) {
         if (!data.url) return socket.emit("exception", { message: "URL not provided." });
-        var v = new validator.Specberus
-        ,   handler = new Sink
+        var v = new validator.Specberus()
+        ,   handler = new Sink()
         ;
         handler.on("end-all", function (metadata) {
             metadata.url = data.url;
@@ -68,8 +68,8 @@ io.sockets.on("connection", function (socket) {
         if (!data.url) return socket.emit("exception", { message: "URL not provided." });
         if (!data.profile) return socket.emit("exception", { message: "Profile not provided." });
         if (!profiles[data.profile]) return socket.emit("exception", { message: "Profile does not exist." });
-        var v = new validator.Specberus
-        ,   handler = new Sink
+        var v = new validator.Specberus()
+        ,   handler = new Sink()
         ,   profile = profiles[data.profile]
         ,   profileCode = profile.name
         ;
@@ -133,7 +133,10 @@ io.sockets.on("connection", function (socket) {
                     socket.emit("finished");
                 }
             } else {
-                socket.emit("exception", {message: "error while resolving " + data.url + " Check the spelling of the host, the protocol (http, https) and ensure that the page is accessible from the public Internet."});
+                const message = `Error while resolving <a href="${data.url}"><code>${data.url}</code></a>;
+                    check the spelling of the host, the protocol (<code>HTTP</code>, <code>HTTPS</code>)
+                    and ensure that the page is accessible from the public internet.`;
+                socket.emit("exception", {message: message});
             }
         }).catch(function(e){
             socket.emit("exception", { message: "Insafe check blew up: " + e });

--- a/lib/api.js
+++ b/lib/api.js
@@ -69,7 +69,7 @@ const processRequest = function(req, res) {
         }
         if (validate && 'auto' === options.profile) {
             errors = [];
-            v = new validator.Specberus;
+            v = new validator.Specberus();
             handler = new Sink(function(data) {
                 errors.push(data);
             }, function(data) {
@@ -96,7 +96,7 @@ const processRequest = function(req, res) {
                     errors2 = [];
                     warnings2 = [];
                     info2 = [];
-                    v2 = new validator.Specberus;
+                    v2 = new validator.Specberus();
                     handler2 = new Sink(function(data2) {
                         errors2.push(data2);
                     }, function() {
@@ -120,7 +120,7 @@ const processRequest = function(req, res) {
             errors = [];
             warnings = [];
             info = [];
-            v = new validator.Specberus;
+            v = new validator.Specberus();
             handler = new Sink(function(data) {
                 errors.push(data);
             }, function(data) {

--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -17,7 +17,7 @@ function findSet(shortname) {
           }
         }
         count++;
-        if (typeof set === "String")
+        if ('string' === typeof set)
             return _findSet(set);
         return set;
     }
@@ -32,14 +32,12 @@ Exceptions.prototype.has = function (shortname, rule, key, extra) {
     if (set === undefined) return false;
     for (var i = set.length - 1; i >= 0; i--) {
         for (var y = set[i].length - 1; y >= 0; y--) {
-          var exception = set[i][y];
+            var exception = set[i][y];
 
-          if (rule === exception.rule
-              && (extra === undefined
-                  || (compareValue(extra.type, exception.type)
-                      && compareValue(extra.source, exception.source)))) {
-                            return true;
-          }
+            if (rule === exception.rule &&
+                (extra === undefined || (compareValue(extra.type, exception.type) && compareValue(extra.source, exception.source)))) {
+                return true;
+            }
         }
     }
     return false;

--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -165,9 +165,9 @@ exports.messages = {
 ,   'structure.display-only.broken-links': false
 ,   'structure.display-only.customised-paragraph': false
 ,   'structure.display-only.known-disclosures': false
-,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
-Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
-for extended information about the publication rules.'
+,   'structure.display-only.old-pubrules': `This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br>
+        Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a>
+        for extended information about the publication rules.`
 ,   'structure.display-only.special-box-markup': 'Remember to use classes <code>example</code>, <code>def</code>, <code>note</code> and <code>marker</code>, and <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#boxes">other special box markup</a>.'
 ,   'structure.display-only.index-list-tables':  'Remember to use class <code>index</code> for <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#indexing">index lists and tables</a>.'
 ,   'structure.display-only.fit-in-a4':          'Make sure spec illustrations/tables fit within an A4 sheet of paper when printed; use class <code>overlarge</code> if needed to improve experience on-screen for things that overflow.'

--- a/lib/l10n-es_ES.js
+++ b/lib/l10n-es_ES.js
@@ -165,9 +165,9 @@ exports.messages = {
 ,   'structure.display-only.broken-links': false
 ,   'structure.display-only.customised-paragraph': false
 ,   'structure.display-only.known-disclosures': false
-,   'structure.display-only.old-pubrules': 'This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br> \
-Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a> \
-for extended information about the publication rules.'
+,   'structure.display-only.old-pubrules': `This alternative pubrules checker is <strong>experimental</strong>, and provided only for early testing. <br>
+        Please refer to <a href="http://www.w3.org/2005/07/pubrules?uimode=filter&uri=">Technical Report Publication Policy (Pubrules)</a>
+        for extended information about the publication rules.`
 ,   'structure.display-only.special-box-markup': 'Remember to use classes <code>example</code>, <code>def</code>, <code>note</code> and <code>marker</code>, and <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#boxes">other special box markup</a>.'
 ,   'structure.display-only.index-list-tables':  'Remember to use class <code>index</code> for <a href="http://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#indexing">index lists and tables</a>.'
 ,   'structure.display-only.fit-in-a4':          'Make sure spec illustrations/tables fit within an A4 sheet of paper when printed; use class <code>overlarge</code> if needed to improve experience on-screen for things that overflow.'

--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -9,8 +9,7 @@ const rulesWrapper = require('./rules-wrapper')
 ;
 
 // Constants:
-const rules = rulesWrapper.rules
-,   en_GB = english.messages
+const en_GB = english.messages
 ,   es_ES = spanish.messages
 ;
 

--- a/lib/rules/headers/copyright.js
+++ b/lib/rules/headers/copyright.js
@@ -11,14 +11,14 @@ exports.check = function (sr, done) {
         }
     ;
     if ($c.length) {
-        var year = (sr.getDocumentDate() || new Date).getFullYear()
+        var year = (sr.getDocumentDate() || new Date()).getFullYear()
         ,   text = sr.norm($c.text())
         ,   startRex = "^Copyright © (?:(?:199\\d|20[01]\\d)-)?" + year + " .*?W3C® \\(MIT, ERCIM, Keio, Beihang\\)"
         ,   isDualLicensed = /CC-BY/.test(text)
         ,   w3cOnlyStatement
         ,   dualLicenseStatement = ", Some Rights Reserved: this document is dual-licensed, CC-BY and W3C Document License"
         ,   endRex = "\\. W3C liability, trademark,? and (document use|permissive document license) rules apply\\.$"
-        ,   isPermissiveLicense = /permissive document license/.test(text);
+        ,   isPermissiveLicense = /permissive document license/.test(text)
         ;
 
         // This takes care of old copyright statement forms and their transitions.

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -6,7 +6,7 @@
 //  dt for editor or author
 
 var Request = require('request')
-,   Promise = require('promise');
+,   PowerPromise = require('promise');
 
 const self = {
     name: 'headers.dl'
@@ -30,7 +30,7 @@ exports.check = function (sr, done) {
     ;
 
     var fetch = function(uri) {
-      return new Promise(function (resolve, reject) {
+      return new PowerPromise(function (resolve, reject) {
         Request.get(uri, {}, function (error, response, body) {
           if (error) {
             reject(new Error('Fetching ' + uri + ' triggered a network error: ' + error.message));
@@ -58,22 +58,21 @@ exports.check = function (sr, done) {
     if (dts.Latest && dts.Previous && dts.Latest.pos > dts.Previous.pos) err("latest-previous-order");
     if (dts.Latest && dts.Rescinds && dts.Latest.pos > dts.Rescinds.pos) err("latest-rescinds-order");
 
-    var shortname;
+    var shortname
+    ,   matches;
+
     if (dts.This) {
         var $linkThis = dts.This.dd.find("a").first();
-        if (!$linkThis
-            || !$linkThis.length
-            || $linkThis.attr("href").trim() !== $linkThis.text().trim()
-           ) err("this-link");
+        if (!$linkThis || !$linkThis.length || $linkThis.attr("href").trim() !== $linkThis.text().trim())
+            err("this-link");
 
         var vThisRex = "^http:\\/\\/www\\.w3\\.org\\/" +
                        topLevel +
                        "\\/(\\d{4})\\/" +
                        (sr.config.status || "[A-Z]+") +
                        "-(.+)-(\\d{4})(\\d\\d)(\\d\\d)\\/?$";
-        var matches = ($linkThis.attr("href") || "").trim().match(new RegExp(vThisRex))
-        ,   docDate = sr.getDocumentDate()
-        ;
+        matches = ($linkThis.attr("href") || "").trim().match(new RegExp(vThisRex));
+        var docDate = sr.getDocumentDate();
         if (matches) {
             thisURI = matches[0];
             var year = matches[1] * 1
@@ -94,17 +93,17 @@ exports.check = function (sr, done) {
         else err("this-syntax");
     }
 
+    var sn;
+
     if (dts.Latest) {
         var $linkLate = dts.Latest.dd.find("a").first();
-        if (!$linkLate
-            || !$linkLate.length
-            || $linkLate.attr("href").trim() !== $linkLate.text().trim()
-           ) err("latest-link");
+        if (!$linkLate || !$linkLate.length || $linkLate.attr("href").trim() !== $linkLate.text().trim())
+            err("latest-link");
 
-        var lateRex = "^https?:\\/\\/www\\.w3\\.org\\/" + topLevel + "\\/(.+?)\\/?$"
-        ,   matches = ($linkLate.attr("href") || "").trim().match(new RegExp(lateRex));
+        var lateRex = "^https?:\\/\\/www\\.w3\\.org\\/" + topLevel + "\\/(.+?)\\/?$";
+        matches = ($linkLate.attr("href") || "").trim().match(new RegExp(lateRex));
         if (matches) {
-            var sn = matches[1];
+            sn = matches[1];
             latestURI = $linkLate.text();
             if (sn !== shortname) err("this-latest-shortname");
         }
@@ -113,16 +112,13 @@ exports.check = function (sr, done) {
 
     if (dts.Previous) {
         var $linkPrev = dts.Previous.dd.find("a").first();
-        if (!$linkPrev
-            || !$linkPrev.length
-            || $linkPrev.attr("href").trim() !== $linkPrev.text().trim()
-           ) err("previous-link");
+        if (!$linkPrev || !$linkPrev.length || $linkPrev.attr("href").trim() !== $linkPrev.text().trim())
+            err("previous-link");
 
-        var prevRex = "^https?:\\/\\/www\\.w3\\.org\\/" + topLevel + "\\/\\d{4}\\/[A-Z]+-(.+)-\\d{8}\\/?$"
-        ,   matches = ($linkPrev.attr("href") || "").trim().match(new RegExp(prevRex))
-        ;
+        var prevRex = "^https?:\\/\\/www\\.w3\\.org\\/" + topLevel + "\\/\\d{4}\\/[A-Z]+-(.+)-\\d{8}\\/?$";
+        matches = ($linkPrev.attr("href") || "").trim().match(new RegExp(prevRex));
         if (matches) {
-            var sn = matches[1];
+            sn = matches[1];
             previousURI = $linkPrev.text();
             if (sn !== shortname) err("this-previous-shortname");
         }
@@ -133,9 +129,9 @@ exports.check = function (sr, done) {
         var $linkResc = dts.Rescinds.dd.find("a").first();
         if (!$linkResc || !$linkResc.length || $linkResc.attr("href") !== $linkResc.text()) err("rescinds-link");
 
-        var matches = ($linkResc.attr("href") || "").trim().match(/^https?:\/\/www\.w3\.org\/TR\/\d{4}\/REC-(.+)-\d{8}\/?$/);
+        matches = ($linkResc.attr("href") || "").trim().match(/^https?:\/\/www\.w3\.org\/TR\/\d{4}\/REC-(.+)-\d{8}\/?$/);
         if (matches) {
-            var sn = matches[1];
+            sn = matches[1];
             if (sn !== shortname) err("this-rescinds-shortname");
         }
         else err("rescinds-syntax");
@@ -149,7 +145,7 @@ exports.check = function (sr, done) {
       done();
     }
     else {
-      Promise.all([fetch(previousURI), fetch(latestURI)]).then(function (bodies) {
+      PowerPromise.all([fetch(previousURI), fetch(latestURI)]).then(function (bodies) {
         if (!bodies || 2 !== bodies.length) {
           err('cant-retrieve');
         }

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -36,7 +36,7 @@ exports.check = function (sr, done) {
             reject(new Error('Fetching ' + uri + ' triggered a network error: ' + error.message));
           }
           else if (response.statusCode !== 200) {
-            reject(new Error('Fetching ' + uri + ' triggered and HTTP error: code ' + response.statusCode));
+            reject(new Error('Fetching ' + uri + ' triggered an HTTP error: code ' + response.statusCode));
           }
           else resolve(body);
         });

--- a/lib/rules/heuristic/date-format.js
+++ b/lib/rules/heuristic/date-format.js
@@ -12,7 +12,7 @@ exports.check = function (sr, done) {
     ,   EXPECTED_DATE_FORMAT = new RegExp('[0123]?\\d\\ (' + MONTHS + ')\\ \\d{4}', 'i');
 
     var boilerplateSections = [
-            sr.$('div.head'),
+            sr.$('div.head')
         ,   sr.$("h2[name='abstract'], h2#abstract, h2[name='status'], h2#status-of-this-document").parent()
         ]
     ,   candidateDates = []

--- a/lib/rules/heuristic/shortname.js
+++ b/lib/rules/heuristic/shortname.js
@@ -16,7 +16,7 @@ exports.check = function (sr, done) {
 
     var extractLatestURI = function (dl) {
       var latestAnchor;
-      dl.find("dt").each(function (idx) {
+      dl.find("dt").each(function () {
         var $dt = sr.$(this)
         ,   txt = sr.norm($dt.text())
                       .replace(":", "")

--- a/lib/rules/links/compound.js
+++ b/lib/rules/links/compound.js
@@ -16,8 +16,8 @@ exports.check = function (sr, done) {
     if ( typeof String.prototype.startsWith != 'function' ) {
         String.prototype.startsWith = function( str ) {
             return this.substring( 0, str.length ) === str;
-        }
-    };
+        };
+    }
 
     if(sr.url) {
         sr.$('a[href]').each(function () {
@@ -64,7 +64,13 @@ exports.check = function (sr, done) {
                         sr.info(self, "link", { file : l.split('/').pop(), link : l , markup : "\u2714", css : "\u2714" });
                     }
                     else {
-                        sr.error(self, "link", { file : l.split('/').pop(), link : l , markup : (isMarkupValid ? "\u2714" : "\u2718") , css : (isCSSValid ? "\u2714" : "\u2718") });
+                        const details = {
+                            file: l.split('/').pop(),
+                            link: l,
+                            markup: (isMarkupValid ? "\u2714" : "\u2718"),
+                            css: (isCSSValid ? "\u2714" : "\u2718")
+                        };
+                        sr.error(self, "link", details);
                     }
                     count++;
                     if (count === links.length - 1) return done();

--- a/lib/rules/links/linkchecker.js
+++ b/lib/rules/links/linkchecker.js
@@ -7,6 +7,6 @@ const self = {
 };
 
 exports.check = function (sr, done) {
-    sr.warning(self, "display", { link : sr.url })
+    sr.warning(self, "display", { link : sr.url });
     done();
 };

--- a/lib/rules/metadata/deliverers.js
+++ b/lib/rules/metadata/deliverers.js
@@ -2,15 +2,7 @@
  * Pseudo-rule for metadata extraction: deliverers' IDs.
  */
 
-// Settings:
-const REGEX_DELIVERER_URL = /^((https?:)?\/\/)?(www\.)?w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/i
-,   REGEX_DELIVERER_TEXT = /^public\s+list\s+of\s+any\s+patent\s+disclosures(\s+\(.+\))?$/i
-,   REGEX_DELIVERER_ID = /pp-impl\/(\d+)\/status/i
-;
-
-const self = {
-    name: 'metadata.deliverers'
-};
+// 'self.name' would be 'metadata.deliverers'
 
 exports.check = function(sr, done) {
 

--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: dl.
  */
 
-const self = {
-    name: 'metadata.dl'
-};
+// 'self.name' would be 'metadata.dl'
 
 exports.check = function(sr, done) {
     var $dl = sr.$("body div.head dl").first()
@@ -15,26 +13,26 @@ exports.check = function(sr, done) {
 
     var $linkThis = (dts.This) ? dts.This.dd.find("a").first() : null;
     if ($linkThis && $linkThis.length)
-      result['thisVersion'] = $linkThis.attr('href').trim();
+      result.thisVersion = $linkThis.attr('href').trim();
 
     var $linkLate = (dts.Latest) ? dts.Latest.dd.find("a").first() : null;
     if ($linkLate && $linkLate.length) {
-        result['latestVersion'] = $linkLate.attr('href').trim();
+        result.latestVersion = $linkLate.attr('href').trim();
         latestShortname = $linkLate.attr("href").trim().match(new RegExp(/.*\/([^/]+)\/$/))[1];
     }
 
     var $linkPrev = (dts.Previous) ? dts.Previous.dd.find("a").first() : null;
     if ($linkPrev && $linkPrev.length) {
-        result['previousVersion'] = $linkPrev.attr('href').trim();
+        result.previousVersion = $linkPrev.attr('href').trim();
         previousShortname = $linkPrev.attr("href").trim().match(new RegExp(/.*\/[^/-]+\-(.*)-\d{8}\/$/))[1];
     }
 
     var $linkEd = (dts.Editor) ? dts.Editor.dd.find("a").first() : null;
     if ($linkEd && $linkEd.length)
-        result['editorsDraft'] = $linkEd.attr('href').trim();
+        result.editorsDraft = $linkEd.attr('href').trim();
 
     if (previousShortname && latestShortname && previousShortname !== latestShortname) {
-        result['sameWorkAs'] = 'http://www.w3.org/TR/'+previousShortname+'/';  // TODO use api to get the previous shortlink
+        result.sameWorkAs = 'http://www.w3.org/TR/'+previousShortname+'/';  // TODO use api to get the previous shortlink
     }
 
     return done(result);

--- a/lib/rules/metadata/docDate.js
+++ b/lib/rules/metadata/docDate.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: docDate.
  */
 
-const self = {
-    name: 'metadata.docDate'
-};
+// 'self.name' would be 'metadata.docDate'
 
 exports.check = function(sr, done) {
 

--- a/lib/rules/metadata/editor-ids.js
+++ b/lib/rules/metadata/editor-ids.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: editor-ids.
  */
 
-const self = {
-    name: 'metadata.editor-ids'
-};
+// 'self.name' would be 'metadata.editor-ids'
 
 exports.check = function(sr, done) {
     return done({editorIDs: sr.getEditorIDs()});

--- a/lib/rules/metadata/informative.js
+++ b/lib/rules/metadata/informative.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: informative.
  */
 
-const self = {
-    name: 'metadata.informative'
-};
+// 'self.name' would be 'metadata.informative'
 
 exports.check = function(sr, done) {
 

--- a/lib/rules/metadata/process.js
+++ b/lib/rules/metadata/process.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: process.
  */
 
-const self = {
-    name: 'metadata.process'
-};
+// 'self.name' would be 'metadata.process'
 
 exports.check = function(sr, done) {
     var $processDocument = sr.$('a#w3c_process_revision');

--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -8,9 +8,7 @@ const SELECTOR_SUBTITLE = 'body div.head h2';
 // Internal packages:
 const profiles = require('../../../public/data/profiles');
 
-const self = {
-    name: 'metadata.profile'
-};
+// 'self.name' would be 'metadata.profile'
 
 exports.check = function(sr, done) {
 

--- a/lib/rules/metadata/rectrack.js
+++ b/lib/rules/metadata/rectrack.js
@@ -2,9 +2,7 @@
  * Pseudo-rule for metadata extraction: rectrack.
  */
 
-const self = {
-    name: 'metadata.rectrack'
-};
+// 'self.name' would be 'metadata.rectrack'
 
 exports.check = function(sr, done) {
 

--- a/lib/rules/metadata/title.js
+++ b/lib/rules/metadata/title.js
@@ -2,12 +2,10 @@
  * Pseudo-rule for metadata extraction: title.
  */
 
-const self = {
-    name: 'metadata.title'
-};
+// 'self.name' would be 'metadata.title'
 
 exports.check = function(sr, done) {
-    var $title = sr.$("body div.head h1").first()
+    var $title = sr.$("body div.head h1").first();
     if (!$title.length) {
         return done();
     } else {

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -35,9 +35,8 @@ exports.check = function (sr, done) {
           if (err || !res.ok) {
               sr.warning(self, "no-response", {status: res.status});
           } else {
-              var homepage = res.body._links.homepage.href
-                  found = false;
-
+              var homepage = res.body._links.homepage.href;
+              found = false;
               $sotd.find("a[href]").each(function () {
                   var href = sr.$(this).attr("href");
                   if (href === homepage) {

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -35,8 +35,8 @@ exports.check = function (sr, done) {
           if (err || !res.ok) {
               sr.warning(self, "no-response", {status: res.status});
           } else {
-              var homepage = res.body._links.homepage.href;
-              found = false;
+              var homepage = res.body._links.homepage.href
+              ,   found = false;
               $sotd.find("a[href]").each(function () {
                   var href = sr.$(this).attr("href");
                   if (href === homepage) {

--- a/lib/rules/sotd/implementation.js
+++ b/lib/rules/sotd/implementation.js
@@ -38,7 +38,7 @@ exports.check = function (sr, done) {
       var found = false;
       var match;
 
-      while (match = STATEMENT_PATTERN.exec(text)) {
+      while (null !== (match = STATEMENT_PATTERN.exec(text))) {
         found = true;
         sr.info(self, 'no-report', {text: match[0]});
       }

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -46,7 +46,7 @@ function findPP ($candidates, sr) {
         var $p = sr.$(this)
         ,   text = sr.norm($p.text())
         ,   wanted = buildWanted(groups, sr)
-        ,   jointRegex = /This document was published by the (.+) Working Group and the (.+) Working Group./;
+        ,   jointRegex = /This document was published by the (.+) Working Group and the (.+) Working Group./
         ;
         expected=wanted.text;
         if (jointRegex.test(text)) {

--- a/lib/rules/structure/name.js
+++ b/lib/rules/structure/name.js
@@ -14,8 +14,7 @@ exports.check = function (sr, done) {
 
     var superagent = require('superagent')
     ,   fileName
-    ,   file1
-    ,   file2;
+    ;
 
     if (!sr || !sr.url || EXPECTED_NAME.test(sr.url)) {
         return done();
@@ -39,7 +38,7 @@ exports.check = function (sr, done) {
                         sr.warning(self, 'wrong', {note: ''});
                     }
                     return done();
-                })
+                });
             });
         }
     }

--- a/lib/rules/style/meta.js
+++ b/lib/rules/style/meta.js
@@ -23,8 +23,8 @@ exports.check = function (sr, done) {
 	if (!props ||
 	    0 !== Object.keys(props.invalidValues).length ||
 	    2 !== Object.keys(props.validProperties).length ||
-	    !props.validProperties['width'] ||
-	    !width.test(props.validProperties['width']) ||
+	    !props.validProperties.width ||
+	    !width.test(props.validProperties.width) ||
 	    !props.validProperties['initial-scale'] ||
 	    1 !== props.validProperties['initial-scale'] ||
 	    1 !== Object.keys(props.unknownProperties).length ||

--- a/lib/rules/validation/css.js
+++ b/lib/rules/validation/css.js
@@ -46,6 +46,9 @@ exports.check = function (sr, done) {
             var json = res.body;
             if (!json) return sr.throw("No JSON input.");
             else {
+                var i
+                ,   n
+                ;
                 // {
                 //     "source":    URL,
                 //     "line":      line number,
@@ -54,7 +57,7 @@ exports.check = function (sr, done) {
                 //     "level":     how important
                 // }
                 if (json.cssvalidation && json.cssvalidation.warnings) {
-                    for (var i = 0, n = json.cssvalidation.warnings.length; i < n; i++) {
+                    for (i = 0, n = json.cssvalidation.warnings.length; i < n; i++) {
                         sr.warning(self, "warning", json.cssvalidation.warnings[i]);
                     }
                 }
@@ -66,7 +69,7 @@ exports.check = function (sr, done) {
                 //     "message":   human message
                 // }
                 if (json.cssvalidation && json.cssvalidation.errors) {
-                    for (var i = 0, n = json.cssvalidation.errors.length; i < n; i++) {
+                    for (i = 0, n = json.cssvalidation.errors.length; i < n; i++) {
                         sr.error(self, "error", json.cssvalidation.errors[i]);
                     }
                 }

--- a/lib/throttled-ua.js
+++ b/lib/throttled-ua.js
@@ -1,3 +1,4 @@
+/* globals setTimeout: false */
 
 var sua = require("superagent")
 ,   delay = 1000
@@ -34,4 +35,3 @@ exports.post = process.env.NO_THROTTLE ? sua.post : function () {
     var req = sua.post.apply(sua, arguments);
     return fixEnd(req);
 };
-

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,15 +96,16 @@ const processParams = function(params, base, constraints) {
         // Origin: one required.
         throw new Error('One parameter of {“url”, “source”, “file”, “document”} is required');
     else {
+        var c;
         if(constraints && constraints.required) {
             // Extra required params:
-            for (var c in constraints.required)
+            for (c in constraints.required)
                 if (!result.hasOwnProperty(constraints.required[c]))
                     throw new Error('Parameter “' + constraints.required[c] + '” is required in this context');
         }
         if(constraints && constraints.forbidden) {
             // Forbidden params:
-            for (var c in constraints.forbidden)
+            for (c in constraints.forbidden)
                 if (result.hasOwnProperty(constraints.forbidden[c]))
                     throw new Error('Parameter “' + constraints.forbidden[c] + '” is not allowed in this context');
         }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -134,9 +134,9 @@ Specberus.prototype.error = function (rule, key, extra) {
         name = rule;
     else
         name = rule.name;
-    if ((this.shortname !== undefined)
-        && (this.config.status === "WD" || this.config.status === "CR")
-        && this.exceptions.has(this.shortname, name, key, extra))
+    if ((this.shortname !== undefined) &&
+        (this.config.status === "WD" || this.config.status === "CR") &&
+        this.exceptions.has(this.shortname, name, key, extra))
         this.warning(rule, key, extra);
     else {
         if('string' === typeof rule)
@@ -198,7 +198,7 @@ Specberus.prototype.stringToDate = function (str) {
             return new Date(matches[3] * 1, months.indexOf(matches[2]), matches[1] * 1);
         }
         catch (e) {
-            self.throw("Creating Date() '" + matches[3] * 1 + ", " +
+            this.self.throw("Creating Date() '" + matches[3] * 1 + ", " +
                                              months.indexOf(matches[2]) + ", " +
                                              matches[1] * 1 + "' caused the validator to blow up.");
         }
@@ -273,7 +273,7 @@ Specberus.prototype.extractHeaders = function ($dl) {
     ,   $dd = $dt.next('dd')
     ,   key = null
     ;
-    if (!$dd) return err("no-dd", { dt: txt });
+    if (!$dd) return this.throw(`No &lt;dd&gt; element found for ${txt}.`);
     if (txt === "this version") key = "This";
     else if (txt.lastIndexOf("latest version", 0) === 0) key = "Latest";
     else if (/^previous version(?:s)?$/.test(txt)) key = "Previous";
@@ -295,7 +295,7 @@ Specberus.prototype.getEditorIDs = function () {
     // remove duplicates
     return editors.filter(function(item, pos) {
         return editors.indexOf(item) === pos;
-    })
+    });
 };
 
 // That rule tries to extract all the dates from the SOTD;
@@ -304,15 +304,16 @@ Specberus.prototype.getEditorIDs = function () {
 // the deadline for feedback.
 Specberus.prototype.getFeedbackDueDate = function() {
   var $sotd = this.getSotDSection()
-  ,   dates = [];
+  ,   dates = []
+  ;
   if ($sotd) {
       var txt        = this.norm($sotd.text())
       ,   rex        = new RegExp(this.dateRegexStrCapturing, 'g')
       ,   lowBound   = this.getDocumentDate()
       ,   highBound  = new Date(lowBound).setFullYear(lowBound.getFullYear() + 1)
       ,   candidates = txt.match(rex)
-      ,   dates      = []
       ;
+      dates= [];
 
       for (var i = 0; i < candidates.length; i++) {
           var d = this.stringToDate(candidates[i]);
@@ -321,7 +322,7 @@ Specberus.prototype.getFeedbackDueDate = function() {
       }
   }
   return dates;
-}
+};
 
 Specberus.prototype.getDelivererIDs = function () {
     const REGEX_DELIVERER_URL = /^((https?:)?\/\/)?(www\.)?w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/i
@@ -355,7 +356,7 @@ Specberus.prototype.getDelivererIDs = function () {
     }
 
     return ids;
-}
+};
 
 Specberus.prototype.loadURL = function (url, cb) {
     if (!cb) return this.throw("Missing callback to loadURL.");
@@ -405,12 +406,10 @@ Specberus.prototype.transition = function (options) {
     if (this.getDocumentDate() < options.from) options.doBefore();
     else if (this.getDocumentDate() > options.to) options.doAfter();
     else options.doMeanwhile();
-}
+};
 
-if (!process || !process.env || !process.env.API_KEY || process.env.API_KEY.length < 1) {
+if (!process || !process.env || !process.env.API_KEY || process.env.API_KEY.length < 1)
     throw new Error('Specberus is missing a valid key for the W3C API; define environment variable “API_KEY”');
-    exports = undefined;
-}
 else {
     if (!process || !process.env || !process.env.BASE_URI || process.env.BASE_URI.length < 1)
         console.warn(`Environment variable “BASE_URI” not defined; assuming that Specberus lives at “/”`);

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "body-parser": "1.15.1",
     "compression": "1.6",
-    "express": "4.13",
     "express-handlebars": "3.0",
+    "express": "4.13",
     "insafe": "0.3",
     "metaviewport-parser": "0.0.1",
     "morgan": "1.7.0",
@@ -23,12 +23,14 @@
     "whacko": "0.19"
   },
   "devDependencies": {
-    "chai": "3.5",
     "chai-as-promised": "5.3.0",
+    "chai": "3.5",
     "coveralls": "2.11",
     "expect.js": "0.3",
     "istanbul": "0.4",
+    "jscs": "3.0.3",
     "jsdoc": "3.4",
+    "jshint": "2.9.2",
     "mocha": "2.5.3",
     "nsp": "2.4.0"
   },
@@ -36,9 +38,10 @@
     "coverage": "istanbul cover _mocha",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "jsdoc": "jsdoc -a all -d doc/api/ -e utf8 -r app.js lib/ test/ tools/",
+    "lint": "jscs app.js lib/ public/ test/ tools/ views/ && jshint app.js lib/ public/ test/ tools/ views/",
     "nsp": "nsp check",
     "start": "node --use_strict app",
-    "test": "mocha"
+    "test": "npm run lint && mocha"
   },
   "engines": {
     "node": "4 || 5 || 6",

--- a/public/js/scroll-tweak.js
+++ b/public/js/scroll-tweak.js
@@ -1,12 +1,14 @@
-'use strict';
+/* globals $: false, document: false, window: false */
+
+'use strict'; // jshint ignore: line
 
 $(document).ready(function() {
     if (document.location && document.location.hash && window.pageYOffset && window.innerHeight)
         window.setTimeout(function() {
             const elem = $(document.location.hash);
-            if (elem && elemen.length > 0) elem[0].scrollIntoViewIfNeeded();
+            if (elem && elem.length > 0) elem[0].scrollIntoViewIfNeeded();
             window.setTimeout(function() {
-                window.scrollTo(window.pageXOffset, window.pageYOffset - window.innerHeight * .5);
+                window.scrollTo(window.pageXOffset, window.pageYOffset - window.innerHeight * 0.5);
             }, 500);
         }, 500);
 });

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -2,7 +2,9 @@
  * @TODO Document.
  */
 
-'use strict';
+/* globals jQuery: false, document: false, io: false, location: false, console: false, window: false, history: false, url: false */
+
+'use strict'; // jshint ignore: line
 
 // TODO:
 //  grab on submit and cancel, get values
@@ -11,7 +13,13 @@
 
 jQuery.extend({
     getQueryParameters : function(str) {
-        return (str || document.location.search).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = (n[1] === "true" || n[1] === "false") ? JSON.parse(n[1]) : n[1],this}.bind({}))[0];
+        return (str || document.location.search)
+            .replace(/(^\?)/,'')
+            .split("&")
+            .map(function(n){
+                return n = n.split("="), this[n[0]] = (n[1] === "true" || n[1] === "false") ? JSON.parse(n[1]) : n[1], this;
+            }
+            .bind({}))[0];
     }
 });
 
@@ -46,7 +54,6 @@ jQuery.extend({
     ,   done = 0
     ,   result = {exceptions: [], errors: [], warnings: [], infos: []}
     ,   total = 0
-    ,   icons = {done: '\u2714', info: '\u2714', warning: '\u2714', error: '\u2718'}
     ;
 
     // handshake
@@ -76,18 +83,6 @@ jQuery.extend({
             url: decodeURIComponent(url)
         });
     }
-
-    var type2class = {
-        error:      "text-danger"
-    ,   warning:    "text-warning"
-    ,   info:       "text-info"
-    };
-
-    var type2bgclass = {
-        error:      "bg-danger"
-    ,   warning:    "bg-warning"
-    ,   info:       "bg-info"
-    };
 
     function addMessage (type, data) {
         const url = $url.val();
@@ -160,7 +155,7 @@ jQuery.extend({
     socket.on('info', function (data) {
         addMessage(MSG_INFO, data);
     });
-    socket.on("done", function (data) {
+    socket.on("done", function () {
         done++;
         $progress.attr({
             "aria-valuenow":    done
@@ -184,7 +179,6 @@ jQuery.extend({
             $profile.val(profile);
             $noRecTrack.prop('checked', !data.metadata.rectrack);
             $informativeOnly.prop('checked', data.metadata.informative);
-            var validation = 'simple-validation';
             $validation.find("label").removeClass('active');
             $validation.find('label#simple-validation').addClass('active');
             var options = {
@@ -197,7 +191,7 @@ jQuery.extend({
                             , "patentPolicy"    : "pp2004"
                           };
             validate(options);
-            var newurl = document.URL.split('?')[0] + "?" + $.param(options)
+            var newurl = document.URL.split('?')[0] + "?" + $.param(options);
             history.pushState(options, url + " - " + profile, newurl);
         }
     });
@@ -230,7 +224,7 @@ jQuery.extend({
                             , "patentPolicy"    : patentPolicy
                           };
             validate(options);
-            var newurl = document.URL.split('?')[0] + "?" + $.param(options)
+            var newurl = document.URL.split('?')[0] + "?" + $.param(options);
             history.pushState(options, url + " - " + profile, newurl);
         }
         return false;
@@ -300,9 +294,9 @@ jQuery.extend({
                 message = `<span class="icon green pull-left">&#10003;</span>
                     <h4>OK!</h4>`;
         }
-        message += `<p class="details">`
+        message += `<p class="details">`;
         if (total > 0 && profile)
-            message += `<p class="details"><a href="doc/rules?profile=${profile}">${total} rules</a> were checked.`
+            message += `<p class="details"><a href="doc/rules?profile=${profile}">${total} rules</a> were checked.`;
         message += `Hover over the rows below for options.<p>`;
         $resultsBody.html(message);
         message = '';
@@ -326,7 +320,7 @@ jQuery.extend({
 
     window.addEventListener('popstate', function(event) {
         var options = event.state;
-        if (options == null) return;
+        if (null === options) return;
         setFormParams(options);
         validate(options);
     });

--- a/test/api.js
+++ b/test/api.js
@@ -2,6 +2,8 @@
  * Test the REST API.
  */
 
+/* globals describe: false, it: false, before: false, after: false */
+
 // Settings:
 const DEFAULT_PORT = 8000
 ,   PORT = process.env.PORT || DEFAULT_PORT
@@ -117,7 +119,7 @@ describe('API', function() {
         it('Should 404 and return an array of errors when validation fails', function() {
             query = get('validate?file=test/docs/metadata/ttml-imsc1.html&profile=REC&validation=simple-validation&processDocument=2047');
             return expect(query).to.eventually.be.rejectedWith(/"headers\.\w+/i);
-        })
+        });
         it('Should accept the parameter “url”, and succeed when the document is valid', function() {
             query = get('validate?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FWD-charmod-norm-20160407%2F&' +
                 'profile=WD&validation=simple-validation&processDocument=2015&noRecTrack=true');

--- a/test/l10n.js
+++ b/test/l10n.js
@@ -2,12 +2,13 @@
  * Test L10n features.
  */
 
+/* globals describe: false, it: false */
+
 // External packages:
 const expect = require('expect.js');
 
 // Internal packages:
-const rulesWrapper = require('../lib/rules-wrapper')
-;
+const rulesWrapper = require('../lib/rules-wrapper');
 
 describe('L10n', function() {
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---reporter spec
---timeout  20000
 --colors
 --growl
+--reporter spec
+--timeout  20000

--- a/test/rules.js
+++ b/test/rules.js
@@ -2,6 +2,8 @@
  * Test the rules.
  */
 
+/* globals __dirname: false, describe: false, it: false */
+
 // Settings:
 const DEBUG = false;
 
@@ -90,9 +92,11 @@ const compareMetadata = function(url, file, expectedObject) {
 
 describe('Basics', function() {
 
-    const specberus = new validator.Specberus;
+    const specberus = new validator.Specberus();
 
     describe('Method "extractMetadata"', function() {
+
+        var i;
 
         it('Should exist and be a function', function(done) {
             chai(specberus).to.have.property('extractMetadata').that.is.a('function');
@@ -100,12 +104,12 @@ describe('Basics', function() {
         });
 
         if (!process || !process.env || (process.env.TRAVIS !== 'true' && !process.env.SKIP_NETWORK)) {
-            for(var i in samples) {
+            for(i in samples) {
                 compareMetadata(samples[i].url, null, samples[i]);
             }
         }
         else {
-            for(var i in samples) {
+            for(i in samples) {
                 compareMetadata(null, samples[i].file, samples[i]);
             }
         }
@@ -347,7 +351,7 @@ Object.keys(tests).forEach(function (category) {
                     var passTest = test.errors ? false : true;
                     it("should " + (passTest ? "pass" : "fail") + " for " + test.doc, function (done) {
                         var r = require("../lib/rules/" + category + "/" + rule)
-                        ,   handler = new sink.Sink
+                        ,   handler = new sink.Sink()
                         ;
                         handler.on("err", function (type, data) {
                             if (DEBUG) console.log(type, data);
@@ -365,19 +369,21 @@ Object.keys(tests).forEach(function (category) {
                             console.error("[EXCEPTION] Validator had a massive failure: " + data.message);
                         });
                         handler.on("end-all", function () {
+                            var i
+                            ,   n;
                             if (passTest) {
                                 expect(handler.errors).to.be.empty();
                             }
                             else {
                                 expect(handler.errors.length).to.eql(test.errors.length);
-                                for (var i = 0, n = test.errors.length; i < n; i++) {
+                                for (i = 0, n = test.errors.length; i < n; i++) {
                                     expect(handler.errors).to.contain(test.errors[i]);
                                 }
                             }
                             if (!test.ignoreWarnings) {
                                 if (test.warnings) {
                                     expect(handler.warnings.length).to.eql(test.warnings.length);
-                                    for (var i = 0, n = test.warnings.length; i < n; i++) {
+                                    for (i = 0, n = test.warnings.length; i < n; i++) {
                                         expect(handler.warnings).to.contain(test.warnings[i]);
                                     }
                                 }

--- a/tools/fetch-groups-db.js
+++ b/tools/fetch-groups-db.js
@@ -1,8 +1,9 @@
-
 // This script updates our local database of groups
 //  Usage: node fetch-groups-db.js your-w3c-user your-w3c-password
 
 // XXX also look at https://cvs.w3.org/Team/WWW/2000/04/mem-news/groups.rdf
+
+/* globals __dirname: false */
 
 var fs = require("fs")
 ,   pth = require("path")
@@ -36,7 +37,7 @@ function munge (err, res) {
         $($tr.find("td")[3]).find("a").each(function () {
             var list = $(this).text();
             if (!/@w3\.org$/.test(list)) list += "@w3.org";
-            if (href.indexOf("http") === 0) true; // noop
+            if (href.indexOf("http") === 0) true; // jshint ignore: line
             else if (href.indexOf("/") === 0) href = "http://www.w3.org" + href;
             else if (/^(\.\.\/){2}\w/.test(href)) href = "http://www.w3.org/" + href.replace(/^(\.\.\/){2}/, "");
             else console.error("--------------- UNKNOWN URL FORM -------------------");

--- a/tools/make-groups-db.js
+++ b/tools/make-groups-db.js
@@ -1,4 +1,3 @@
-
 // XXX
 //  This script is obsolete.
 //  I keep it here in case the RDF source becomes reliable and turns out to be better than the
@@ -13,6 +12,8 @@
 //
 // 1. Visit http://kwz.me/8p. Copy the JSON into groups-sparql.json
 // 2. Run this script
+
+/* globals __dirname: false */
 
 var src = require("./groups-sparql.json")
 ,   fs = require("fs")


### PR DESCRIPTION
* Use `jscs` and `jshint`: add dependencies, write config files, run always before test suite.
* Fix all errors detected by those tools.
* Fix https://github.com/w3c/specberus/commit/8f0b8a47f86b80aba58fb8ab2899048a5010fd64#commitcomment-17643963.
* Fix a typo.