### PR TITLE
Mute a new nsp error

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,7 @@
 {
   "exceptions": [
     "https://nodesecurity.io/advisories/479",
-    "https://nodesecurity.io/advisories/528"
+    "https://nodesecurity.io/advisories/528",
+    "https://nodesecurity.io/advisories/535"
   ]
 }


### PR DESCRIPTION
`express`: [the issue](https://nodesecurity.io/advisories/535) in `mime` [is fixed](https://github.com/broofa/node-mime/issues/167), and both `mime` and `send` are upgraded. But `express` [has not picked it up yet](https://github.com/expressjs/express/issues/3431). Thus, muting for the time being.

cf #684