### PR TITLE
fix bug on rectrack param in the validation API

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -92,7 +92,7 @@ const processRequest = function(req, res) {
                         return sendJSONresult([err.toString()], [], [], res, {});
                     }
                     options2.validation = 'simple-validation';
-                    options2.noRecTrack = !data.rectrack;
+                    options2.noRecTrack = !meta.rectrack;
                     errors2 = [];
                     warnings2 = [];
                     info2 = [];


### PR DESCRIPTION
The `rectrack` param is not properly retrieve from the JSON.