### PR TITLE
Omnibus PR

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -115,19 +115,22 @@ jQuery.extend({
         if (data && data.name)
             issue = `<a href="https://github.com/w3c/specberus/issues/new?` +
                 `title=Bug%20in%20rule%20%E2%80%9C${data.name}%E2%80%9D:%20[WHAT]&` +
-                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
+                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${encodeURIComponent(url)}\`]` +
+                `(${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
                 `">Report a bug</a>`;
         else if (data && data.exception)
             issue = `<a href="https://github.com/w3c/specberus/issues/new?` +
                 `title=Bug:%20[WHAT]&` +
-                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
+                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${encodeURIComponent(url)}\`]` +
+                `(${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
                 `">Report a bug</a>`;
         else
             issue = `<a href="https://github.com/w3c/specberus/issues/new?` +
                 `title=Bug%20in%20rules:%20[WHAT]&` +
-                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
+                `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${encodeURIComponent(url)}\`]` +
+                `(${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
                 `">Report a bug</a>`;
         var item = `<li class="list-group-item alert alert-${type.bootstrap}${exc}">

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -8,6 +8,7 @@
     <meta name="description" content="Pubrules checker — reloaded">
     <meta name="keywords" content="pubrules,checker,specberus,w3c">
     <meta name="author" content="W3C">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <title>Pubrules {{version}}{{#if title }} &mdash; {{title}}{{/if}}</title>
     {{#if DEBUG}}
       <link rel="stylesheet" type="text/css" href="https://www.w3.org/scripts/bootstrap/3.3/css/bootstrap.css">


### PR DESCRIPTION
* Improve `viewport` meta tag.
* Encode also the URL when submitting a GH issue. As it was before, a URL containing ampersands (which happens often when using spec-generator on labs.w3.org) was interpreted by GH as containing parameters *for it*, thus truncating the rest of the markdown.