### PR TITLE
Fix “undefined property” runtime error in “cr-end” rule

### DIFF
--- a/lib/rules/sotd/cr-end.js
+++ b/lib/rules/sotd/cr-end.js
@@ -3,14 +3,18 @@ const self = {
 };
 
 exports.check = function (sr, done) {
-    var dates = sr.getFeedbackDueDate()
-    ,   res   = dates[0]
-    ;
-    if (dates.length === 0) sr.error(self, "not-found");
-    if (dates.length > 1) {
-      res = new Date(Math.min.apply(null,dates));
-      sr.warning(self, "multiple-found");
+    const dates = sr.getFeedbackDueDate();
+    if (0 === dates.length)
+        sr.error(self, "not-found");
+    else {
+        var res;
+        if (1 === dates.length)
+            res = dates[0];
+        else {
+            sr.warning(self, "multiple-found");
+            res = new Date(Math.min(...dates));
+        }
+        sr.info(self, "date-found", {date: res.toDateString()});
     }
-    sr.info(self, "date-found", {date: res.toDateString()});
     done();
 };

--- a/lib/rules/sotd/cr-end.js
+++ b/lib/rules/sotd/cr-end.js
@@ -12,7 +12,7 @@ exports.check = function (sr, done) {
             res = dates[0];
         else {
             sr.warning(self, "multiple-found");
-            res = new Date(Math.min(...dates));
+            res = new Date(Math.min.apply(null, dates));
         }
         sr.info(self, "date-found", {date: res.toDateString()});
     }


### PR DESCRIPTION
Fix:

```
/specberus/lib/rules/sotd/cr-end.js:14
    sr.info(self, "date-found", {date: res.toDateString()});
                                          ^

TypeError: Cannot read property 'toDateString' of undefined
    at Object.exports.check (/specberus/lib/rules/sotd/cr-end.js:14:43)
    at /specberus/lib/validator.js:116:18
    at Array.forEach (native)
    at doValidation (/specberus/lib/validator.js:112:23)
    at Specberus.loadSource (/specberus/lib/validator.js:383:5)
    at /specberus/lib/validator.js:369:18
    at Request.callback (/specberus/node_modules/superagent/lib/node/index.js:691:12)
    at IncomingMessage.<anonymous> (/specberus/node_modules/superagent/lib/node/index.js:922:12)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
```

(The build fails in Travis [for Node v4 only](https://travis-ci.org/w3c/specberus/jobs/133905702#L353-L355) because that version didn't know yet about [the spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator).)