### PR TITLE
Fix duplicate “no SotD section” error messages

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -5,6 +5,8 @@ exports.messages = {
 ,   "dummy.h1.not-found":       "Selector h1 not found."
     // dummy/dahut
 ,   "dummy.dahut.not-found":    "No element containing DAHUT."
+    // Generic
+,   'generic.sotd.not-found': 'No <em>&ldquo;status of this document&rdquo;</em> section found. Some errors related to this one will be omitted from the output, but most likely this will cause further problems along the line.'
     // headers/title
 ,   "headers.title.not-found":  "Document does not have a title."
     // headers/logo
@@ -82,27 +84,21 @@ exports.messages = {
 ,   "links.compound.html-timeout":      "The HTML validator timed out."
 ,   "links.compound.css-timeout":       "The CSS validator timed out."
     // sotd/supersedable
-,   "sotd.supersedable.no-sotd":        "No 'Status of this Document' section."
-,   "sotd.supersedable.no-sotd-intro":  "No 'Status of this Document' introduction."
-,   "sotd.supersedable.no-sotd-tr":     "No 'Status of this Document' introduction link to TR."
+,   "sotd.supersedable.no-sotd-intro":  "No <em>&ldquo;status of this document&rdquo;</em> introduction."
+,   "sotd.supersedable.no-sotd-tr":     "No <em>&ldquo;status of this document&rdquo;</em> introduction link to TR."
     // sotd/submission
-,   "sotd.submission.no-sotd":              "No 'Status of this Document' section."
 ,   "sotd.submission.no-submission-text":   "No member submission paragraph."
 ,   "sotd.submission.link-text":            "Missing link '${href}' with text '${text}'."
 ,   "sotd.submission.no-sm-link":           "Missing link 'http://www.w3.org/Submission/...' with text 'Submitting Members'."
 ,   "sotd.submission.no-tc-link":           "Missing link 'http://www.w3.org/Submission/...' with text 'W3C Team Comment'."
     // sotd/team-subm-link
-,   "sotd.team-subm-link.no-sotd":  "No 'Status of this Document' section."
 ,   "sotd.team-subm-link.no-link":  "No link to all Team Submissions."
     // sotd/stability
-,   "sotd.stability.no-sotd":       "No 'Status of this Document' section."
 ,   "sotd.stability.no-stability":  "No stability warning paragraph."
 ,   "sotd.stability.no-rec-review": "No indication that the Director, developers, and interested parties have reviewed this Recommendation."
     // sotd/status
-,   "sotd.status.no-sotd":      "No 'Status of this Document' section."
-,   "sotd.status.no-mention":   "'Status of this Document' does not mention that this is a ${status}."
+,   "sotd.status.no-mention":   "<em>&ldquo;status of this document&rdquo;</em> does not mention that this is a ${status}."
     // sotd/review-end
-,   "sotd.review-end.no-sotd":      "No 'Status of this Document' section."
 ,   "sotd.review-end.not-found":    "No review end date found."
 ,   "sotd.review-end.found":        "Review end date found: ${date}"
     // sotd/cr-end
@@ -110,7 +106,6 @@ exports.messages = {
 ,   "sotd.cr-end.multiple-found": "Multiple feedback due dates found. Choosing the closest date."
 ,   "sotd.cr-end.date-found":     "Feedback due date detected: ${date}"
     // sotd/pp
-,   "sotd.pp.no-sotd":           "No 'Status of this Document' section."
 ,   "sotd.pp.no-pp":             "Required patent policy paragraph not found."
 ,   "sotd.pp.no-feb5":           "No link to the 2004 Feb 5 patent policy (https://www.w3.org/Consortium/Patent-Policy-20040205/)."
 ,   "sotd.pp.no-disclosures":    "No link to public list of disclosures (https://www.w3.org/2004/01/pp-impl/NNNNN/status)."
@@ -121,35 +116,30 @@ exports.messages = {
 ,   "sotd.pp.joint-publication": "Joint publication detected."
 ,   "sotd.pp.expected-pp":       "Expected text related to patent policy requirements: <blockquote>${expected}</blockquote>"
     // sotd/charter-disclosure
-,   "sotd.charter-disclosure.no-sotd":      "No 'Status of this Document' section."
 ,   "sotd.charter-disclosure.not-found":    "No link to charter for disclosure obligations found."
     // sotd/mailing-list
-,   "sotd.mailing-list.no-sotd":    "No 'Status of this Document' section."
 ,   "sotd.mailing-list.no-list":    "No mailing list link."
 ,   "sotd.mailing-list.no-sub":     "No mailing list subscription link."
 ,   "sotd.mailing-list.no-arch":    "No mailing list archives link."
     // sotd/group-homepage
 ,   "sotd.group-homepage.no-response":  "The connection to the API failed: HTTP ${status}"
-,   "sotd.group-homepage.no-homepage":  "The homepage ${homepage} should appear in the 'Status of this Document'"
+,   "sotd.group-homepage.no-homepage":  "The homepage ${homepage} should appear in the <em>&ldquo;status of this document&rdquo;</em>"
 ,   "sotd.group-homepage.no-group":     "Unable to find the deliverer"
 ,   "sotd.group-homepage.no-key":       `This instance of Pubrules is missing a valid <a href="https://w3c.github.io/w3c-api/#apikeys">key
         for the W3C API</a>; contact <a href="mailto:sysreq@w3.org"><code>sysreq@w3.org</code></a> for help.`
     // sotd/process-document
 ,   "sotd.process-document.deprecated":        "It seems the document attemps to follow process 1 Aug 2014, which is deprecated in favour of <a href='https://www.w3.org/2015/Process-20150901/'>1 September 2015</a>."
 ,   "sotd.process-document.multiple-times":    "The governing process statement has been found multiple times."
-,   "sotd.process-document.no-sotd":           "No 'Status of this Document' section."
 ,   "sotd.process-document.not-found":         "The document must mention the governing process: ${process}"
 ,   "sotd.process-document.wrong-link":        "The link to the process rules specified in the document is erroneous."
 ,   "sotd.process-document.wrong-process":     "The document doesn't specify the right governing process: ${process}."
     // sotd/implementation
-,   "sotd.implementation.no-sotd":      "No 'Status of this Document' section."
 ,   "sotd.implementation.candidate":    "Found link to a preliminary interoperability/implementation report: <em><a href=\"${url}\">${text}</a></em>."
 ,   "sotd.implementation.no-report":    "Found a statement about a (missing) preliminary interoperability/implementation report: <em>“…${text}…”</em>."
 ,   "sotd.implementation.unknown":      "Could not find statements nor links about preliminary implementation/interoperability reports."
     // sotd/ac-review
 ,   "sotd.ac-review.found":       "Found a link to an online questionnaire: ${link}. Does this link provide access to the review form?"
 ,   "sotd.ac-review.not-found":   "Did not find information about a forum for AC Representative feedback."
-,   "sotd.ac-review.no-sotd":     "No 'Status of this Document' section."
     // sotd/diff
 ,   "sotd.diff.note":   false
     // structure/name
@@ -157,9 +147,9 @@ exports.messages = {
     // structure/section-ids
 ,   "structure.section-ids.no-id":  "No ID for section: '${text}'."
     // structure/h2
-,   "structure.h2.abstract":    "First &lt;h2&gt; after div.head must be 'Abstract', was '${was}'."
-,   "structure.h2.sotd":        "Second &lt;h2&gt; after div.head must be 'Status of This Document', was '${was}'."
-,   "structure.h2.toc":         "Third &lt;h2&gt; after div.head must be 'Table of Contents', was '${was}'."
+,   "structure.h2.abstract":    "First <code>&lt;h2&gt;</code> after <code>div.head</code> must be &ldquo;Abstract&rdquo;, but was &ldquo;${was}&rdquo;."
+,   "structure.h2.sotd":        "Second <code>&lt;h2&gt;</code> after <code>div.head</code> must be &ldquo;status of this document&rdquo;, but was &ldquo;${was}&rdquo;."
+,   "structure.h2.toc":         "Third <code>&lt;h2&gt;</code> after <code>div.head</code> must be &ldquo;Table of Contents&rdquo;, but was &ldquo;${was}&rdquo;."
     // structure/display-only
 ,   'structure.display-only.customised-paragraph': false
 ,   'structure.display-only.known-disclosures': false

--- a/lib/rules/sotd/ac-review.js
+++ b/lib/rules/sotd/ac-review.js
@@ -4,18 +4,16 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
+    if ($sotd && $sotd.length) {
+        var found = false;
+        $sotd.find("a[href*='www.w3.org/2002/09/wbs/']").each(function() {
+            var href = sr.$(this).attr("href");
+            found = true;
+            // XXX use an <a href> to display the link
+            sr.info(self, "found", { link : href });
+            return;
+        });
+        if (!found) sr.error(self, "not-found");
     }
-    var found = false;
-    $sotd.find("a[href*='www.w3.org/2002/09/wbs/']").each(function() {
-        var href = sr.$(this).attr("href");
-        found = true;
-        // XXX use an <a href> to display the link
-        sr.info(self, "found", { link : href });
-        return;
-    });
-    if (!found) sr.error(self, "not-found");
     done();
 };

--- a/lib/rules/sotd/charter-disclosure.js
+++ b/lib/rules/sotd/charter-disclosure.js
@@ -4,12 +4,10 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
+    if ($sotd && $sotd.length) {
+        var txt = sr.norm($sotd.text());
+        if (!/The disclosure obligations of the Participants of this group are described in the charter\./.test(txt))
+            sr.error(self, "not-found");
     }
-    var txt = sr.norm($sotd.text());
-    if (!/The disclosure obligations of the Participants of this group are described in the charter\./.test(txt))
-        sr.error(self, "not-found");
     done();
 };

--- a/lib/rules/sotd/implementation.js
+++ b/lib/rules/sotd/implementation.js
@@ -9,44 +9,41 @@ exports.check = function (sr, done) {
     var url_candidates = {};
     var item;
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
+    if ($sotd && $sotd.length) {
+        sr.$('a').each(function (foo, element) {
+          item = sr.$(element);
 
-    sr.$('a').each(function (foo, element) {
-      item = sr.$(element);
+          if (LINK_PATTERN.exec(item.text())) {
+            url_candidates[item.attr('href')] = item.text();
+          }
 
-      if (LINK_PATTERN.exec(item.text())) {
-        url_candidates[item.attr('href')] = item.text();
-      }
+        });
 
-    });
+        if (Object.keys(url_candidates).length > 0) {
 
-    if (Object.keys(url_candidates).length > 0) {
+          for (item in url_candidates) {
+            sr.info(self, 'candidate', {text: url_candidates[item], url: item});
+          }
 
-      for (item in url_candidates) {
-        sr.info(self, 'candidate', {text: url_candidates[item], url: item});
-      }
+        }
+        else {
 
-    }
-    else {
+          var STATEMENT_PATTERN = /.{40}(implementation|interoperability)\s+report.{40}/ig;
 
-      var STATEMENT_PATTERN = /.{40}(implementation|interoperability)\s+report.{40}/ig;
+          var text = sr.getSotDSection().text().replace(/\n+/g, ' ');
+          var found = false;
+          var match;
 
-      var text = sr.getSotDSection().text().replace(/\n+/g, ' ');
-      var found = false;
-      var match;
+          while (null !== (match = STATEMENT_PATTERN.exec(text))) {
+            found = true;
+            sr.info(self, 'no-report', {text: match[0]});
+          }
 
-      while (null !== (match = STATEMENT_PATTERN.exec(text))) {
-        found = true;
-        sr.info(self, 'no-report', {text: match[0]});
-      }
+          if (!found) {
+            sr.error(self, 'unknown');
+          }
 
-      if (!found) {
-        sr.error(self, 'unknown');
-      }
-
+        }
     }
 
     return done();

--- a/lib/rules/sotd/mailing-list.js
+++ b/lib/rules/sotd/mailing-list.js
@@ -13,42 +13,40 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-    var foundML = false
-    ,   foundSub = false
-    ,   foundArch = false
-    ,   foundRepo = false
-    ;
-    $sotd.find("a[href]").each(function () {
-        var $a = sr.$(this)
-        ,   href = $a.attr("href")
-        ,   text = sr.norm($a.text())
+    if ($sotd && $sotd.length) {
+        var foundML = false
+        ,   foundSub = false
+        ,   foundArch = false
+        ,   foundRepo = false
         ;
-        if (/^mailto:.+@w3\.org(?:\?subject=.*)?$/i.test(href) &&
-            !/.+-request@/.test(href)) {
-            foundML = true;
-            return;
+        $sotd.find("a[href]").each(function () {
+            var $a = sr.$(this)
+            ,   href = $a.attr("href")
+            ,   text = sr.norm($a.text())
+            ;
+            if (/^mailto:.+@w3\.org(?:\?subject=.*)?$/i.test(href) &&
+                !/.+-request@/.test(href)) {
+                foundML = true;
+                return;
+            }
+            if (/^mailto:.+?-request@w3\.org\?subject=subscribe$/i.test(href) && text === "subscribe") {
+                foundSub = true;
+                return;
+            }
+            if (/^https?:\/\/lists\.w3\.org\/Archives\//.test(href) && /archive/i.test(text)) {
+                foundArch = true;
+                return;
+            }
+            if (/^https:\/\/github.com\/[\w-]+\/[\w-]+\/issues/.test(href)) {
+                foundRepo = true;
+                return;
+            }
+        });
+        if (!foundRepo) {
+            if (!foundML) sr.error(self, "no-list");
+            if (!foundSub) sr.warning(self, "no-sub");
         }
-        if (/^mailto:.+?-request@w3\.org\?subject=subscribe$/i.test(href) && text === "subscribe") {
-            foundSub = true;
-            return;
-        }
-        if (/^https?:\/\/lists\.w3\.org\/Archives\//.test(href) && /archive/i.test(text)) {
-            foundArch = true;
-            return;
-        }
-        if (/^https:\/\/github.com\/[\w-]+\/[\w-]+\/issues/.test(href)) {
-            foundRepo = true;
-            return;
-        }
-    });
-    if (!foundRepo) {
-        if (!foundML) sr.error(self, "no-list");
-        if (!foundSub) sr.warning(self, "no-sub");
+        if (!foundArch) sr.error(self, "no-arch");
     }
-    if (!foundArch) sr.error(self, "no-arch");
     done();
 };

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -73,68 +73,66 @@ const self = {
 exports.check = function (sr, done) {
 
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-    var $pp = findPP($sotd.filter("p").add($sotd.find("p")), sr);
-    if (!$pp || !$pp.length) {
-        sr.error(self, "no-pp");
-        return done();
-    }
-    var foundFeb5 = false
-    ,   foundPublicList = false
-    ,   foundEssentials = false
-    ,   foundSection6 = false
-    ,   foundJan24 = false
-    ,   foundPPTransition = false
-    ;
-    $pp.find("a[href]").each(function () {
-        var $a = sr.$(this)
-        ,   href = $a.attr("href")
-        ,   text = sr.norm($a.text())
+    if ($sotd && $sotd.length) {
+        var $pp = findPP($sotd.filter("p").add($sotd.find("p")), sr);
+        if (!$pp || !$pp.length) {
+            sr.error(self, "no-pp");
+            return done();
+        }
+        var foundFeb5 = false
+        ,   foundPublicList = false
+        ,   foundEssentials = false
+        ,   foundSection6 = false
+        ,   foundJan24 = false
+        ,   foundPPTransition = false
         ;
-        if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/" &&
-            text === "5 February 2004 W3C Patent Policy") {
-            foundFeb5 = true;
-            return;
-        }
-        if (/^https:\/\/www\.w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/.test(href) &&
-            /public list of any patent disclosures( \(.+\))?/.test(text) &&
-            $a.attr("rel") === "disclosure") {
-            foundPublicList = true;
-            return;
-        }
-        if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential" &&
-            text === "Essential Claim(s)") {
-            foundEssentials = true;
-            return;
-        }
-        if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure" &&
-            text === "section 6 of the W3C Patent Policy") {
-            foundSection6 = true;
-            return;
-        }
-        if (href === "https://www.w3.org/TR/2002/NOTE-patent-practice-20020124" &&
-            text === "24 January 2002 CPP") {
-                foundJan24 = true;
+        $pp.find("a[href]").each(function () {
+            var $a = sr.$(this)
+            ,   href = $a.attr("href")
+            ,   text = sr.norm($a.text())
+            ;
+            if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/" &&
+                text === "5 February 2004 W3C Patent Policy") {
+                foundFeb5 = true;
                 return;
-        }
-        if (href === "https://www.w3.org/2004/02/05-pp-transition" &&
-            text === "W3C Patent Policy Transition Procedure") {
-                foundPPTransition = true;
+            }
+            if (/^https:\/\/www\.w3\.org\/2004\/01\/pp-impl\/\d+\/status(#.*)?$/.test(href) &&
+                /public list of any patent disclosures( \(.+\))?/.test(text) &&
+                $a.attr("rel") === "disclosure") {
+                foundPublicList = true;
                 return;
-        }
-    });
+            }
+            if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential" &&
+                text === "Essential Claim(s)") {
+                foundEssentials = true;
+                return;
+            }
+            if (href === "https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure" &&
+                text === "section 6 of the W3C Patent Policy") {
+                foundSection6 = true;
+                return;
+            }
+            if (href === "https://www.w3.org/TR/2002/NOTE-patent-practice-20020124" &&
+                text === "24 January 2002 CPP") {
+                    foundJan24 = true;
+                    return;
+            }
+            if (href === "https://www.w3.org/2004/02/05-pp-transition" &&
+                text === "W3C Patent Policy Transition Procedure") {
+                    foundPPTransition = true;
+                    return;
+            }
+        });
 
-    var isPP2002 = (sr.config.patentPolicy === "pp2002");
-    if (!foundJan24 && isPP2002) sr.error(self, "no-jan24");
-    if (!foundPPTransition && isPP2002) sr.error(self, "no-pp-transition");
-    if (!foundFeb5 && !isPP2002) sr.error(self, "no-feb5");
-    if (!foundPublicList) sr.error(self, "no-disclosures");
-    if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundEssentials)
-        sr.error(self, "no-claims");
-    if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundSection6)
-        sr.error(self, "no-section6");
+        var isPP2002 = (sr.config.patentPolicy === "pp2002");
+        if (!foundJan24 && isPP2002) sr.error(self, "no-jan24");
+        if (!foundPPTransition && isPP2002) sr.error(self, "no-pp-transition");
+        if (!foundFeb5 && !isPP2002) sr.error(self, "no-feb5");
+        if (!foundPublicList) sr.error(self, "no-disclosures");
+        if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundEssentials)
+            sr.error(self, "no-claims");
+        if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundSection6)
+            sr.error(self, "no-section6");
+    }
     done();
 };

