### PR TITLE
Fix critical bug (causes a crash) when recursively validating page with broken links

### DIFF
--- a/lib/rules/links/compound.js
+++ b/lib/rules/links/compound.js
@@ -51,7 +51,7 @@ exports.check = function (sr, done) {
               req.timeout(TIMEOUT);
               req.end(function (err1, res) {
                   if (err1 && err1.timeout === TIMEOUT) sr.warning(self, "html-timeout");
-                  var json = res.body;
+                  var json = res ? res.body : null;
                   if (!json) return sr.throw("No JSON input.");
                   if (json.messages) {
                       var errors = json.messages.filter(function(msg) {
@@ -70,7 +70,7 @@ exports.check = function (sr, done) {
                   reqCSS.timeout(TIMEOUT);
                   reqCSS.end(function (err2, res) {
                       if (err2 && err2.timeout === TIMEOUT) sr.warning(self, "css-timeout");
-                      if (res.header['x-w3c-validator-status'] === 'Valid') isCSSValid = true;
+                      if (res && res.header && res.header['x-w3c-validator-status'] === 'Valid') isCSSValid = true;
                       if (isMarkupValid && isCSSValid) {
                           sr.info(self, "link", { file : l.split('/').pop(), link : l , markup : "\u2714", css : "\u2714" });
                       }


### PR DESCRIPTION
How to reproduce: validate recursively a page that contains at least one hyperlink that can't be resolved; a RTE will occur and the application will crash.

(For example: [`https://r12a.github.io/scripts/tutorial/`](https://r12a.github.io/scripts/tutorial/) has near the top a link (text: &ldquo;intended audience&rdquo;) where the author forgot to include the `#` at the beginning (it's supposed to be a fragment ID), so instead it's interpreted as a link to `https://r12a.github.io/scripts/tutorial/audience`, which does not exist.)

This should solve the issue.