### PR TITLE
Prevent Specberus from reloading the page automatically when connection to the server is lost

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -64,7 +64,7 @@ jQuery.extend({
         socket.on('disconnect', () => {
             socket.close();
             toggleForm(false);
-            window.location.href = window.location.href;
+            $('#offline').modal();
         });
 
     });

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -117,3 +117,22 @@
 <div class="alert alert-info" role="alert">
   Graphical UI's not your thing? Check out the <a href="https://github.com/w3c/specberus/blob/master/README.md#5-rest-api">REST interface of Pubrules</a>.
 </div>
+
+<div id="offline" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Lost connection to the server</h4>
+      </div>
+      <div class="modal-body">
+        <p>Connection to the Specberus server has been lost.</p>
+        <p>Once you are done with this one, reload the page to check a new document.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close this notice and continue inspecting results</button>
+        <button type="button" class="btn btn-primary" onclick="javascript:window.location.href = window.location.href">Reload now</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
@deniak, this is my first take, but I'm not sure. Let me know your thoughts.

When the socket disconnects, a modal appears, informing the user of what just happened. Users can either dismiss and continue examining the results of validation, or reload the page if they finished reading the results already.

The modal won't bother the user a second time (not unless they reload the page and validate a document again).

I like this approach. The problem is, if connection through the socket is interrupted quite often (as it seems; I don't know why), it's a matter of (little) time that users will see this pop-up. I fear it will be annoying and interrupt the user while they're reading the results.

I may not be listening to the correct socket event, too.

Fix #479.