### PR TITLE
joint publication detection: use non-greedy regex to catch the right WG names

### DIFF
--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -46,8 +46,8 @@ function findPP ($candidates, sr) {
         var $p = sr.$(this)
         ,   text = sr.norm($p.text())
         ,   wanted = buildWanted(groups, sr)
-        ,   jointRegex = new RegExp('This document was published by the (.+ Working Group|Technical Architecture Group)' +
-                                    ' and the (.+ Working Group|Technical Architecture Group)');
+        ,   jointRegex = new RegExp('This document was published by the (.+? Working Group|Technical Architecture Group)' +
+                                    ' and the (.+? Working Group|Technical Architecture Group)');
         expected=wanted.text;
         if (jointRegex.test(text)) {
           var matches = text.match(jointRegex);

--- a/test/docs/sotd/joint-publication.html
+++ b/test/docs/sotd/joint-publication.html
@@ -66,7 +66,7 @@
     </p>
     <p>
         This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a>
-      and the <a href="http://www.w3.org/Style/CSS/member">CSS Working Group</a>.
+      and the <a href="http://www.w3.org/Style/CSS/member">CSS Working Group</a>. The Working Groups resolved the issues.
     </p>
     <p>
       This document was produced by groups operating under the


### PR DESCRIPTION
Fix #557 