### PR TITLE
SVG errors reported by the CSS validator are treated as exceptions

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -35,7 +35,9 @@ Exceptions.prototype.has = function (shortname, rule, key, extra) {
             var exception = set[i][y];
 
             if (rule === exception.rule &&
-                (extra === undefined || (compareValue(extra.type, exception.type) && compareValue(extra.source, exception.source)))) {
+                (extra === undefined ||
+                  (!exception.message && compareValue(extra.type, exception.type)) ||
+                  (exception.message && compareValue(extra.type, exception.type) && compareValue(extra.message, exception.message)))) {
                 return true;
             }
         }

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -1,4 +1,36 @@
 {
+  ".*": [
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property fill doesn't exist : "
+    },
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property fill-opacity doesn't exist : "
+    },
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property text-anchor doesn't exist : "
+    },
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property stroke doesn't exist : "
+    },
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property stroke-width doesn't exist : "
+    },
+    {
+      "rule": "validation.css",
+      "type": "noexistence-at-all",
+      "message": "Property stroke-dasharray doesn't exist : "
+    }
+  ],
   "^webrtc$": [
     {
       "rule": "headers.copyright"
@@ -13,12 +45,6 @@
     {
       "rule": "validation.css",
       "type": "at-rule"
-    }
-  ],
-  "^powerful-features$": [
-    {
-      "rule": "validation.css",
-      "type": "noexistence-at-all"
     }
   ]
 }


### PR DESCRIPTION
@tabatkins @ylafon, that PR makes specberus ignore the SVG errors reported by the CSS validator. 
I did it that way because I expect it will require a lot of work to implement all the SVG properties in the validator. Here's the list of properties that will be skipped:
* `fill`
* `fill-opacity`
* `text-anchor`
* `stroke`
* `stroke-width`
* `stroke-dasharray`

This is a non-exhaustive list but I believe it'll enough for the specs generated by bikeshed.
@ylafon I assigned you as the reviewer to get your input on how we are going to handle these errors.