### PR TITLE
Miscellaneous improvements

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -46,7 +46,7 @@ exports.messages = {
 ,   "headers.dl.latest-syntax":             "Wrong syntax for Latest Version link."
 ,   "headers.dl.previous-link":             "Link href and text differ for Previous Version."
 ,   "headers.dl.this-previous-shortname":   "<em>Shortnames</em> differ between This and Previous Versions."
-,   "headers.dl.previous-syntax":           "Wrong syntax for Previous Version link."
+,   "headers.dl.previous-syntax":           "Wrong syntax for Previous Version link (perhaps not using HTTPS)."
 ,   "headers.dl.rescinds":                  "Rescinds this Recommendation is missing."
 ,   "headers.dl.rescinds-not-needed":       "Rescinds this Recommendation is included but does not seem necessary."
 ,   "headers.dl.latest-rescinds-order":     "Latest Version must be before Rescinds this Recommendation."

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -129,13 +129,13 @@ exports.check = function (sr, done) {
         if (!$linkPrev || !$linkPrev.length || $linkPrev.attr("href").trim() !== $linkPrev.text().trim())
             sr.error(self, "previous-link");
 
-        var prevRex = "^(https?:\\/\\/www\\.w3\\.org\\/TR\\/\\d{4}\\/[A-Z]+-(.+)-(19\\d{6}|200\\d{5}|201[0-5]\\d{4}|20160[1-7]\\d{2})\\/" +
-                      "|https:\\/\\/www\\.w3\\.org\\/TR\\/\\d{4}\\/[A-Z]+-(.+)-(2016(?:08|09|10|11|12)\\d{2}|201[7-9]\\d{4}|20[2-9]\\d{5})\\/)$";
-        matches = ($linkPrev.attr("href") || "").trim().match(new RegExp(prevRex));
+        const prevRex = /^http(s?):\/\/www\.w3\.org\/TR\/\d{4}\/[A-Z]+-(.+)-(\d{8})\/$/;
+        matches = ($linkPrev.attr("href") || "").trim().match(prevRex);
         if (matches) {
-            sn = matches[2] || matches[4];
+            if (matches[3] >= 20160801 && 's' !== matches[1])
+                sr.error(previousError, "previous-syntax");
             previousURI = $linkPrev.text();
-            if (sn !== shortname) {
+            if (matches[2] !== shortname) {
               fetch(latestURI).then(null, function() {
                 sr.warning(self, "this-previous-shortname");
               });

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -70,6 +70,12 @@ const self = {
     name: 'sotd.pp'
 };
 
+const selfDisclosures = {
+    name: 'sotd.pp'
+,   section: 'document-status'
+,   rule: 'patPolReq'
+};
+
 exports.check = function (sr, done) {
 
     var $sotd = sr.getSotDSection();
@@ -128,7 +134,7 @@ exports.check = function (sr, done) {
         if (!foundJan24 && isPP2002) sr.error(self, "no-jan24");
         if (!foundPPTransition && isPP2002) sr.error(self, "no-pp-transition");
         if (!foundFeb5 && !isPP2002) sr.error(self, "no-feb5");
-        if (!foundPublicList) sr.error(self, "no-disclosures");
+        if (!foundPublicList) sr.error(selfDisclosures, "no-disclosures");
         if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundEssentials)
             sr.error(self, "no-claims");
         if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundSection6)

--- a/test/docs/headers/wrong-urls.html
+++ b/test/docs/headers/wrong-urls.html
@@ -20,7 +20,7 @@
         <dt>Latest Version:</dt>
         <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
         <dt>Previous Version:</dt>
-        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170315/'>https://www.w3.org/TR/2017/WD-specberus-20170315/</a></dd>
+        <dd><a href='http://www.w3.org/TR/2017/WD-specberus-20160801/'>http://www.w3.org/TR/2017/WD-specberus-20160801/</a></dd>
         <dt>Editor:</dt>
         <dd>Specberus The Cranky</dd>
       </dl>


### PR DESCRIPTION
* Add better context to one particular error, to be shown on results page when it occurs
* Simplify a long regex (and adapt logic accordingly); cf https://github.com/w3c/specberus/pull/559#pullrequestreview-13297525

About the latter: change is covered by tests ([old](https://coveralls.io/builds/9313910/source?filename=lib%2Frules%2Fheaders%2Fdl.js#L132), [new](https://coveralls.io/builds/9315355/source?filename=lib%2Frules%2Fheaders%2Fdl.js#L132)), and the new regex behaves as expected ([old diagram](https://jex.im/regulex/#!embed=false&flags=&re=%5E(https%3F%3A%5C%2F%5C%2Fwww%5C.w3%5C.org%5C%2FTR%5C%2F%5Cd%7B4%7D%5C%2F%5BA-Z%5D%2B-(.%2B)-(19%5Cd%7B6%7D%7C200%5Cd%7B5%7D%7C201%5B0-5%5D%5Cd%7B4%7D%7C20160%5B1-7%5D%5Cd%7B2%7D)%5C%2F%7Chttps%3A%5C%2F%5C%2Fwww%5C.w3%5C.org%5C%2FTR%5C%2F%5Cd%7B4%7D%5C%2F%5BA-Z%5D%2B-(.%2B)-(2016(%3F%3A08%7C09%7C10%7C11%7C12)%5Cd%7B2%7D%7C201%5B7-9%5D%5Cd%7B4%7D%7C20%5B2-9%5D%5Cd%7B5%7D)%5C%2F)%24), [old test cases](https://regex101.com/r/LFwwPN/1), [new diagram](https://jex.im/regulex/#!embed=false&flags=&re=%5Ehttp(s%3F)%3A%5C%2F%5C%2Fwww%5C.w3%5C.org%5C%2FTR%5C%2F%5Cd%7B4%7D%5C%2F%5BA-Z%5D%2B-(.%2B)-(%5Cd%7B8%7D)%5C%2F%24), [new test cases](https://regex101.com/r/4dxcFY/1)).