### PR TITLE
Avoid asynchronous “fs.readdir” and non-portable paths

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
     "esversion": 6,
-    "globals": {"require": false, "console": false, "exports": false, "process": false},
+    "globals": {"require": false, "console": false, "exports": false, "process": false, "__dirname": false},
     "laxcomma": true,
     "loopfunc": true,
     "undef": true,

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,10 @@
 
 const fs = require('fs');
 
+const files1 = fs.readdirSync(`${__dirname}/profiles/TR/`),
+    files2 = fs.readdirSync(`${__dirname}/profiles/SUBM/`),
+    profiles = {};
+
 /**
  * Build a JSON result (of validation, metadata extraction, etc).
  *
@@ -114,23 +118,12 @@ const buildProcessParamsFunction = function(profiles) {
     };
 };
 
-fs.readdir('./lib/profiles/TR/', (err, files1) => {
-    if (err)
-        throw new Error(`Cannot build profiles in dir "/lib/profiles/TR/": "${err}"`);
-    else
-        fs.readdir('./lib/profiles/SUBM/', (err, files2) => {
-            if (err)
-                throw new Error(`Cannot build profiles in dir "/lib/profiles/SUBM/": "${err}"`);
-            else {
-                const profiles = {};
-                [...files1.map((x) => `TR/${x}`), ...files2.map((x) => `SUBM/${x}`)].forEach((i) => {
-                    var valid = /((TR|SUBM)\/([A-Z][A-Z\-]*[A-Z](\-Echidna)?))\.js$/.exec(i);
-                    if (valid && valid.length > 3)
-                        profiles[valid[3]] = require(`./profiles/${valid[1]}`);
-                });
-                exports.profiles = profiles;
-                exports.buildJSONresult = buildJSONresult;
-                exports.processParams = buildProcessParamsFunction(profiles);
-            }
-        });
+[...files1.map((x) => `TR/${x}`), ...files2.map((x) => `SUBM/${x}`)].forEach((i) => {
+    var valid = /((TR|SUBM)\/([A-Z][A-Z\-]*[A-Z](\-Echidna)?))\.js$/.exec(i);
+    if (valid && valid.length > 3)
+        profiles[valid[3]] = require(`./profiles/${valid[1]}`);
 });
+
+exports.profiles = profiles;
+exports.buildJSONresult = buildJSONresult;
+exports.processParams = buildProcessParamsFunction(profiles);


### PR DESCRIPTION
* Use [`fs.readdirSync()`](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_readdirsync_path_options) instead to traverse the filesystem in search of profiles. (Bad idea in general to opt for synchronous methods, but there would be too many ramifications down the line if we were to defer the value of `exports.profiles` in this module&hellip;)
* `` `${__dirname}/profiles/` `` instead of `'./lib/profiles/'` for better portability.