### PR TITLE
Fix "TypeError: Cannot read property '1' of null"

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -201,7 +201,8 @@ exports.messages = {
 ,   'echidna.todays-date.date-not-detected': 'Could not find a publication date in the document.'
     // Metadata:
 ,   'metadata.deliverers':        false
-,   'metadata.dl':                false
+,   'metadata.dl.latest-not-found': 'Metadata extraction could not find the latest version link.'
+,   'metadata.dl.previous-not-found': 'Metadata extraction could not find the previous version link.'
 ,   'metadata.docDate':           false
 ,   'metadata.editor-ids':        false
 ,   'metadata.editor-names':      false

--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -2,7 +2,17 @@
  * Pseudo-rule for metadata extraction: dl.
  */
 
-// 'self.name' would be 'metadata.dl'
+const latestRule = {
+    name: 'metadata.dl'
+,   section: 'front-matter'
+,   rule: 'docIDLatestVersion'
+};
+
+const previousRule = {
+    name: 'metadata.dl'
+,   section: 'front-matter'
+,   rule: 'docIDFormat'
+};
 
 exports.check = function(sr, done) {
     var $dl = sr.$("body div.head dl").first()
@@ -18,13 +28,21 @@ exports.check = function(sr, done) {
     var $linkLate = (dts.Latest) ? dts.Latest.dd.find("a").first() : null;
     if ($linkLate && $linkLate.length) {
         result.latestVersion = $linkLate.attr('href').trim();
-        latestShortname = $linkLate.attr("href").trim().match(new RegExp(/.*\/([^/]+)\/$/))[1];
+        var latestRegex = $linkLate.attr("href").trim().match(new RegExp(/.*\/([^/]+)\/$/));
+        if (latestRegex && latestRegex.length > 0)
+            latestShortname = latestRegex[1];
+        else
+            sr.error(latestRule, 'latest-not-found');
     }
 
     var $linkPrev = (dts.Previous) ? dts.Previous.dd.find("a").first() : null;
     if ($linkPrev && $linkPrev.length) {
         result.previousVersion = $linkPrev.attr('href').trim();
-        previousShortname = $linkPrev.attr("href").trim().match(new RegExp(/.*\/[^/-]+\-(.*)-\d{8}\/$/))[1];
+        var previousRegex = $linkPrev.attr("href").trim().match(new RegExp(/.*\/[^/-]+\-(.*)-\d{8}\/$/));
+        if (previousRegex && previousRegex.length > 0)
+            previousShortname = previousRegex[1];
+        else
+            sr.error(previousRule, 'previous-not-found');
     }
 
     var $linkEd = (dts.EditorDraft) ? dts.EditorDraft.dd.find("a").first() : null;


### PR DESCRIPTION
Fixes #508.

The build fails because this change relies on the ones made in PR #503 (allowing metadata extraction to throw errors, and splitting 'meta' in `l10n-en_GB.js` into several categories). This PR should be merged *after* that one, and the contents of `l10n-en_GB.js` merged appropriately.