--- a/lib/rules/sotd/process-document.js
+++ b/lib/rules/sotd/process-document.js
@@ -9,35 +9,32 @@ exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection()
     ,   proc = "1 September 2015"
     ,   procUri = "https://www.w3.org/2015/Process-20150901/";
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-
-    var found = false
-    ,   boilerplate = BOILERPLATE_PREFIX + proc + BOILERPLATE_SUFFIX
-    ,   regex = new RegExp(BOILERPLATE_PREFIX + '.+' + BOILERPLATE_SUFFIX)
-    ,   deprecatedBoilerplate = BOILERPLATE_PREFIX + '1 August 2014' + BOILERPLATE_SUFFIX
-    ,   deprecatedUri = 'http://www.w3.org/2014/Process-20140801/'
-    ;
-    $sotd.parent().find("p").each(function () {
-        var $p = sr.$(this);
-        if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") === procUri) {
-            if (found) sr.error(self, "multiple-times", { process: proc });
-            else {
-                found = true;
+    if ($sotd && $sotd.length) {
+        var found = false
+        ,   boilerplate = BOILERPLATE_PREFIX + proc + BOILERPLATE_SUFFIX
+        ,   regex = new RegExp(BOILERPLATE_PREFIX + '.+' + BOILERPLATE_SUFFIX)
+        ,   deprecatedBoilerplate = BOILERPLATE_PREFIX + '1 August 2014' + BOILERPLATE_SUFFIX
+        ,   deprecatedUri = 'http://www.w3.org/2014/Process-20140801/'
+        ;
+        $sotd.parent().find("p").each(function () {
+            var $p = sr.$(this);
+            if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") === procUri) {
+                if (found) sr.error(self, "multiple-times", { process: proc });
+                else {
+                    found = true;
+                }
             }
-        }
-        else if (deprecatedBoilerplate === sr.norm($p.text()) || deprecatedUri === $p.find('a').attr('href')) {
-            sr.error(self, 'deprecated');
-        }
-        else if (sr.norm($p.text()) !== boilerplate && regex.test($p.text())) {
-            sr.error(self, "wrong-process", { process: proc });
-        }
-        else if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") !== procUri) {
-            sr.error(self, "wrong-link");
-        }
-    });
-    if (!found) sr.error(self, "not-found", { process: proc });
+            else if (deprecatedBoilerplate === sr.norm($p.text()) || deprecatedUri === $p.find('a').attr('href')) {
+                sr.error(self, 'deprecated');
+            }
+            else if (sr.norm($p.text()) !== boilerplate && regex.test($p.text())) {
+                sr.error(self, "wrong-process", { process: proc });
+            }
+            else if (sr.norm($p.text()) === boilerplate && $p.find("a").attr("href") !== procUri) {
+                sr.error(self, "wrong-link");
+            }
+        });
+        if (!found) sr.error(self, "not-found", { process: proc });
+    }
     done();
 };

