### PR TITLE
Prevent redundant run; monitor socket status

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -72,11 +72,11 @@ jQuery.extend({
     const toggleForm = (bool) => {
         if (bool) {
             $('form').css('opacity', 1);
-            $('form input').removeClass('disabled').removeAttr('disabled');
+            $('form input, form select, form label').removeClass('disabled').removeAttr('disabled');
             $('button[type=submit]').text('Check');
         } else {
-            $('form').css('opacity', 0.25);
-            $('form input').addClass('disabled').attr('disabled', 'disabled');
+            $('form').css('opacity', 0.333);
+            $('form input, form select, form label').addClass('disabled').attr('disabled', 'disabled');
             $('button[type=submit]').text('Wait…');
         }
     };

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -186,8 +186,6 @@ jQuery.extend({
     });
     socket.on("finished", function () {
         console.log('Finished.');
-        toggleForm(true);
-        running = false;
         showResults();
     });
     socket.on("finishedExtraction", function (data) {
@@ -304,6 +302,8 @@ jQuery.extend({
     };
 
     function showResults() {
+        toggleForm(true);
+        running = false;
         $results.fadeIn();
         $progressStyler.removeClass("active progress-striped");
         $progressContainer.hide();


### PR DESCRIPTION
* Whole form is disabled (greyed-out) and text of button changes (from &ldquo;check&rdquo; to &ldquo;wait&hellip;&rdquo;) if there's a validation running. Prevents against clicking more than once. Fixes #149.
* When the socket disconnects, reload the page (fixes #399).
* When there are query parameters and validation occurs automatically, do so by actually submitting the form (instead of just sending stuff through the socket). Makes it consistent with the changes above (form is disabled), and hopefully will solve situations where validation isn't triggered automatically now&hellip; (not sure; I'll have to keep on testing that).
* Progress bar returns to 0 once validation finishes (prevents that effect when the progress bar appears to go backwards).