### PR TITLE
Link rel=canonical

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -151,6 +151,8 @@ exports.messages = {
     // sotd/rescind
 ,   "sotd.obsl-rescind.no-rationale":          "No rationale section found."
 ,   "sotd.obsl-rescind.no-explanation-link":   "Link to \"explanation of Obsoleting and Rescinding W3C Specifications\" not found."
+    // structure/canonical
+,   "structure.canonical.not-found":         "No canonical link found."
     // structure/name
 ,   'structure.name.wrong':  'The main page should be called <code>Overview.html</code>${note}.'
     // structure/section-ids

--- a/lib/profiles/base.js
+++ b/lib/profiles/base.js
@@ -46,6 +46,7 @@ exports.rules = [
 
 ,   require("../rules/structure/name")
 ,   require("../rules/structure/h2")
+,   require("../rules/structure/canonical")
 ,   require("../rules/structure/section-ids")
 ,   require("../rules/structure/display-only")
 

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -38,7 +38,8 @@
                                 "IG-NOTE"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -138,7 +139,8 @@
                                 "IG-NOTE"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -242,7 +244,8 @@
                                 "WG-NOTE"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -342,7 +345,8 @@
                                 "WG-NOTE"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -452,7 +456,8 @@
                                 "WD"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -551,7 +556,8 @@
                                 "WD"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -653,7 +659,8 @@
                                 "CR"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -755,7 +762,8 @@
                                 "CR"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -862,7 +870,8 @@
                                 "PR"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -969,7 +978,8 @@
                                 "REC"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -1071,7 +1081,8 @@
                                 "RSCND"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -1167,7 +1178,8 @@
                                 "OBSL"
                             ],
                             "lastStylesheet": true,
-                            "viewport": true
+                            "viewport": true,
+                            "canonical": true
                         }
                     },
                     "front-matter": {
@@ -1269,7 +1281,8 @@
                 "rules": {
                     "goodStylesheet": "<span class=\"subset\">recursive</span> Each document <span class=\"rfc2119\">must</span> include the following absolute URI to identify a style sheet for this maturity level: <code> <span class=\"boilerplate-nocode\">https://www.w3.org/StyleSheets/TR/2016/W3C-@{param1}</span> </code> <p> <span style=\"font-style: italic\">Include this source code:</span> <br> <code>&lt;link rel=\"stylesheet\" type=\"text/css\" href=\"https://www.w3.org/StyleSheets/TR/2016/W3C-@{param1}\"/&gt;</code> </p>",
                     "lastStylesheet": "<span class=\"subset\">recursive</span> Any internal style sheets <span class=\"rfc2119\">must</span> be cascaded before this link; i.e., the internal style sheets <span class=\"rfc2119\">must not</span> override the W3C tech report styles.",
-                    "viewport": "<span class=\"subset\">recursive</span> The viewport meta tag is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\"&gt;</code></p>"
+                    "viewport": "<span class=\"subset\">recursive</span> The viewport meta tag is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\"&gt;</code></p>",
+                    "canonical": "<span class=\"subset\">recursive</span> The canonical link is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;link rel=\"canonical\" url=\"@@URL@@\"&gt;</code></p>"
                 }
             },
             "front-matter": {

--- a/lib/rules/structure/canonical.js
+++ b/lib/rules/structure/canonical.js
@@ -15,7 +15,7 @@ exports.check = function (sr, done) {
     // See https://lists.w3.org/Archives/Public/spec-prod/2017JulSep/0005.html
     sr.transition({
         to:          new Date('2017-09-30')
-    ,   doMeanwhile: function () { return done(); }
+    ,   doMeanwhile: () => {}
     ,   doAfter:     checkCanonical
     });
 

--- a/lib/rules/structure/canonical.js
+++ b/lib/rules/structure/canonical.js
@@ -1,0 +1,23 @@
+const self = {
+    name: 'structure.canonical'
+,   section: 'metadata'
+,   rule: 'canonical'
+};
+
+exports.check = function (sr, done) {
+
+    const checkCanonical = function () {
+        var $lnk = sr.$("head > link[rel=canonical]");
+        if (!$lnk.length || !$lnk.attr("href")) sr.error(self, "not-found");
+    };
+
+    // That canonical link is mandatory starting from Oct 1, 2017.
+    // See https://lists.w3.org/Archives/Public/spec-prod/2017JulSep/0005.html
+    sr.transition({
+        to:          new Date('2017-09-30')
+    ,   doMeanwhile: function () { return done(); }
+    ,   doAfter:     checkCanonical
+    });
+
+    done();
+};

--- a/test/docs/structure/canonical-href-missing.html
+++ b/test/docs/structure/canonical-href-missing.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <style></style>
+    <link rel='stylesheet' href='https://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
+    <link rel='canonical' href=''>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="https://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 1 October 2017</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20171001/'>https://www.w3.org/TR/2017/WD-specberus-20171001/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170312/'>https://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <hr>
+    </div>
+  </body>
+</html>

--- a/test/docs/structure/canonical-missing.html
+++ b/test/docs/structure/canonical-missing.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <style></style>
+    <link rel='stylesheet' href='https://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="https://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 1 October 2017</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20171001/'>https://www.w3.org/TR/2017/WD-specberus-20171001/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170312/'>https://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <hr>
+    </div>
+  </body>
+</html>

--- a/test/docs/structure/canonical.html
+++ b/test/docs/structure/canonical.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <style></style>
+    <link rel='stylesheet' href='https://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
+    <link rel='canonical' href='https://www.w3.org/TR/specberus/'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="https://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 1 October 2017</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20171001/'>https://www.w3.org/TR/2017/WD-specberus-20171001/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170312/'>https://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <hr>
+    </div>
+  </body>
+</html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -281,6 +281,12 @@ var tests = {
                       ,"structure.section-ids", "structure.section-ids", "structure.section-ids"
                       ]  }
         ]
+    ,   canonical:  [
+            { doc: "headers/simple.html" }
+        ,   { doc: "structure/canonical.html" }
+        ,   { doc: "structure/canonical-missing.html", errors: ["structure.canonical"] }
+        ,   { doc: "structure/canonical-href-missing.html", errors: ["structure.canonical"] }
+        ]
     }
 ,   sotd:   {
         supersedable:  [


### PR DESCRIPTION
Starting from Oct 1, we will require a `rel=canonical`.
See https://lists.w3.org/Archives/Public/spec-prod/2017JulSep/0005.html for more details.