--- a/lib/rules/sotd/review-end.js
+++ b/lib/rules/sotd/review-end.js
@@ -4,24 +4,22 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-    var txt = sr.norm($sotd.text())
-    ,   rex = new RegExp(sr.dateRegexStrCapturing, "g")
-    ;
-    // XXX we want to make this an error, but there is no standard for the text.
-    if (!rex.test(txt)) sr.warning(self, "not-found");
-    else {
-        var matches = txt.match(rex);
-        for (var i in matches) {
-            if (sr.stringToDate(matches[i]) > sr.getDocumentDate()) {
-                sr.info(self, "found", { date : matches[i] });
-                return done();
+    if ($sotd && $sotd.length) {
+        var txt = sr.norm($sotd.text())
+        ,   rex = new RegExp(sr.dateRegexStrCapturing, "g")
+        ;
+        // XXX we want to make this an error, but there is no standard for the text.
+        if (!rex.test(txt)) sr.warning(self, "not-found");
+        else {
+            var matches = txt.match(rex);
+            for (var i in matches) {
+                if (sr.stringToDate(matches[i]) > sr.getDocumentDate()) {
+                    sr.info(self, "found", { date : matches[i] });
+                    return done();
+                }
             }
+            sr.warning(self, "not-found");
         }
-        sr.warning(self, "not-found");
     }
     done();
 };

--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -30,28 +30,25 @@ const self = {
 exports.check = function (sr, done) {
     if (!sr.config.stabilityWarning) return done();
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-
-    if (sr.config.stabilityWarning === "REC") {
-        var txt = sr.norm($sotd.text())
-        ,   wanted = "This document has been reviewed by W3C Members, by software developers, " +
-                     "and by other W3C groups and interested parties, and is endorsed by the " +
-                     "Director as a W3C Recommendation. It is a stable document and may be used " +
-                     "as reference material or cited from another document. W3C's role in making " +
-                     "the Recommendation is to draw attention to the specification and to " +
-                     "promote its widespread deployment. This enhances the functionality and " +
-                     "interoperability of the Web."
-        ,   rex = new RegExp(wanted.replace(/\./g, "\\."))
-        ;
-        if (!rex.test(txt)) sr.error(self, "no-rec-review");
-    }
-    else {
-        var $sw = findSW($sotd.filter("p"), sr) || findSW($sotd.find("p"), sr);
-        if (!$sw || !$sw.length)
-            sr.error(self, "no-stability");
+    if ($sotd && $sotd.length) {
+        if (sr.config.stabilityWarning === "REC") {
+            var txt = sr.norm($sotd.text())
+            ,   wanted = "This document has been reviewed by W3C Members, by software developers, " +
+                         "and by other W3C groups and interested parties, and is endorsed by the " +
+                         "Director as a W3C Recommendation. It is a stable document and may be used " +
+                         "as reference material or cited from another document. W3C's role in making " +
+                         "the Recommendation is to draw attention to the specification and to " +
+                         "promote its widespread deployment. This enhances the functionality and " +
+                         "interoperability of the Web."
+            ,   rex = new RegExp(wanted.replace(/\./g, "\\."))
+            ;
+            if (!rex.test(txt)) sr.error(self, "no-rec-review");
+        }
+        else {
+            var $sw = findSW($sotd.filter("p"), sr) || findSW($sotd.find("p"), sr);
+            if (!$sw || !$sw.length)
+                sr.error(self, "no-stability");
+        }
     }
     done();
 };

--- a/lib/rules/sotd/status.js
+++ b/lib/rules/sotd/status.js
@@ -5,11 +5,7 @@ const self = {
 exports.check = function (sr, done) {
     if (!sr.config.sotdStatus) return done();
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-    if (!sr.norm($sotd.text()).match(new RegExp(sr.config.longStatus)))
+    if ($sotd && $sotd.length && !sr.norm($sotd.text()).match(new RegExp(sr.config.longStatus)))
         sr.error(self, "no-mention", { status: sr.config.longStatus });
     done();
 };

--- a/lib/rules/sotd/submission.js
+++ b/lib/rules/sotd/submission.js
@@ -29,36 +29,33 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
-    }
-    var $st = findSubmText($sotd.filter("p"), sr) || findSubmText($sotd.find("p"), sr);
-    if (!$st || !$st.length) {
-        sr.error(self, "no-submission-text");
-        return done();
-    }
+    if ($sotd && $sotd.length) {
+        var $st = findSubmText($sotd.filter("p"), sr) || findSubmText($sotd.find("p"), sr);
+        if (!$st || !$st.length) {
+            sr.error(self, "no-submission-text");
+            return done();
+        }
 
-    // check the links
-    var links = {
-        "http://www.w3.org/Consortium/Process":             "W3C Process"
-    ,   "http://www.w3.org/Consortium/Prospectus/Joining":  "W3C Membership"
-    ,   "http://www.w3.org/Consortium/Patent-Policy-20030520.html#sec-submissions":  "section 3.3 of the W3C Patent Policy"
-    ,   "http://www.w3.org/Submission":  "list of acknowledged W3C Member Submissions"
-    };
-    for (var href in links) {
-        if (!$st.find("a[href='" + href + "']:contains('" + links[href] + "')").length)
-            sr.error(self, "link-text", { href: href, text: links[href] });
+        // check the links
+        var links = {
+            "http://www.w3.org/Consortium/Process":             "W3C Process"
+        ,   "http://www.w3.org/Consortium/Prospectus/Joining":  "W3C Membership"
+        ,   "http://www.w3.org/Consortium/Patent-Policy-20030520.html#sec-submissions":  "section 3.3 of the W3C Patent Policy"
+        ,   "http://www.w3.org/Submission":  "list of acknowledged W3C Member Submissions"
+        };
+        for (var href in links) {
+            if (!$st.find("a[href='" + href + "']:contains('" + links[href] + "')").length)
+                sr.error(self, "link-text", { href: href, text: links[href] });
+        }
+        var $sm = $st.find("a:contains('Submitting Members')")
+        ,   $tc = $st.find("a:contains('W3C Team Comment')")
+        ;
+        if (!$sm.length || !$sm.attr("href") ||
+            $sm.attr("href").indexOf("http://www.w3.org/Submission/") !== 0)
+                sr.error(self, "no-sm-link");
+        if (!$tc.length || !$tc.attr("href") ||
+            $tc.attr("href").indexOf("http://www.w3.org/Submission/") !== 0)
+                sr.error(self, "no-tc-link");
     }
-    var $sm = $st.find("a:contains('Submitting Members')")
-    ,   $tc = $st.find("a:contains('W3C Team Comment')")
-    ;
-    if (!$sm.length || !$sm.attr("href") ||
-        $sm.attr("href").indexOf("http://www.w3.org/Submission/") !== 0)
-            sr.error(self, "no-sm-link");
-    if (!$tc.length || !$tc.attr("href") ||
-        $tc.attr("href").indexOf("http://www.w3.org/Submission/") !== 0)
-            sr.error(self, "no-tc-link");
-
     done();
 };

--- a/lib/rules/sotd/supersedable.js
+++ b/lib/rules/sotd/supersedable.js
@@ -11,21 +11,18 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
+    if ($sotd && $sotd.length) {
+        var $em = $sotd.filter("p").children("em").first();
+        if (!$em.length) $em = $sotd.find("p").children("em").first();
+        var txt = sr.norm($em.text())
+        ,   wanted = "This section describes the status of this document at the time of its " +
+                     "publication. Other documents may supersede this document. A list of current " +
+                     "W3C publications and the latest revision of this technical report can be found " +
+                     "in the W3C technical reports index at https://www.w3.org/TR/."
+        ,   $a = $em.find("a[href='https://www.w3.org/TR/']")
+        ;
+        if (txt !== wanted) sr.error(self, "no-sotd-intro");
+        if (!$a.length) sr.error(self, "no-sotd-tr");
     }
-
-    var $em = $sotd.filter("p").children("em").first();
-    if (!$em.length) $em = $sotd.find("p").children("em").first();
-    var txt = sr.norm($em.text())
-    ,   wanted = "This section describes the status of this document at the time of its " +
-                 "publication. Other documents may supersede this document. A list of current " +
-                 "W3C publications and the latest revision of this technical report can be found " +
-                 "in the W3C technical reports index at https://www.w3.org/TR/."
-    ,   $a = $em.find("a[href='https://www.w3.org/TR/']")
-    ;
-    if (txt !== wanted) sr.error(self, "no-sotd-intro");
-    if (!$a.length) sr.error(self, "no-sotd-tr");
     done();
 };

--- a/lib/rules/sotd/team-subm-link.js
+++ b/lib/rules/sotd/team-subm-link.js
@@ -4,11 +4,9 @@ const self = {
 
 exports.check = function (sr, done) {
     var $sotd = sr.getSotDSection();
-    if (!$sotd || !$sotd.length) {
-        sr.error(self, "no-sotd");
-        return done();
+    if ($sotd && $sotd.length) {
+        var $a = $sotd.find("a[href='http://www.w3.org/TeamSubmission/']");
+        if (!$a.length) sr.error(self, "no-link");
     }
-    var $a = $sotd.find("a[href='http://www.w3.org/TeamSubmission/']");
-    if (!$a.length) sr.error(self, "no-link");
     done();
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -22,7 +22,7 @@ var Specberus = function () {
 Specberus.prototype.clearCache = function () {
     this.docDate = null;
     this.docDateEl = null;
-    this.sotdSection = null;
+    this.sotdSection = undefined;
     this.url = null;
     this.source = null;
     this.shortname = undefined;
@@ -228,7 +228,8 @@ Specberus.prototype.getDocumentDateElement = function () {
 };
 
 Specberus.prototype.getSotDSection = function () {
-    if (this.sotdSection) return this.sotdSection;
+    if (undefined !== this.sotdSection)
+        return this.sotdSection;
     var $startH2, $endH2
     ,   $ = this.$
     ,   $div = $("<div></div>")
@@ -244,18 +245,23 @@ Specberus.prototype.getSotDSection = function () {
         }
         if (/^Status [Oo]f [Tt]his [Dd]ocument$/.test(self.norm($h2.text()))) $startH2 = $h2;
     });
-    if (!$startH2 || !$endH2) return null;
-    var started = false;
-    $startH2.parent().children().each(function () {
-        if ($startH2[0] === this) {
-            started = true;
-            return;
-        }
-        if (!started) return;
-        if ($endH2[0] === this || $nav[0] === this) return false;
-        $div.append($(this).clone());
-    });
-    this.sotdSection = $div.children();
+    if (!$startH2 || !$endH2)
+        this.sotdSection = null;
+    else {
+        var started = false;
+        $startH2.parent().children().each(function () {
+            if ($startH2[0] === this) {
+                started = true;
+                return;
+            }
+            if (!started) return;
+            if ($endH2[0] === this || $nav[0] === this) return false;
+            $div.append($(this).clone());
+        });
+        this.sotdSection = $div.children();
+    }
+    if (!this.sotdSection || !this.sotdSection.length)
+        this.error({name: 'generic.sotd', section: 'document-status', rule: 'sotd'}, 'not-found');
     return this.sotdSection;
 };
 

--- a/test/docs/heuristic/dated-url.html
+++ b/test/docs/heuristic/dated-url.html
@@ -8,6 +8,10 @@
     <h1>Has an h1</h1>
     <h2 class='foo'>Has an h2.foo</h2>
     <div>
+      <h2>Status of this document</h2>
+      <p>Foo</p>
+    </div>
+    <div>
       <h2 id="abstract">Abstract</h2>
       <p>
         This document does not have wrong dates but a URL to http://example.com/2014/05/22/ ,

--- a/test/docs/heuristic/dates.html
+++ b/test/docs/heuristic/dates.html
@@ -8,6 +8,10 @@
     <h1>Has an h1</h1>
     <h2 class='foo'>Has an h2.foo</h2>
     <div>
+      <h2>Status of this document</h2>
+      <p>Foo</p>
+    </div>
+    <div>
       <h2 id="abstract">Abstract</h2>
       <p>Hi! This date has the good format: 13 January 1998. And these two, too: 2 Nov 2014 and 2 february 1998.</p>
     </div>

--- a/test/l10n.js
+++ b/test/l10n.js
@@ -47,47 +47,50 @@ const scanStrings = function() {
         var c = i.split('.');
         if (!c || c.length < 1 || c.length > 3)
             throw new Error(`message key “${i}” doesn't follow the pattern “x[.y[.z]]”`);
+        if ('generic' !== c[0]) {
 
-        // 1. Process the section:
-        if (!result.hasOwnProperty(c[0])) {
-            if (1 === c.length) {
-                if (false === messages[i])
-                    result[c[0]] = false;
-                else
-                    throw new Error(`key “${i}” can be used only to indicate an empty category using “false”`);
-            }
-            else
-                result[c[0]] = {};
-        }
-        else if (1 === c.length &&
-            ((false === result[c[0]] && false !== messages[i]) ||
-            (false !== result[c[0]] && false === messages[i])))
-            throw new Error(`key “${i}” can't be used to indicate an empty category because it's used for messages too`);
-
-        // 2. Process the rule:
-        if (c.length > 1) {
-            if (!result[c[0]].hasOwnProperty(c[1])) {
-                if (2 === c.length) {
+            // 1. Process the section:
+            if (!result.hasOwnProperty(c[0])) {
+                if (1 === c.length) {
                     if (false === messages[i])
-                        result[c[0]][c[1]] = false;
+                        result[c[0]] = false;
                     else
                         throw new Error(`key “${i}” can be used only to indicate an empty category using “false”`);
                 }
                 else
-                    result[c[0]][c[1]] = {};
+                    result[c[0]] = {};
             }
-            else if (2 === c.length &&
-                ((false === result[c[0]][c[1]] && false !== messages[i]) ||
-                (false !== result[c[0]][c[1]] && false === messages[i])))
+            else if (1 === c.length &&
+                ((false === result[c[0]] && false !== messages[i]) ||
+                (false !== result[c[0]] && false === messages[i])))
                 throw new Error(`key “${i}” can't be used to indicate an empty category because it's used for messages too`);
-        }
 
-        // 3. Process the message ID:
-        if (c.length > 2) {
-            if (!result[c[0]][c[1]].hasOwnProperty(c[2]))
-                result[c[0]][c[1]][c[2]] = !!(messages[i]);
-            else
-                throw new Error(`key “${i}” is defined more than once`);
+            // 2. Process the rule:
+            if (c.length > 1) {
+                if (!result[c[0]].hasOwnProperty(c[1])) {
+                    if (2 === c.length) {
+                        if (false === messages[i])
+                            result[c[0]][c[1]] = false;
+                        else
+                            throw new Error(`key “${i}” can be used only to indicate an empty category using “false”`);
+                    }
+                    else
+                        result[c[0]][c[1]] = {};
+                }
+                else if (2 === c.length &&
+                    ((false === result[c[0]][c[1]] && false !== messages[i]) ||
+                    (false !== result[c[0]][c[1]] && false === messages[i])))
+                    throw new Error(`key “${i}” can't be used to indicate an empty category because it's used for messages too`);
+            }
+
+            // 3. Process the message ID:
+            if (c.length > 2) {
+                if (!result[c[0]][c[1]].hasOwnProperty(c[2]))
+                    result[c[0]][c[1]][c[2]] = !!(messages[i]);
+                else
+                    throw new Error(`key “${i}” is defined more than once`);
+            }
+
         }
 
     }


### PR DESCRIPTION
Absence of a proper SotD section throws one error only, the first time it's searched for in `validator.js`; rules calling `Specberus.getSotDSection()` don't throw that error themselves.

eg, if one checks `http://example.com/` as a WD, 4 redundant error messages are removed after this change.

Fix #462.