### PR TITLE
update the copyright regex to avoid dummy copyrights

### DIFF
--- a/lib/rules/headers/copyright.js
+++ b/lib/rules/headers/copyright.js
@@ -10,7 +10,7 @@ exports.check = function (sr, done) {
     if ($c.length) {
         var year = (sr.getDocumentDate() || new Date()).getFullYear()
         ,   text = sr.norm($c.text())
-        ,   startRex = "^Copyright (©|&copy;) (?:(?:199\\d|20[01]\\d)-)?" + year + " .*?W3C(®|&reg;) \\(MIT, ERCIM, Keio, Beihang\\)"
+        ,   startRex = "^Copyright (©|&copy;) (?:(?:199\\d|20[01]\\d)-)?" + year + " W3C(®|&reg;) \\(MIT, ERCIM, Keio, Beihang\\)"
         ,   isDualLicensed = /CC-BY/.test(text)
         ,   w3cOnlyStatement
         ,   dualLicenseStatement = ", Some Rights Reserved: this document is dual-licensed, CC-BY and W3C Document License"

--- a/lib/rules/headers/copyright.js
+++ b/lib/rules/headers/copyright.js
@@ -10,7 +10,7 @@ exports.check = function (sr, done) {
     if ($c.length) {
         var year = (sr.getDocumentDate() || new Date()).getFullYear()
         ,   text = sr.norm($c.text())
-        ,   startRex = "^Copyright (©|&copy;) (?:(?:199\\d|20[01]\\d)-)?" + year + " W3C(®|&reg;) \\(MIT, ERCIM, Keio, Beihang\\)"
+        ,   startRex = "^Copyright (©|&copy;) (?:(?:199\\d|20[01]\\d)-)?" + year + " *W3C(®|&reg;) \\(MIT, ERCIM, Keio, Beihang\\)"
         ,   isDualLicensed = /CC-BY/.test(text)
         ,   w3cOnlyStatement
         ,   dualLicenseStatement = ", Some Rights Reserved: this document is dual-licensed, CC-BY and W3C Document License"

--- a/test/docs/headers/copyright-freedom.html
+++ b/test/docs/headers/copyright-freedom.html
@@ -25,14 +25,13 @@
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
-        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
         <a href="http://www.keio.ac.jp/">Keio</a>,
         <a href="http://ev.buaa.edu.cn/">Beihang</a>),
         Some Rights Reserved: this document is dual-licensed,
-        <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> and 
+        <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> and
         <a href="http://www.w3.org/Consortium/Legal/copyright-documents"><abbr title="World Wide Web Consortium">W3C</abbr> Document License</a>.
         <abbr title="World Wide Web Consortium">W3C</abbr>
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,

--- a/test/docs/headers/simple-oxford.html
+++ b/test/docs/headers/simple-oxford.html
@@ -26,7 +26,6 @@
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
-        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,

--- a/test/docs/headers/simple.html
+++ b/test/docs/headers/simple.html
@@ -26,7 +26,6 @@
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
-        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,


### PR DESCRIPTION
The current regex won't return an error on copyrights like:
```
Copyright © 2017 FOOBAR & W3C® (MIT, ERCIM, Keio, Beihang). W3C liability, trademark and permissive document license rules apply. 
```

These cases should be handled as exceptions.