### PR TITLE
Metadata: extract editors' names

### DIFF
--- a/lib/profiles/metadata.js
+++ b/lib/profiles/metadata.js
@@ -11,6 +11,7 @@ exports.rules = [
 ,   require('../rules/metadata/dl')
 ,   require('../rules/metadata/deliverers')
 ,   require('../rules/metadata/editor-ids')
+,   require('../rules/metadata/editor-names')
 ,   require('../rules/metadata/rectrack')
 ,   require('../rules/metadata/informative')
 ,   require('../rules/metadata/process')

--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -27,7 +27,7 @@ exports.check = function(sr, done) {
         previousShortname = $linkPrev.attr("href").trim().match(new RegExp(/.*\/[^/-]+\-(.*)-\d{8}\/$/))[1];
     }
 
-    var $linkEd = (dts.Editor) ? dts.Editor.dd.find("a").first() : null;
+    var $linkEd = (dts.EditorDraft) ? dts.EditorDraft.dd.find("a").first() : null;
     if ($linkEd && $linkEd.length)
         result.editorsDraft = $linkEd.attr('href').trim();
 

--- a/lib/rules/metadata/editor-names.js
+++ b/lib/rules/metadata/editor-names.js
@@ -10,8 +10,8 @@ exports.check = function(sr, done) {
     ,   result = [];
     if (dts.Editor) {
       dts.Editor.dd.each(function() {
-          var editor = sr.$(this).text().trim();
-          result.push(editor.substring(0, editor.indexOf(',')));
+          var editor = sr.$(this).text().trim().replace(/[,(].*$/, "").trim();
+          if (editor) result.push(editor);
       });
     }
     return done({editorNames: result});

--- a/lib/rules/metadata/editor-names.js
+++ b/lib/rules/metadata/editor-names.js
@@ -1,0 +1,18 @@
+/**
+ * Pseudo-rule for metadata extraction: editor-names.
+ */
+
+// 'self.name' would be 'metadata.editor-names'
+
+exports.check = function(sr, done) {
+    var $dl = sr.$("body div.head dl").first()
+    ,   dts = sr.extractHeaders($dl)
+    ,   result = [];
+    if (dts.Editor) {
+      dts.Editor.dd.each(function(d) {
+          var editor = sr.$(this).text().trim();
+          result.push(editor.substring(0, editor.indexOf(',')));
+      });
+    }
+    return done({editorNames: result});
+};

--- a/lib/rules/metadata/editor-names.js
+++ b/lib/rules/metadata/editor-names.js
@@ -9,7 +9,7 @@ exports.check = function(sr, done) {
     ,   dts = sr.extractHeaders($dl)
     ,   result = [];
     if (dts.Editor) {
-      dts.Editor.dd.each(function(d) {
+      dts.Editor.dd.each(function() {
           var editor = sr.$(this).text().trim();
           result.push(editor.substring(0, editor.indexOf(',')));
       });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -282,7 +282,7 @@ Specberus.prototype.extractHeaders = function ($dl) {
     if (EDITORS_DRAFT.test(txt) && $dd.find('a')) key = "EditorDraft";
     if (EDITORS.test(txt)) {
         key = "Editor";
-        $dd = $dt.nextUntil('dt', 'dd')
+        $dd = $dt.nextUntil('dt', 'dd');
     }
     if (key) dts[key] = { pos: idx, el: $dt, dd: $dd };
   });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -263,6 +263,7 @@ Specberus.prototype.extractHeaders = function ($dl) {
   var $ = this.$
   ,   self = this
   ,   dts = {}
+  ,   EDITORS = /^editor(s)?$/
   ,   EDITORS_DRAFT = /(latest\ )?editor's\ draft/i;
   $dl.find("dt").each(function (idx) {
     var $dt = $(this)
@@ -278,7 +279,11 @@ Specberus.prototype.extractHeaders = function ($dl) {
     else if (!dts.Latest && txt.lastIndexOf("latest version", 0) === 0) key = "Latest";
     else if (/^previous version(?:s)?$/.test(txt)) key = "Previous";
     else if (/^rescinds this recommendation?$/.test(txt)) key = "Rescinds";
-    if (EDITORS_DRAFT.test(txt) && $dd.find('a')) key = "Editor";
+    if (EDITORS_DRAFT.test(txt) && $dd.find('a')) key = "EditorDraft";
+    if (EDITORS.test(txt)) {
+        key = "Editor";
+        $dd = $dt.nextUntil('dt', 'dd')
+    }
     if (key) dts[key] = { pos: idx, el: $dt, dd: $dd };
   });
   return dts;

--- a/test/rules.js
+++ b/test/rules.js
@@ -72,6 +72,10 @@ const compareMetadata = function(url, file, expectedObject) {
             chai(specberus).to.have.property('meta').to.have.property('latestVersion').equal(expectedObject.latestVersion);
             chai(specberus).to.have.property('meta').to.have.property('previousVersion').equal(expectedObject.previousVersion);
             chai(specberus).to.have.property('meta').to.have.property('editorsDraft').equal(expectedObject.editorsDraft);
+            chai(specberus).to.have.property('meta').to.have.property('editorNames');
+            chai(specberus.meta.editorNames).to.satisfy(function(found) {
+                return equivalentArray(found, expectedObject.editorNames);
+            });
             chai(specberus).to.have.property('meta').to.have.property('delivererIDs');
             chai(specberus.meta.delivererIDs).to.satisfy(function(found) {
                 return equivalentArray(found, expectedObject.delivererIDs);

--- a/test/samples.json
+++ b/test/samples.json
@@ -16,6 +16,10 @@
     ,   "docDate": "2016-3-8"
     ,   "delivererIDs": [83482]
     ,   "editorIDs": []
+    ,   "editorNames": [
+            "Cameron McCormack"
+        ,   "Boris Zbarsky"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -37,6 +41,9 @@
     ,   "docDate": "2016-3-8"
     ,   "delivererIDs": [34314]
     ,   "editorIDs": []
+    ,   "editorNames": [
+            "Pierre Lemieux"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -58,6 +65,11 @@
     ,   "docDate": "2016-2-25"
     ,   "delivererIDs": [68238]
     ,   "editorIDs": []
+    ,   "editorNames": [
+            "Jeremy Tandy"
+        ,   "Davide Ceolin"
+        ,   "Eric Stephan"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -79,6 +91,10 @@
     ,   "docDate": "2015-12-17"
     ,   "delivererIDs": [68238]
     ,   "editorIDs": [33715,44770,7382]
+    ,   "editorNames": [
+            "Jeni Tennison"
+        ,   "Gregg Kellogg"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -104,6 +120,11 @@
     ,   "docDate": "2016-2-26"
     ,   "delivererIDs": [47318, 43696]
     ,   "editorIDs": [41974,68202,76096]
+    ,   "editorNames": [
+            "Anssi Kostiainen"
+        ,   "Ningxin Hu"
+        ,   "Rob Manson"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -125,6 +146,9 @@
     ,   "docDate": "2016-4-7"
     ,   "delivererIDs": [32113]
     ,   "editorIDs": [33573]
+    ,   "editorNames": [
+            "Addison Phillips"
+    ]
     ,   "informative": false
     ,   "rectrack": false
     ,   "process": "http://www.w3.org/2015/Process-20150901/"
@@ -146,6 +170,10 @@
     ,   "docDate": "2013-6-6"
     ,   "delivererIDs": [42538]
     ,   "editorIDs": []
+    ,   "editorNames": [
+            "Dominic Cooney"
+        ,   "Dimitri Glazkov"
+    ]
     ,   "informative": true
     ,   "rectrack": true
     }
@@ -166,6 +194,12 @@
     ,   "docDate": "2016-6-2"
     ,   "delivererIDs": [83482]
     ,   "editorIDs": []
+    ,   "editorNames": [
+            "Steve Faulkner"
+        ,   "Arron Eicholz"
+        ,   "Travis Leithead"
+        ,   "Alex Danilo"
+    ]
     ,   "informative": false
     ,   "rectrack": true
     ,   "process": "http://www.w3.org/2015/Process-20150901/"


### PR DESCRIPTION
If the document doesn't contain any `data-editor-id`, it's useful to know which editors appear on the spec.