### PR TITLE
NSP exceptions are no longer needed

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,0 @@
-{
-    "exceptions": [
-      "https://nodesecurity.io/advisories/106",
-      "https://nodesecurity.io/advisories/120"
-    ]
-}


### PR DESCRIPTION
socket.io has been upgraded to 1.5.0 which fixes vulnerabilities #106 and #120