### PR TITLE
Prevent "socket disconnected" modal from appearing in FF when navigating away following a link

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -60,9 +60,11 @@ jQuery.extend({
         console.log(`Handshake; using version “${data.version}”.`);
 
         socket.on('disconnect', function () {
-            socket.close();
-            toggleForm(false);
-            $('#offline').modal();
+            if (!window.navigatingAway) {
+                socket.close();
+                toggleForm(false);
+                $('#offline').modal();
+            }
         });
 
     });
@@ -117,19 +119,19 @@ jQuery.extend({
                 `title=Bug%20in%20rule%20%E2%80%9C${data.name}%E2%80%9D:%20[WHAT]&` +
                 `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
-                `">Report a bug</a>`;
+                `" onclick="javascript:window.navigatingAway=true;">Report a bug</a>`;
         else if (data && data.exception)
             issue = `<a href="https://github.com/w3c/specberus/issues/new?` +
                 `title=Bug:%20[WHAT]&` +
                 `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
-                `">Report a bug</a>`;
+                `" onclick="javascript:window.navigatingAway=true;">Report a bug</a>`;
         else
             issue = `<a href="https://github.com/w3c/specberus/issues/new?` +
                 `title=Bug%20in%20rules:%20[WHAT]&` +
                 `body=[EXPLANATION]%0A%0AFound%20[while%20checking%20\`${url}\`](${encodeURIComponent(window.location)}).&` +
                 `labels=from-template` +
-                `">Report a bug</a>`;
+                `" onclick="javascript:window.navigatingAway=true;">Report a bug</a>`;
         var item = `<li class="list-group-item alert alert-${type.bootstrap}${exc}">
             <label class="pull-left label label-${type.bootstrap}">${type.ui}</label>
             <div class="detailed pull-right"><small> ${inContext} ${issue} </small></div>


### PR DESCRIPTION
cf https://github.com/w3c/specberus/pull/486#issuecomment-239391818