### PR TITLE
Fix relative links to profile rules

### DIFF
--- a/views/doc/index.handlebars
+++ b/views/doc/index.handlebars
@@ -13,7 +13,7 @@
       <h4 id="{{this.abbr}}"><a href="#{{this.abbr}}">{{this.name}}</a></h3>
       <ul>
       {{#each this.profiles}}
-        <li><a href="{{../BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
+        <li><a href="{{BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
       {{/each}}
       </ul>
     {{/each}}

--- a/views/doc/index.handlebars
+++ b/views/doc/index.handlebars
@@ -13,7 +13,7 @@
       <h4 id="{{this.abbr}}"><a href="#{{this.abbr}}">{{this.name}}</a></h3>
       <ul>
       {{#each this.profiles}}
-        <li><a href="{{BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
+        <li><a href="{{../../BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
       {{/each}}
       </ul>
     {{/each}}


### PR DESCRIPTION
Relative links on the [pubrules documentation page](https://www.w3.org/pubrules/doc/) to the different profiles are broken.

I think this fixes the issue.