### PR TITLE
Mention in output common "HTTP vs HTTPS" errors with boilerplate URLs

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -107,12 +107,12 @@ exports.messages = {
 ,   "sotd.cr-end.date-found":     "Feedback due date detected: ${date}"
     // sotd/pp
 ,   "sotd.pp.no-pp":             "Required patent policy paragraph not found."
-,   "sotd.pp.no-feb5":           "No link to the 2004 Feb 5 patent policy (https://www.w3.org/Consortium/Patent-Policy-20040205/)."
-,   "sotd.pp.no-disclosures":    "No link to public list of disclosures (https://www.w3.org/2004/01/pp-impl/NNNNN/status)."
-,   "sotd.pp.no-claims":         "No link to definition of essential claims (https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential)."
-,   "sotd.pp.no-section6":       "No link to the Disclosure section of the patent policy (https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure)."
-,   "sotd.pp.no-jan24":          "No link to 2002 Jan 24 patent policy."
-,   "sotd.pp.no-pp-transition":  "No link to PP transition procedure."
+,   "sotd.pp.no-feb5":           "No valid HTTPS link to the 2004 Feb 5 patent policy (<code>https://www.w3.org/Consortium/Patent-Policy-20040205/</code>)."
+,   "sotd.pp.no-disclosures":    "No valid HTTPS link to public list of disclosures (<code>https://www.w3.org/2004/01/pp-impl/NNNNN/status</code>)."
+,   "sotd.pp.no-claims":         "No valid HTTPS link to definition of essential claims (<code>https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential</code>)."
+,   "sotd.pp.no-section6":       "No valid HTTPS link to the Disclosure section of the patent policy (<code>https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure</code>)."
+,   "sotd.pp.no-jan24":          "No valid link to 2002 Jan 24 patent policy (eg absent, or not using HTTPS)."
+,   "sotd.pp.no-pp-transition":  "No valid link to PP transition procedure (eg absent, or not using HTTPS)."
 ,   "sotd.pp.joint-publication": "Joint publication detected."
 ,   "sotd.pp.expected-pp":       "Expected text related to patent policy requirements: <blockquote>${expected}</blockquote>"
     // sotd/charter-disclosure


### PR DESCRIPTION
Fix #528.
