### PR TITLE
When auto-detecting, show also extracted metadata in result table

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -196,11 +196,6 @@ jQuery.extend({
             if (data.warnings && data.warnings.length > 0)
                 for (var w in data.warnings)
                     addMessage(MSG_WARN, w);
-            const json = JSON.stringify(data.metadata, null, 4)
-            ,   jsonMessage = `<p>Review the <strong>metadata that was inferred from the document</strong>
-                to make sure that there are no errors:</p>\n<pre>${json}</pre>`
-            ;
-            addMessage(MSG_INFO, {message: `<div class="message">\n${jsonMessage}\n</div>`});
             toggleManual(true);
             profile = data.metadata.profile;
             $profile.val(profile);
@@ -329,7 +324,9 @@ jQuery.extend({
         $progressContainer.hide();
         $progress.text('');
         $progress.attr('style', '0');
-        var message;
+        var message
+        ,   metadataURL = `${baseURI}api/metadata?url=${encodeURIComponent(url.value)}`
+        ;
         if (result.errors.length > 0 || result.exceptions.length > 0) {
             message = `<span class="icon red pull-left">&#10007;</span>`;
             if (result.warnings.length > 0)
@@ -350,7 +347,9 @@ jQuery.extend({
         message += `<p class="details">`;
         if (total > 0 && profile)
             message += `<a href="doc/rules?profile=${profile}">${total} rules</a> were checked. `;
-        message += `Hover over the rows below for options.<p>`;
+        message += `Hover over the rows below for options.<br />`;
+        message += `Tip: review the <a href="${metadataURL}">metadata that was inferred from the document</a> to make sure that there are no errors.`;
+        message += '</p>';
         $resultsBody.html(message);
         message = '';
         if (result.exceptions.length > 0 || result.errors.length > 0 || result.warnings.length > 0 || result.infos.length > 0) {

--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -164,7 +164,6 @@ jQuery.extend({
     socket.on("start", function (data) {
         console.log('Started.');
         done = 0;
-        result = {exceptions: [], errors: [], warnings: [], infos: []};
         total = data.rules.length;
         $progressStyler.addClass("active progress-striped");
         $progressContainer.fadeIn();
@@ -197,6 +196,11 @@ jQuery.extend({
             if (data.warnings && data.warnings.length > 0)
                 for (var w in data.warnings)
                     addMessage(MSG_WARN, w);
+            const json = JSON.stringify(data.metadata, null, 4)
+            ,   jsonMessage = `<p>Review the <strong>metadata that was inferred from the document</strong>
+                to make sure that there are no errors:</p>\n<pre>${json}</pre>`
+            ;
+            addMessage(MSG_INFO, {message: `<div class="message">\n${jsonMessage}\n</div>`});
             toggleManual(true);
             profile = data.metadata.profile;
             $profile.val(profile);


### PR DESCRIPTION
Looks like this:

![exp](https://cloud.githubusercontent.com/assets/1016538/18591282/4f257eee-7c32-11e6-837b-490ffa9436b8.png)

(If it's too intrusive, we can limit its height, like this:

![coll](https://cloud.githubusercontent.com/assets/1016538/18591331/7586f5cc-7c32-11e6-8f88-cfc6c7d7486f.png)

Although I prefer not to: scrollbars within scrollbars are annoying and not a good practice.)

Fixes #301.

**Merge before #503** (this goes on top of those changes).