### PR TITLE
Remove package “body-parser”

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,8 +9,7 @@ const DEFAULT_PORT = 80;
 const http = require('http');
 
 // External packages:
-const bodyParser = require('body-parser')
-,   compression = require('compression')
+const compression = require('compression')
 ,   express = require('express')
 ,   insafe = require('insafe')
 ,   morgan = require('morgan')
@@ -37,7 +36,6 @@ const app = express()
 // Middleware:
 app.use(morgan('combined'));
 app.use(compression());
-app.use(bodyParser.json());
 app.use(express.static("public"));
 api.setUp(app);
 views.setUp(app);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/w3c/specberus.git"
   },
   "dependencies": {
-    "body-parser": "1.18.0",
     "compression": "1.7.0",
     "express": "4.15.4",
     "express-handlebars": "3.0",


### PR DESCRIPTION
As far as I can tell, we don't seem to be using it.

Closes #668.