### PR TITLE
Fix/mute nsp errors

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,6 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/479",
+    "https://nodesecurity.io/advisories/528"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "compression": "1.7.1",
-    "express": "4.15.4",
+    "express": "5.0.0-alpha.6",
     "express-handlebars": "3.0",
     "insafe": "0.3",
     "metaviewport-parser": "0.1.0",


### PR DESCRIPTION
* Express: I rejected greenkeeper's automatic upgrade to [that pre-release](https://github.com/expressjs/express/releases/tag/5.0.0-alpha.6) earlier today, as I usually do, without realising it's the best way to prevent one of the vulnerabilities. Using that now.
* `superagent`: [not fixed anywhere](https://github.com/visionmedia/superagent/issues/1259). Added exception for now.
* `socket.io`: dependency [not fixed anywhere](https://github.com/get/parsejson/issues/4). Added exception for now.

After merging: please tag Specberus with a new patch number (`3.4.1`) and publish it on npm, so that w3c/echidna#497 can pick it up.