### PR TITLE
Improve error messages thrown by “sotd.supersedable”

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -84,8 +84,8 @@ exports.messages = {
 ,   "links.compound.html-timeout":      "The HTML validator timed out."
 ,   "links.compound.css-timeout":       "The CSS validator timed out."
     // sotd/supersedable
-,   "sotd.supersedable.no-sotd-intro":  "No <em>&ldquo;status of this document&rdquo;</em> introduction."
-,   "sotd.supersedable.no-sotd-tr":     "No <em>&ldquo;status of this document&rdquo;</em> introduction link to TR."
+,   "sotd.supersedable.no-sotd-intro":  "No <em>&ldquo;status of this document&rdquo;</em> introduction (eg absent, not using HTTPS, wrong copy)."
+,   "sotd.supersedable.no-sotd-tr":     "No <em>&ldquo;status of this document&rdquo;</em> introduction link to TR (or perhaps not using HTTPS)."
     // sotd/submission
 ,   "sotd.submission.no-submission-text":   "No member submission paragraph."
 ,   "sotd.submission.link-text":            "Missing link '${href}' with text '${text}'."

--- a/lib/rules/sotd/supersedable.js
+++ b/lib/rules/sotd/supersedable.js
@@ -7,6 +7,8 @@
 
 const self = {
     name: 'sotd.supersedable'
+,   section: 'document-status'
+,   rule: 'boilerplateTRDoc'
 };
 
 exports.check = function (sr, done) {


### PR DESCRIPTION
Link to corresponding section on publication rules page, and mention HTTP<del>S</del> as a likely error.

Fixes #535.