### PR TITLE
Omnibus PR

### DIFF
--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -33,7 +33,7 @@ exports.check = function (sr, done) {
         req.query({apikey: apikey});
         req.end(function(err, res) {
           if (err || !res.ok) {
-              sr.error(self, "no-response", {status: res.status});
+              sr.error(self, "no-response", {status: (res ? res.status : (err ? err : 'error'))});
           } else {
               var homepage = res.body._links.homepage.href
               ,   found = false;

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -9,7 +9,7 @@ const self = {
 exports.check = function (sr, done) {
 
     var deliverers = sr.getDelivererIDs()
-    ,   ua         = "Specberus/" + sr.version
+    ,   ua         = "W3C-Pubrules/" + sr.version
     ,   $sotd      = sr.getSotDSection()
     ,   count      = 0
     ,   apikey     = process.env.API_KEY

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -368,7 +368,7 @@ Specberus.prototype.loadURL = function (url, cb) {
     if (!cb) return this.throw("Missing callback to loadURL.");
     var self = this;
     sua.get(url)
-        .set("User-Agent", "Specberus/" + version + " Node/" + process.version + " by sexy Robin")
+        .set("User-Agent", "W3C-Pubrules/" + version)
         .end(function (err, res) {
             if (err) return self.throw(err.message);
             if (!res.text) return self.throw("Body of " + url + " is empty.");
@@ -415,9 +415,9 @@ Specberus.prototype.transition = function (options) {
 };
 
 if (!process || !process.env || !process.env.API_KEY || process.env.API_KEY.length < 1)
-    throw new Error('Specberus is missing a valid key for the W3C API; define environment variable “API_KEY”');
+    throw new Error('Pubrules is missing a valid key for the W3C API; define environment variable “API_KEY”');
 else {
     if (!process || !process.env || !process.env.BASE_URI || process.env.BASE_URI.length < 1)
-        console.warn(`Environment variable “BASE_URI” not defined; assuming that Specberus lives at “/”`);
+        console.warn(`Environment variable “BASE_URI” not defined; assuming that Pubrules lives at “/”`);
     exports.Specberus = Specberus;
 }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -8,7 +8,7 @@
     <meta name="description" content="Pubrules checker — reloaded">
     <meta name="keywords" content="pubrules,checker,specberus,w3c">
     <meta name="author" content="W3C">
-    <title>Technical Report Publication Policy (Pubrules) {{version}}{{#if title }} &mdash; {{title}}{{/if}}</title>
+    <title>Pubrules {{version}}{{#if title }} &mdash; {{title}}{{/if}}</title>
     {{#if DEBUG}}
       <link rel="stylesheet" type="text/css" href="https://www.w3.org/scripts/bootstrap/3.3/css/bootstrap.css">
     {{else}}
@@ -26,7 +26,7 @@
           <div class="col-xs-7 navbar-brand">
             <a href="http://www.w3.org/"><img class="logo" src="{{BASE_URI}}img/logo-w3c.svg" alt="W3C logo"></a>
             <img src="{{BASE_URI}}img/logo.svg" alt="Logo for the Pubrules Checker">
-            <a href="{{BASE_URI}}">Technical Report Publication Policy (Pubrules)</a> {{version}}{{#if title }} &mdash; {{title}}{{/if}}
+            <a href="{{BASE_URI}}"><abbr title="Technical Report Publication Policy">Pubrules</abbr></a> {{version}}{{#if title }} &mdash; {{title}}{{/if}}
           </div>
           <div class="contribute col-xs-5 text-right">
             <a id="infoLink" href="#" onclick="$('#about').show(); $('#infoLink').hide();">Important information about this tool</a>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta name="application-name" content="Pubrules Checker">
     <meta name="description" content="Pubrules checker — reloaded">
-    <meta name="keywords" content="pubrules,checker,specberus,w3c,publict">
+    <meta name="keywords" content="pubrules,checker,specberus,w3c">
     <meta name="author" content="W3C">
     <title>Technical Report Publication Policy (Pubrules) {{version}}{{#if title }} &mdash; {{title}}{{/if}}</title>
     {{#if DEBUG}}


### PR DESCRIPTION
* `s/specberus/pubrules/gi`: fix last occurrences of `specberus` in the output, and consolidate the new UA string introduced by #393.
* Fix meta `keywords` in main Handlebars layout.
* The long title was too long IMHO. When the version and the page title are appended, it takes too much space in the window title bar, and it is wrapped on the header of the page so part of it isn't visible. This is a proposal. If the long one *has* to be displayed, I'll rearrange the layout of the header.
* Fix TypeError:

```
Uncaught TypeError: Cannot read property 'status' of undefined
      at lib/rules/sotd/group-homepage.js:36:57
      at Request.callback (node_modules/superagent/lib/node/index.js:592:12)
      at ClientRequest.<anonymous> (node_modules/superagent/lib/node/index.js:544:10)
      at TLSSocket.socketErrorListener (_http_client.js:306:9)
      at connectErrorNT (net.js:1015:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```
