### PR TITLE
Enable errors and warnings from metadata extraction; alert if process document is not found

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -199,6 +199,15 @@ exports.messages = {
 ,   'echidna.editor-ids.no-editor-id': 'Editor IDs must be set for each editor, in the <code>data-editor-id</code> attribute.'
 ,   'echidna.todays-date.wrong-date': 'The publication date of this document must be set to today (UTC).'
 ,   'echidna.todays-date.date-not-detected': 'Could not find a publication date in the document.'
-    // Metadata: indicate that there are no messages expected:
-,   'metadata': false
+    // Metadata:
+,   'metadata.deliverers':        false
+,   'metadata.dl':                false
+,   'metadata.docDate':           false
+,   'metadata.editor-ids':        false
+,   'metadata.editor-names':      false
+,   'metadata.informative':       false
+,   'metadata.process.not-found': 'Missing, or wrong, boilerplate text in the status section to identify the governing process.'
+,   'metadata.profile':           false
+,   'metadata.rectrack':          false
+,   'metadata.title':             false
 };

--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -32,8 +32,11 @@ exports.setLanguage = function(language) {
  * @TODO Document.
  */
 
-exports.message = function (profile, rule, key, extra) {
-    const result = {};
+exports.message = function (profileCode, rule, key, extra) {
+    const result = {}
+    // Corner case: if the profile is unknown, let's assume 'WD' (most common).
+    ,   profile = profileCode ? profileCode.replace('-Echidna', '') : 'WD'
+    ;
     var name
     ,   additionalMessage = ''
     ;
@@ -41,7 +44,6 @@ exports.message = function (profile, rule, key, extra) {
         name = rule;
     else
         name = rule.name;
-    profile = profile.replace('-Echidna', '');
     if (!lang)
         throw new Error('l10n.message() invoked before a locale is defined; call l10n.setLanguage() first');
     else if (!rulesWrapper.hasOwnProperty(profile))

--- a/lib/rules/metadata/process.js
+++ b/lib/rules/metadata/process.js
@@ -2,9 +2,18 @@
  * Pseudo-rule for metadata extraction: process.
  */
 
-// 'self.name' would be 'metadata.process'
+const self = {
+    name: 'metadata.process'
+,   section: 'document-status'
+,   rule: 'whichProcess'
+};
 
 exports.check = function(sr, done) {
     var $processDocument = sr.$('a#w3c_process_revision');
-    return done({process: $processDocument.attr('href')});
+    if (!$processDocument || !$processDocument.attr('href')) {
+        sr.error(self, 'not-found');
+        return done();
+    }
+    else
+        return done({process: $processDocument.attr('href')});
 };

--- a/test/docs/metadata/components-intro.html
+++ b/test/docs/metadata/components-intro.html
@@ -786,6 +786,6 @@ by Web Components, with links to their normative definitions.</p>
 
 <p>Thanks to <span class="vcard">Alex Komoroske</span>, <span class="vcard">Alex Russell</span>, <span class="vcard">Darin Fisher</span>, <span class="vcard">Dirk Pranke</span>, <span class="vcard">Divya Manian</span>, <span class="vcard">Erik Arvidsson</span>, <span class="vcard">Hayato Ito</span>, <span class="vcard">Hajime Morita</span>, <span class="vcard">Ian Hickson</span>, <span class="vcard">Jonas Sicking</span>, <span class="vcard">Rafael Weinstein</span>, <span class="vcard">Roland Steiner</span>, and <span class="vcard">Tab Atkins</span> for their comments and contributions to this document.</p>
 
-
+<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>. </p>
 
 </body></html>

--- a/test/samples.json
+++ b/test/samples.json
@@ -176,6 +176,7 @@
     ]
     ,   "informative": true
     ,   "rectrack": true
+    ,   "process": "https://www.w3.org/2015/Process-20150901/"
     }
 ,   {
         "url": "https://www.w3.org/TR/2016/WD-html51-20160602/"


### PR DESCRIPTION
* Metadata extraction can now throw errors and warnings, like validation does, and those are captured by the application.
* Those events are shown on the web UI too, including rule desriptions and &ldquo;see rule in context&rdquo; and &ldquo;report a bug&rdquo; links (if pertinent).
* Throw an error if the process document isn't found (this fixes #501).
* One test document tweaked to fix this new error in it.

**Merge #504 before this one** (that PR is against this branch, not against `master`).