### PR TITLE
/doc/rules/: fix scroll of selected fragment ID

### DIFF
--- a/public/js/scroll-tweak.js
+++ b/public/js/scroll-tweak.js
@@ -3,12 +3,36 @@
 'use strict'; // jshint ignore: line
 
 $(document).ready(function() {
-    if (document.location && document.location.hash && window.pageYOffset && window.innerHeight)
+
+    var scrolled = 0;
+
+    var scrollTo = function(selector) {
+        var elem = $(selector);
+        if (elem) {
+            var elemOffset = elem[0].offsetTop;
+            var elemHeight = elem.outerHeight(true);
+            var windowHeight = $(window).height();
+            window.scrollTo(window.pageXOffset, elemOffset - (windowHeight - elemHeight) / 2);
+        }
+    };
+
+    $(window).scroll(function() {
+        scrolled++;
+    });
+
+    $('a[href^="#"]').click(function(e) {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        document.location.hash = e.target.hash;
+        scrollTo(e.target.hash);
+    });
+
+    if (document.location && document.location.hash) {
         window.setTimeout(function() {
-            const elem = $(document.location.hash);
-            if (elem && elem.length > 0) elem[0].scrollIntoViewIfNeeded();
-            window.setTimeout(function() {
-                window.scrollTo(window.pageXOffset, window.pageYOffset - window.innerHeight * 0.5);
-            }, 500);
+            $(window).off('scroll');
+            if (scrolled < 3)    // Merely loading a page may trigger one or two scroll events.
+                scrollTo(document.location.hash);
         }, 500);
+    }
+
 });


### PR DESCRIPTION
I think I have improved the JS logic that prevents selected fragment IDs from being aligned at the very top of the viewport and therefore obscured by the header overlay.

Now, the fragment ID (if there is one) should be shown near the middle of the viewport (after a delay of 500 ms and provided that the user has *not* scrolled the page manually already, to prevent jitters and any confusing behaviour).

Also, now this works too when clicking hashes: the page will scroll and the selected rule will be in the middle.

Fixes #538.