### PR TITLE
mailing list archive: also check https

### DIFF
--- a/lib/rules/sotd/mailing-list.js
+++ b/lib/rules/sotd/mailing-list.js
@@ -35,7 +35,7 @@ exports.check = function (sr, done) {
             foundSub = true;
             return;
         }
-        if (/^http:\/\/lists\.w3\.org\/Archives\//.test(href) && /archive/i.test(text)) {
+        if (/^https?:\/\/lists\.w3\.org\/Archives\//.test(href) && /archive/i.test(text)) {
             foundArch = true;
             return;
         }


### PR DESCRIPTION
Some documents list the https version of the archive link, e.g. http://www.w3.org/TR/2016/CR-mediacapture-streams-20160519/