### PR TITLE
Notes can also take advantage of exceptions

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -135,7 +135,7 @@ Specberus.prototype.error = function (rule, key, extra) {
     else
         name = rule.name;
     if ((this.shortname !== undefined) &&
-        (this.config.status === "WD" || this.config.status === "CR") &&
+        (this.config.status === "WD" || this.config.status === "CR" || this.config.status === "NOTE") &&
         this.exceptions.has(this.shortname, name, key, extra))
         this.warning(rule, key, extra);
     else {


### PR DESCRIPTION
@plehegar your [earlier commit](https://github.com/w3c/specberus/commit/a6c6594dad3d99de8069c3bfffb75559565c9255#diff-b973211993289ad59465118eecb30110) limits the exceptions to WDs and CRs only.
How about adding notes too? FYI, this is preventing some people to publish with echidna