### PR TITLE
Groupnote pp

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -153,6 +153,8 @@ exports.messages = {
     // sotd/rescind
 ,   "sotd.obsl-rescind.no-rationale":          "No rationale section found."
 ,   "sotd.obsl-rescind.no-explanation-link":   "Link to \"explanation of Obsoleting and Rescinding W3C Specifications\" not found."
+    // sotd/delivererNote
+,   "sotd.delivererNote.not-found": "Deliverer not found. An attribute <code>data-deliverer</code> must be in the SotD"
     // structure/canonical
 ,   "structure.canonical.not-found":         "No canonical link found."
     // structure/name

--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -154,7 +154,7 @@ exports.messages = {
 ,   "sotd.obsl-rescind.no-rationale":          "No rationale section found."
 ,   "sotd.obsl-rescind.no-explanation-link":   "Link to \"explanation of Obsoleting and Rescinding W3C Specifications\" not found."
     // sotd/delivererNote
-,   "sotd.delivererNote.not-found": "Deliverer not found. An attribute <code>data-deliverer</code> must be in the SotD"
+,   "sotd.deliverer-note.not-found": "Deliverer not found. An attribute <code>data-deliverer</code> must be in the SotD"
     // structure/canonical
 ,   "structure.canonical.not-found":         "No canonical link found."
     // structure/name

--- a/lib/profiles/TR/WG-NOTE.js
+++ b/lib/profiles/TR/WG-NOTE.js
@@ -17,4 +17,11 @@ const base = require("../base")
     )
 ;
 
+exports.rules = base.extendWithInserts({
+    "sotd.supersedable":    [
+                              require("../../rules/sotd/diff")
+                            , require("../../rules/sotd/delivererNote")
+                            ]
+});
+
 exports.rules = rules;

--- a/lib/profiles/TR/WG-NOTE.js
+++ b/lib/profiles/TR/WG-NOTE.js
@@ -20,7 +20,7 @@ const base = require("../base")
 exports.rules = base.extendWithInserts({
     "sotd.supersedable":    [
                               require("../../rules/sotd/diff")
-                            , require("../../rules/sotd/delivererNote")
+                            , require("../../rules/sotd/deliverer-note")
                             ]
 });
 

--- a/lib/profiles/TR/WG-NOTE.js
+++ b/lib/profiles/TR/WG-NOTE.js
@@ -9,13 +9,7 @@ exports.config = {
 ,   noteStatus:         true
 };
 
-const base = require("../base")
-,   rules = base.insertAfter(
-        require("../TR").rules
-    ,   "sotd.supersedable"
-    ,   [require("../../rules/sotd/diff")]
-    )
-;
+const base = require("../base");
 
 exports.rules = base.extendWithInserts({
     "sotd.supersedable":    [
@@ -23,5 +17,3 @@ exports.rules = base.extendWithInserts({
                             , require("../../rules/sotd/deliverer-note")
                             ]
 });
-
-exports.rules = rules;

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -246,7 +246,7 @@
                             "lastStylesheet": true,
                             "viewport": true,
                             "canonical": true,
-                            "delivererID": "The Working Group(s) id(s) <span class=\"rfc2119\">must</span> be listed in a <code>data-deliverer</code> attribute in the section \"Status of This Document\".<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;p data-deliverer=\"@@ID1@@,@@ID2@@,...\"&gt;</code></p>"
+                            "delivererID": true
                         }
                     },
                     "front-matter": {
@@ -348,7 +348,7 @@
                             "lastStylesheet": true,
                             "viewport": true,
                             "canonical": true,
-                            "delivererID": "The Working Group(s) id(s) <span class=\"rfc2119\">must</span> be listed in a <code>data-deliverer</code> attribute in the section \"Status of This Document\".<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;p data-deliverer=\"@@ID1@@,@@ID2@@,...\"&gt;</code></p>"
+                            "delivererID": true
                         }
                     },
                     "front-matter": {
@@ -1284,7 +1284,8 @@
                     "goodStylesheet": "<span class=\"subset\">recursive</span> Each document <span class=\"rfc2119\">must</span> include the following absolute URI to identify a style sheet for this maturity level: <code> <span class=\"boilerplate-nocode\">https://www.w3.org/StyleSheets/TR/2016/W3C-@{param1}</span> </code> <p> <span style=\"font-style: italic\">Include this source code:</span> <br> <code>&lt;link rel=\"stylesheet\" type=\"text/css\" href=\"https://www.w3.org/StyleSheets/TR/2016/W3C-@{param1}\"/&gt;</code> </p>",
                     "lastStylesheet": "<span class=\"subset\">recursive</span> Any internal style sheets <span class=\"rfc2119\">must</span> be cascaded before this link; i.e., the internal style sheets <span class=\"rfc2119\">must not</span> override the W3C tech report styles.",
                     "viewport": "<span class=\"subset\">recursive</span> The viewport meta tag is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\"&gt;</code></p>",
-                    "canonical": "<span class=\"subset\">recursive</span> The canonical link is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;link rel=\"canonical\" url=\"@@URL@@\"&gt;</code></p>"
+                    "canonical": "<span class=\"subset\">recursive</span> The canonical link is required.<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;link rel=\"canonical\" url=\"@@URL@@\"&gt;</code></p>",
+                    "delivererID": "The Working Group(s) id(s) <span class=\"rfc2119\">must</span> be listed in a <code>data-deliverer</code> attribute in the section \"Status of This Document\".<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;p data-deliverer=\"@@ID1@@,@@ID2@@,...\"&gt;</code></p>"
                 }
             },
             "front-matter": {

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -245,7 +245,8 @@
                             ],
                             "lastStylesheet": true,
                             "viewport": true,
-                            "canonical": true
+                            "canonical": true,
+                            "delivererID": "The Working Group(s) id(s) <span class=\"rfc2119\">must</span> be listed in a <code>data-deliverer</code> attribute in the section \"Status of This Document\".<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;p data-deliverer=\"@@ID1@@,@@ID2@@,...\"&gt;</code></p>"
                         }
                     },
                     "front-matter": {
@@ -346,7 +347,8 @@
                             ],
                             "lastStylesheet": true,
                             "viewport": true,
-                            "canonical": true
+                            "canonical": true,
+                            "delivererID": "The Working Group(s) id(s) <span class=\"rfc2119\">must</span> be listed in a <code>data-deliverer</code> attribute in the section \"Status of This Document\".<p><span style=\"font-style: italic\">Include this source code:</span><br/><code>&lt;p data-deliverer=\"@@ID1@@,@@ID2@@,...\"&gt;</code></p>"
                         }
                     },
                     "front-matter": {

--- a/lib/rules/sotd/deliverer-note.js
+++ b/lib/rules/sotd/deliverer-note.js
@@ -1,5 +1,5 @@
 const self = {
-    name: 'sotd.delivererNote'
+    name: 'sotd.deliverer-note'
 };
 
 exports.check = function (sr, done) {

--- a/lib/rules/sotd/deliverer-note.js
+++ b/lib/rules/sotd/deliverer-note.js
@@ -1,5 +1,7 @@
 const self = {
     name: 'sotd.deliverer-note'
+,   section: 'metadata'
+,   rule: 'delivererID'
 };
 
 exports.check = function (sr, done) {

--- a/lib/rules/sotd/delivererNote.js
+++ b/lib/rules/sotd/delivererNote.js
@@ -1,0 +1,11 @@
+const self = {
+    name: 'sotd.delivererNote'
+};
+
+exports.check = function (sr, done) {
+    const deliverers = sr.getDelivererIDsNote();
+
+    if (0 === deliverers.length)
+        sr.error(self, "not-found");
+    done();
+};

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -19,7 +19,7 @@ function buildWanted (groups, sr) {
         else {
             wanted = "This document was produced by " +
                      ((groups.length == 2) ? "groups " : "a group ") +
-                     "operating under the( 5 February 2004)? W3C Patent Policy\\. ";
+                     "operating under the( 5 February 2004)? W3C Patent Policy\\. ?";
             if (config.recTrackStatus && config.noRecTrack)
                 wanted += ((groups.length == 2) ? "The groups do not " : "The group does not ") +
                           "expect this document to become a W3C Recommendation\\. ";
@@ -156,7 +156,8 @@ exports.check = function (sr, done) {
                         return;
                 }
             });
-            var isPP2002 = (sr.config.patentPolicy === "pp2002");
+            var isPP2002 = (sr.config.patentPolicy === "pp2002")
+            ,   isWGNote = (sr.config.longStatus === "Working Group Note");
             if (!foundJan24 && isPP2002) sr.error(self, "no-jan24");
             if (!foundPPTransition && isPP2002) sr.error(self, "no-pp-transition");
             if (!isPP2002) {
@@ -166,10 +167,10 @@ exports.check = function (sr, done) {
                     sr.error(self, 'deprecated', {policy: deprecatedPp});
                 else if (!found2017Aug1 && !foundFeb5) sr.error(self, "no-aug1");
             }
-            if (!foundPublicList) sr.error(selfDisclosures, "no-disclosures");
-            if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundEssentials)
+            if (!foundPublicList && !isWGNote) sr.error(selfDisclosures, "no-disclosures");
+            if ((sr.config.recTrackStatus || sr.config.noteStatus) && !isWGNote && !foundEssentials)
                 sr.error(self, "no-claims");
-            if ((sr.config.recTrackStatus || sr.config.noteStatus) && !foundSection6)
+            if ((sr.config.recTrackStatus || sr.config.noteStatus) && !isWGNote && !foundSection6)
                 sr.error(self, "no-section6");
         }
     }

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -4,6 +4,7 @@ function buildWanted (groups, sr) {
     ,   wanted
     ,   result = {}
     ,   isPP2002 = (config.patentPolicy === "pp2002")
+    ,   isWGNote = (config.longStatus === "Working Group Note")
     ,   isIGNote = (config.longStatus === "Interest Group Note");
 
     if (isIGNote)
@@ -25,21 +26,23 @@ function buildWanted (groups, sr) {
             if (config.informativeOnly && !config.noteStatus)
                 wanted += "This document is informative only\\. ";
         }
-        wanted += "W3C maintains ";
-        if (groups.length < 2) {
-            wanted += "a public list of any patent disclosures";
-        } else {
-            wanted += groups.map(function(wg) {
-                        return "a public list of any patent disclosures \\(" + wg.replace(' Working Group', '') + "( Working Group)?\\)";
-                      }).join(" and ");
+        if (!isWGNote) {
+            wanted += "W3C maintains ";
+            if (groups.length < 2) {
+                wanted += "a public list of any patent disclosures";
+            } else {
+                wanted += groups.map(function(wg) {
+                            return "a public list of any patent disclosures \\(" + wg.replace(' Working Group', '') + "( Working Group)?\\)";
+                          }).join(" and ");
+            }
+            wanted += " made in connection with the deliverables of " +
+                      ((groups.length == 2) ? "each group; these pages also include " : "the group; that page also includes ") +
+                      "instructions for disclosing a patent\\.";
+            if (config.recTrackStatus || config.noteStatus || isPP2002)
+                wanted += " An individual who has actual knowledge of a patent which the individual " +
+                          "believes contains Essential Claim\\(s\\) must disclose the information in " +
+                          "accordance with section 6 of the W3C Patent Policy\\.";
         }
-        wanted += " made in connection with the deliverables of " +
-                  ((groups.length == 2) ? "each group; these pages also include " : "the group; that page also includes ") +
-                  "instructions for disclosing a patent\\.";
-        if (config.recTrackStatus || config.noteStatus || isPP2002)
-            wanted += " An individual who has actual knowledge of a patent which the individual " +
-                      "believes contains Essential Claim\\(s\\) must disclose the information in " +
-                      "accordance with section 6 of the W3C Patent Policy\\.";
     }
     result.regex = new RegExp(wanted);
     result.text  = wanted.replace(/\\/g, '');

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -347,10 +347,11 @@ Specberus.prototype.getDelivererIDs = function () {
     var ids = []
     ,   $    = this.$
     ,   self = this
-    ,   $sotd = self.getSotDSection();
+    ,   $sotd = self.getSotDSection()
+    ,   $container = $("<div></div>").append($sotd);
 
-    if ($sotd && $sotd.find('[data-deliverer]').length > 0) {
-        $sotd.find('[data-deliverer]').each(function() {
+    if ($sotd && $container.find('[data-deliverer]').length > 0) {
+        $container.find('[data-deliverer]').each(function() {
             var item = $(this)
             ,   deliverers = item.attr('data-deliverer').trim().split(/\s+/)
             ;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -349,7 +349,17 @@ Specberus.prototype.getDelivererIDs = function () {
     ,   self = this
     ,   $sotd = self.getSotDSection();
 
-    if ($sotd && $sotd.find('a[href]')) {
+    if ($sotd && $sotd.find('*[data-deliverer]')) {
+        $sotd.find('*[data-deliverer]').each(function() {
+            var item = $(this)
+            ,   deliverers = item.attr('data-deliverer').trim().split(/\s+/)
+            ;
+
+            deliverers.forEach(function (id) {
+                if (/\d+/.test(id)) ids.push(parseInt(id, 10));
+            });
+        });
+    } else if ($sotd && $sotd.find('a[href]')) {
 
         $sotd.find('a[href]').each(function() {
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -344,23 +344,12 @@ Specberus.prototype.getDelivererIDs = function () {
     ,   TAG_ID = 34270
     ;
 
-    var ids = []
+    var ids = this.getDelivererIDsNote() || []
     ,   $    = this.$
     ,   self = this
-    ,   $sotd = self.getSotDSection()
-    ,   $container = $("<div></div>").append($sotd);
+    ,   $sotd = self.getSotDSection();
 
-    if ($sotd && $container.find('[data-deliverer]').length > 0) {
-        $container.find('[data-deliverer]').each(function() {
-            var item = $(this)
-            ,   deliverers = item.attr('data-deliverer').trim().split(/\s+/)
-            ;
-
-            deliverers.forEach(function (id) {
-                if (/\d+/.test(id)) ids.push(parseInt(id, 10));
-            });
-        });
-    } else if ($sotd && $sotd.find('a[href]').length > 0) {
+    if (ids.length === 0 && $sotd && $sotd.find('a[href]').length > 0) {
 
         $sotd.find('a[href]').each(function() {
 
@@ -381,6 +370,28 @@ Specberus.prototype.getDelivererIDs = function () {
                   ids.push(TAG_ID);
                 }
             }
+        });
+    }
+
+    return ids;
+};
+
+Specberus.prototype.getDelivererIDsNote = function() {
+    var ids = []
+    ,   $    = this.$
+    ,   self = this
+    ,   $sotd = self.getSotDSection()
+    ,   $container = $("<div></div>").append($sotd);
+
+    if ($sotd && $container.find('[data-deliverer]').length > 0) {
+        $container.find('[data-deliverer]').each(function() {
+            var item = $(this)
+            ,   deliverers = item.attr('data-deliverer').trim().split(/\s+/)
+            ;
+
+            deliverers.forEach(function (id) {
+                if (/\d+/.test(id)) ids.push(parseInt(id, 10));
+            });
         });
     }
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -349,8 +349,8 @@ Specberus.prototype.getDelivererIDs = function () {
     ,   self = this
     ,   $sotd = self.getSotDSection();
 
-    if ($sotd && $sotd.find('*[data-deliverer]')) {
-        $sotd.find('*[data-deliverer]').each(function() {
+    if ($sotd && $sotd.find('[data-deliverer]').length > 0) {
+        $sotd.find('[data-deliverer]').each(function() {
             var item = $(this)
             ,   deliverers = item.attr('data-deliverer').trim().split(/\s+/)
             ;
@@ -359,7 +359,7 @@ Specberus.prototype.getDelivererIDs = function () {
                 if (/\d+/.test(id)) ids.push(parseInt(id, 10));
             });
         });
-    } else if ($sotd && $sotd.find('a[href]')) {
+    } else if ($sotd && $sotd.find('a[href]').length > 0) {
 
         $sotd.find('a[href]').each(function() {
 

--- a/test/docs/headers/wg-note.html
+++ b/test/docs/headers/wg-note.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <style></style>
+    <link rel='stylesheet' href='http://www.w3.org/StyleSheets/TR/2016/W3C-IG-NOTE'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="http://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="http://www.w3.org/Icons/w3c_home">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Group Note 15 March 2017, edited in place 01 April 2014</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='http://www.w3.org/TR/2017/NOTE-specberus-20170315/'>http://www.w3.org/TR/2017/NOTE-specberus-20170315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='http://www.w3.org/TR/specberus/'>http://www.w3.org/TR/specberus/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+      </dl>
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
+        <a href="http://trustee.ietf.org/">The IETF Trust</a> &amp;
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>,
+        <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+      <hr>
+    </div>
+    <h2>Abstract</h2>
+    <p>
+      We are the internets!
+    </p>
+    <h2>Status of This Document</h2>
+    <p data-deliverer="68238">
+        This document was produced by a group operating under the
+        <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    </p>
+    <h2>Table of Contents</h2>
+    <ul>
+      <li>Nothing</li>
+    </ul>
+  </body>
+</html>

--- a/test/docs/metadata/csvw-ucr.html
+++ b/test/docs/metadata/csvw-ucr.html
@@ -492,14 +492,33 @@ input.task-list-item-checkbox {
 
 
 
-          <p data-deliverer="68238">
+          <p>
 
               This document was produced by
 
               a group
                operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
+
+
+
+
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/68238/status" rel="disclosure">public list of any patent
+                disclosures</a>
+
+              made in connection with the deliverables of
+
+              the group; that page also includes
+
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+
+
           </p>
 
             <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.

--- a/test/docs/metadata/csvw-ucr.html
+++ b/test/docs/metadata/csvw-ucr.html
@@ -498,27 +498,8 @@ input.task-list-item-checkbox {
 
               a group
                operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
-
-
-
-
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/68238/status" rel="disclosure">public list of any patent
-                disclosures</a>
-
-              made in connection with the deliverables of
-
-              the group; that page also includes
-
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-              Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-
-
           </p>
 
             <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.

--- a/test/docs/metadata/csvw-ucr.html
+++ b/test/docs/metadata/csvw-ucr.html
@@ -492,7 +492,7 @@ input.task-list-item-checkbox {
 
 
 
-          <p>
+          <p data-deliverer="68238">
 
               This document was produced by
 

--- a/test/docs/metadata/csvw-ucr.html
+++ b/test/docs/metadata/csvw-ucr.html
@@ -492,33 +492,13 @@ input.task-list-item-checkbox {
 
 
 
-          <p>
+          <p data-deliverer="68238">
 
               This document was produced by
 
               a group
                operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-              Policy</a>.
-
-
-
-
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/68238/status" rel="disclosure">public list of any patent
-                disclosures</a>
-
-              made in connection with the deliverables of
-
-              the group; that page also includes
-
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-              Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-
-
+              <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
           </p>
 
             <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.

--- a/test/docs/sotd/note-deliverer-bad.html
+++ b/test/docs/sotd/note-deliverer-bad.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" typeof="bibo:Document w3p:NOTE" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
+<head><meta property="dc:language" content="en" lang="">
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>CSV on the Web: Use Cases and Requirements</title>
+<link href="https://www.w3.org/StyleSheets/TR/W3C-WG-NOTE" rel="stylesheet"></head>
+  <body id="respecDocument" role="document" class="h-entry"><div id="respecHeader" role="contentinfo" class="head">
+  <p>
+
+
+            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a>
+
+
+
+
+  </p>
+  <h1 class="title p-name" id="title" property="dcterms:title">CSV on the Web: Use Cases and Requirements</h1>
+
+  <h2 id="w3c-working-group-note-25-february-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Group Note <time property="dcterms:issued" class="dt-published" datetime="2016-02-25">25 February 2016</time></h2>
+  <dl>
+
+      <dt>This version:</dt>
+      <dd><a class="u-url" href="https://www.w3.org/TR/2016/NOTE-csvw-ucr-20160225/">https://www.w3.org/TR/2016/NOTE-csvw-ucr-20160225/</a></dd>
+      <dt>Latest published version:</dt>
+      <dd><a href="https://www.w3.org/TR/csvw-ucr/">https://www.w3.org/TR/csvw-ucr/</a></dd>
+
+
+      <dt>Latest editor's draft:</dt>
+      <dd><a href="http://w3c.github.io/csvw/use-cases-and-requirements/">http://w3c.github.io/csvw/use-cases-and-requirements/</a></dd>
+
+
+
+
+
+
+      <dt>Previous version:</dt>
+      <dd><a rel="dcterms:replaces" href="https://www.w3.org/TR/2014/WD-csvw-ucr-20140701/">https://www.w3.org/TR/2014/WD-csvw-ucr-20140701/</a></dd>
+
+
+    <dt>Editors:</dt>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jeremy Tandy</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.metoffice.gov.uk/">Met Office</a></span>
+<span property="rdf:rest" resource="_:editor1"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Davide Ceolin</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.vu.nl">VU University Amsterdam</a></span>
+<span property="rdf:rest" resource="_:editor2"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Eric Stephan</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.pnnl.gov">Pacific Northwest National Laboratory</a></span>
+<span property="rdf:rest" resource="rdf:nil"></span>
+</dd>
+
+
+
+
+
+          <dt>Repository:</dt>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw">
+                      We are on GitHub
+                    </a>
+                  </dd>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw">
+                      File a bug
+                    </a>
+                  </dd>
+
+
+
+
+
+
+          <dt>Changes:</dt>
+
+
+
+                  <dd>
+                    <a href="diff.html">
+                      Diff to previous version
+                    </a>
+                  </dd>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw/commits/gh-pages">
+                      Commit history
+                    </a>
+                  </dd>
+
+
+
+
+
+
+  </dl>
+
+
+    <p>
+
+        This document is also available in this non-normative format:
+
+      <a rel="alternate" href="csvw-ucr.epub">ePub</a>
+    </p>
+
+
+
+
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        2016
+
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+
+
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+
+
+        rules apply.
+      </p>
+
+
+  <hr title="Separator for header">
+</div>
+    <section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+      <p> A large percentage of the data published on the Web is tabular data, commonly published as
+        comma separated values (CSV) files. The <a href="http://www.w3.org/2013/csvw/">CSV on the Web Working Group</a> aim to specify
+        technologies that provide greater interoperability for data dependent applications on the
+        Web when working with tabular datasets comprising single or multiple files using CSV, or
+        similar, format. </p>
+      <p> This document lists the use cases compiled by the Working Group that are considered
+        representative of how tabular data is commonly used within data dependent applications. The
+        use cases observe existing common practice undertaken when working with tabular data, often
+        illustrating shortcomings or limitations of existing formats or technologies. This document
+        also provides a set of requirements derived from these use cases that have been used to
+        guide the specification design. </p>
+    </section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+
+
+
+        <p>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+        </p>
+
+
+
+      <p> This is a draft document which may be merged into another document or eventually make its
+        way into being a standalone Working Draft. </p>
+
+
+
+          <p>
+            This document was published by the <a href="http://www.w3.org/2013/csvw/">CSV on the Web Working Group</a> as a Working Group Note.
+
+
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-csv-wg@w3.org">public-csv-wg@w3.org</a>
+              (<a href="mailto:public-csv-wg-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-csv-wg/">archives</a>).
+
+
+
+
+
+
+              All comments are welcome.
+
+
+          </p>
+
+
+
+
+            <p>
+              Publication as a Working Group Note does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+
+
+
+            <p>
+
+                This document was produced by
+
+                a group
+                 operating under the
+                <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+                Policy</a>.
+
+
+
+
+                  <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/68238/status" rel="disclosure">public list of any patent
+                  disclosures</a>
+
+                made in connection with the deliverables of
+
+                the group; that page also includes
+
+                instructions for disclosing a patent. An individual who has actual knowledge of a patent
+                which the individual believes contains
+                <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+                Claim(s)</a> must disclose the information in accordance with
+                <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+                6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+
+
+            </p>
+
+            <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+
+
+
+
+
+
+</section><section id="toc"><h2 resource="#h-toc" id="h-toc" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#intro"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a class="tocxref" href="#uc"><span class="secno">2. </span>Use Cases</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#UC-DigitalPreservationOfGovernmentRecords"><span class="secno">2.1 </span>Use Case #1 - Digital preservation of government records</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfNationalStatistics"><span class="secno">2.2 </span>Use Case #2 - Publication of National Statistics</a></li><li class="tocline"><a class="tocxref" href="#UC-SurfaceTemperatureDatabank"><span class="secno">2.3 </span>Use Case #3 - Creation of consolidated global land surface temperature climate
+          databank</a></li><li class="tocline"><a class="tocxref" href="#UC-OrganogramData"><span class="secno">2.4 </span>Use Case #4 - Publication of public sector roles and salaries</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfPropertyTransactionData"><span class="secno">2.5 </span>Use Case #5 - Publication of property transaction data</a></li><li class="tocline"><a class="tocxref" href="#UC-JournalArticleSearch"><span class="secno">2.6 </span>Use Case #6 - Journal Article Solr Search Results </a></li><li class="tocline"><a class="tocxref" href="#UC-ReliabilityAnalyzesOfPoliceOpenData"><span class="secno">2.7 </span>Use Case #7 - Reliability Analyzes of Police Open Data</a></li><li class="tocline"><a class="tocxref" href="#UC-AnalyzingScientificSpreadsheets"><span class="secno">2.8 </span>Use Case #8 - Analyzing Scientific Spreadsheets</a></li><li class="tocline"><a class="tocxref" href="#UC-ChemicalImaging"><span class="secno">2.9 </span>Use Case #9 - Chemical Imaging</a></li><li class="tocline"><a class="tocxref" href="#UC-OpenSpendingData"><span class="secno">2.10 </span>Use Case #10 - OpenSpending Data</a></li><li class="tocline"><a class="tocxref" href="#UC-PaloAltoTreeData"><span class="secno">2.11 </span>Use Case #11 - City of Palo Alto Tree Data</a></li><li class="tocline"><a class="tocxref" href="#UC-ChemicalStructures"><span class="secno">2.12 </span>Use Case #12 - Chemical Structures</a></li><li class="tocline"><a class="tocxref" href="#UC-RepresentingEntitiesAndFactsExtractedFromText"><span class="secno">2.13 </span>Use Case #13 - Representing Entities and Facts Extracted From Text</a></li><li class="tocline"><a class="tocxref" href="#UC-DisplayingLocationsOfCareHomesOnAMap"><span class="secno">2.14 </span>Use Case #14 - Displaying Locations of Care Homes on a Map</a></li><li class="tocline"><a class="tocxref" href="#UC-IntelligentlyPreviewingCSVFiles"><span class="secno">2.15 </span>Use Case #15 - Intelligently Previewing CSV files</a></li><li class="tocline"><a class="tocxref" href="#UC-NetCdFcDl"><span class="secno">2.16 </span>Use Case #16 - Tabular Representations of NetCDF data Using CDL Syntax</a></li><li class="tocline"><a class="tocxref" href="#UC-CanonicalMappingOfCSV"><span class="secno">2.17 </span>Use Case #17 - Canonical mapping of CSV</a></li><li class="tocline"><a class="tocxref" href="#UC-SupportingSemantic-basedRecommendations"><span class="secno">2.18 </span>Use Case #18 - Supporting Semantic-based Recommendations</a></li><li class="tocline"><a class="tocxref" href="#UC-SupportingRightToLeftDirectionality"><span class="secno">2.19 </span>Use Case #19 - Supporting Right to Left (RTL) Directionality</a></li><li class="tocline"><a class="tocxref" href="#UC-PlatformIntegrationUsingSTDF"><span class="secno">2.20 </span>Use Case #20 - Integrating components with the TIBCO Spotfire platform using tabular data</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfBiodiversityInformation"><span class="secno">2.21 </span>Use Case #21 - Publication of Biodiversity Information from GBIF using the Darwin Core Archive Standard</a></li><li class="tocline"><a class="tocxref" href="#UC-MakingSenseOfOtherPeoplesData"><span class="secno">2.22 </span>Use Case #22 - Making sense of other people's data</a></li><li class="tocline"><a class="tocxref" href="#UC-CollatingHumanitarianResponseInformation"><span class="secno">2.23 </span>Use Case #23 - Collating humanitarian information for crisis response</a></li><li class="tocline"><a class="tocxref" href="#UC-ExpressingHierarchyWithinOccupationalListings"><span class="secno">2.24 </span>Use Case #24 - Expressing a hierarchy within occupational listings</a></li><li class="tocline"><a class="tocxref" href="#UC-ConsistentPublicationOfLocalAuthorityData"><span class="secno">2.25 </span>Use Case #25 - Consistent publication of local authority data</a></li></ul></li><li class="tocline"><a class="tocxref" href="#req"><span class="secno">3. </span>Requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#acc-req"><span class="secno">3.1 </span>Accepted requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#acc-req-parsing"><span class="secno">3.1.1 </span>CSV parsing requirements</a></li><li class="tocline"><a class="tocxref" href="#acc-req-application"><span class="secno">3.1.2 </span>Applications requirements</a></li><li class="tocline"><a class="tocxref" href="#acc-req-data-model"><span class="secno">3.1.3 </span>Data model requirements</a></li></ul></li><li class="tocline"><a class="tocxref" href="#p-acc-req"><span class="secno">3.2 </span>Partially accepted requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#p-acc-req-data-model"><span class="secno">3.2.1 </span>Data model requirements</a></li></ul></li><li class="tocline"><a class="tocxref" href="#deferred-req"><span class="secno">3.3 </span>Deferred requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#deferred-req-parsing"><span class="secno">3.3.1 </span>CSV parsing requirements</a></li><li class="tocline"><a class="tocxref" href="#deferred-req-applications"><span class="secno">3.3.2 </span>Applications requirements</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><span class="secno">A. </span>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#changes"><span class="secno">B. </span>Changes since previous versions</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#changes-since-working-draft-of-01-july-2014"><span class="secno">B.1 </span>Changes since working draft of 01 July 2014</a></li><li class="tocline"><a class="tocxref" href="#changes-since-first-public-working-draft-of-27-march-2014"><span class="secno">B.2 </span>Changes since first public working draft of 27 March 2014</a></li></ul></li><li class="tocline"><a class="tocxref" href="#references"><span class="secno">C. </span>References</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">C.1 </span>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><span class="secno">C.2 </span>Informative references</a></li></ul></li></ul></section>
+
+    <section>
+        [CONTENT]
+    </section>
+
+</body></html>

--- a/test/docs/sotd/note-deliverer.html
+++ b/test/docs/sotd/note-deliverer.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" typeof="bibo:Document w3p:NOTE" prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
+<head><meta property="dc:language" content="en" lang="">
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>CSV on the Web: Use Cases and Requirements</title>
+<link href="https://www.w3.org/StyleSheets/TR/W3C-WG-NOTE" rel="stylesheet"></head>
+  <body id="respecDocument" role="document" class="h-entry"><div id="respecHeader" role="contentinfo" class="head">
+  <p>
+
+
+            <a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a>
+
+
+
+
+  </p>
+  <h1 class="title p-name" id="title" property="dcterms:title">CSV on the Web: Use Cases and Requirements</h1>
+
+  <h2 id="w3c-working-group-note-25-february-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Working Group Note <time property="dcterms:issued" class="dt-published" datetime="2016-02-25">25 February 2016</time></h2>
+  <dl>
+
+      <dt>This version:</dt>
+      <dd><a class="u-url" href="https://www.w3.org/TR/2016/NOTE-csvw-ucr-20160225/">https://www.w3.org/TR/2016/NOTE-csvw-ucr-20160225/</a></dd>
+      <dt>Latest published version:</dt>
+      <dd><a href="https://www.w3.org/TR/csvw-ucr/">https://www.w3.org/TR/csvw-ucr/</a></dd>
+
+
+      <dt>Latest editor's draft:</dt>
+      <dd><a href="http://w3c.github.io/csvw/use-cases-and-requirements/">http://w3c.github.io/csvw/use-cases-and-requirements/</a></dd>
+
+
+
+
+
+
+      <dt>Previous version:</dt>
+      <dd><a rel="dcterms:replaces" href="https://www.w3.org/TR/2014/WD-csvw-ucr-20140701/">https://www.w3.org/TR/2014/WD-csvw-ucr-20140701/</a></dd>
+
+
+    <dt>Editors:</dt>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jeremy Tandy</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.metoffice.gov.uk/">Met Office</a></span>
+<span property="rdf:rest" resource="_:editor1"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Davide Ceolin</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.vu.nl">VU University Amsterdam</a></span>
+<span property="rdf:rest" resource="_:editor2"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Eric Stephan</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.pnnl.gov">Pacific Northwest National Laboratory</a></span>
+<span property="rdf:rest" resource="rdf:nil"></span>
+</dd>
+
+
+
+
+
+          <dt>Repository:</dt>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw">
+                      We are on GitHub
+                    </a>
+                  </dd>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw">
+                      File a bug
+                    </a>
+                  </dd>
+
+
+
+
+
+
+          <dt>Changes:</dt>
+
+
+
+                  <dd>
+                    <a href="diff.html">
+                      Diff to previous version
+                    </a>
+                  </dd>
+
+
+
+                  <dd>
+                    <a href="https://github.com/w3c/csvw/commits/gh-pages">
+                      Commit history
+                    </a>
+                  </dd>
+
+
+
+
+
+
+  </dl>
+
+
+    <p>
+
+        This document is also available in this non-normative format:
+
+      <a rel="alternate" href="csvw-ucr.epub">ePub</a>
+    </p>
+
+
+
+
+      <p class="copyright">
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        2016
+
+        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+
+
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+
+
+        rules apply.
+      </p>
+
+
+  <hr title="Separator for header">
+</div>
+    <section property="dc:abstract" class="introductory" id="abstract"><h2 resource="#h-abstract" id="h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+      <p> A large percentage of the data published on the Web is tabular data, commonly published as
+        comma separated values (CSV) files. The <a href="http://www.w3.org/2013/csvw/">CSV on the Web Working Group</a> aim to specify
+        technologies that provide greater interoperability for data dependent applications on the
+        Web when working with tabular datasets comprising single or multiple files using CSV, or
+        similar, format. </p>
+      <p> This document lists the use cases compiled by the Working Group that are considered
+        representative of how tabular data is commonly used within data dependent applications. The
+        use cases observe existing common practice undertaken when working with tabular data, often
+        illustrating shortcomings or limitations of existing formats or technologies. This document
+        also provides a set of requirements derived from these use cases that have been used to
+        guide the specification design. </p>
+    </section><section id="sotd" class="introductory"><h2 resource="#h-sotd" id="h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+
+
+
+        <p>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+        </p>
+
+
+
+      <p> This is a draft document which may be merged into another document or eventually make its
+        way into being a standalone Working Draft. </p>
+
+
+
+          <p>
+            This document was published by the <a href="http://www.w3.org/2013/csvw/">CSV on the Web Working Group</a> as a Working Group Note.
+
+
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-csv-wg@w3.org">public-csv-wg@w3.org</a>
+              (<a href="mailto:public-csv-wg-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-csv-wg/">archives</a>).
+
+
+
+
+
+
+              All comments are welcome.
+
+
+          </p>
+
+
+
+
+            <p>
+              Publication as a Working Group Note does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+
+
+
+          <p data-deliverer="68238">
+
+              This document was produced by
+
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+          </p>
+
+            <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+
+
+
+
+
+
+</section><section id="toc"><h2 resource="#h-toc" id="h-toc" class="introductory"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul role="directory" class="toc"><li class="tocline"><a class="tocxref" href="#intro"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a class="tocxref" href="#uc"><span class="secno">2. </span>Use Cases</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#UC-DigitalPreservationOfGovernmentRecords"><span class="secno">2.1 </span>Use Case #1 - Digital preservation of government records</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfNationalStatistics"><span class="secno">2.2 </span>Use Case #2 - Publication of National Statistics</a></li><li class="tocline"><a class="tocxref" href="#UC-SurfaceTemperatureDatabank"><span class="secno">2.3 </span>Use Case #3 - Creation of consolidated global land surface temperature climate
+          databank</a></li><li class="tocline"><a class="tocxref" href="#UC-OrganogramData"><span class="secno">2.4 </span>Use Case #4 - Publication of public sector roles and salaries</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfPropertyTransactionData"><span class="secno">2.5 </span>Use Case #5 - Publication of property transaction data</a></li><li class="tocline"><a class="tocxref" href="#UC-JournalArticleSearch"><span class="secno">2.6 </span>Use Case #6 - Journal Article Solr Search Results </a></li><li class="tocline"><a class="tocxref" href="#UC-ReliabilityAnalyzesOfPoliceOpenData"><span class="secno">2.7 </span>Use Case #7 - Reliability Analyzes of Police Open Data</a></li><li class="tocline"><a class="tocxref" href="#UC-AnalyzingScientificSpreadsheets"><span class="secno">2.8 </span>Use Case #8 - Analyzing Scientific Spreadsheets</a></li><li class="tocline"><a class="tocxref" href="#UC-ChemicalImaging"><span class="secno">2.9 </span>Use Case #9 - Chemical Imaging</a></li><li class="tocline"><a class="tocxref" href="#UC-OpenSpendingData"><span class="secno">2.10 </span>Use Case #10 - OpenSpending Data</a></li><li class="tocline"><a class="tocxref" href="#UC-PaloAltoTreeData"><span class="secno">2.11 </span>Use Case #11 - City of Palo Alto Tree Data</a></li><li class="tocline"><a class="tocxref" href="#UC-ChemicalStructures"><span class="secno">2.12 </span>Use Case #12 - Chemical Structures</a></li><li class="tocline"><a class="tocxref" href="#UC-RepresentingEntitiesAndFactsExtractedFromText"><span class="secno">2.13 </span>Use Case #13 - Representing Entities and Facts Extracted From Text</a></li><li class="tocline"><a class="tocxref" href="#UC-DisplayingLocationsOfCareHomesOnAMap"><span class="secno">2.14 </span>Use Case #14 - Displaying Locations of Care Homes on a Map</a></li><li class="tocline"><a class="tocxref" href="#UC-IntelligentlyPreviewingCSVFiles"><span class="secno">2.15 </span>Use Case #15 - Intelligently Previewing CSV files</a></li><li class="tocline"><a class="tocxref" href="#UC-NetCdFcDl"><span class="secno">2.16 </span>Use Case #16 - Tabular Representations of NetCDF data Using CDL Syntax</a></li><li class="tocline"><a class="tocxref" href="#UC-CanonicalMappingOfCSV"><span class="secno">2.17 </span>Use Case #17 - Canonical mapping of CSV</a></li><li class="tocline"><a class="tocxref" href="#UC-SupportingSemantic-basedRecommendations"><span class="secno">2.18 </span>Use Case #18 - Supporting Semantic-based Recommendations</a></li><li class="tocline"><a class="tocxref" href="#UC-SupportingRightToLeftDirectionality"><span class="secno">2.19 </span>Use Case #19 - Supporting Right to Left (RTL) Directionality</a></li><li class="tocline"><a class="tocxref" href="#UC-PlatformIntegrationUsingSTDF"><span class="secno">2.20 </span>Use Case #20 - Integrating components with the TIBCO Spotfire platform using tabular data</a></li><li class="tocline"><a class="tocxref" href="#UC-PublicationOfBiodiversityInformation"><span class="secno">2.21 </span>Use Case #21 - Publication of Biodiversity Information from GBIF using the Darwin Core Archive Standard</a></li><li class="tocline"><a class="tocxref" href="#UC-MakingSenseOfOtherPeoplesData"><span class="secno">2.22 </span>Use Case #22 - Making sense of other people's data</a></li><li class="tocline"><a class="tocxref" href="#UC-CollatingHumanitarianResponseInformation"><span class="secno">2.23 </span>Use Case #23 - Collating humanitarian information for crisis response</a></li><li class="tocline"><a class="tocxref" href="#UC-ExpressingHierarchyWithinOccupationalListings"><span class="secno">2.24 </span>Use Case #24 - Expressing a hierarchy within occupational listings</a></li><li class="tocline"><a class="tocxref" href="#UC-ConsistentPublicationOfLocalAuthorityData"><span class="secno">2.25 </span>Use Case #25 - Consistent publication of local authority data</a></li></ul></li><li class="tocline"><a class="tocxref" href="#req"><span class="secno">3. </span>Requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#acc-req"><span class="secno">3.1 </span>Accepted requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#acc-req-parsing"><span class="secno">3.1.1 </span>CSV parsing requirements</a></li><li class="tocline"><a class="tocxref" href="#acc-req-application"><span class="secno">3.1.2 </span>Applications requirements</a></li><li class="tocline"><a class="tocxref" href="#acc-req-data-model"><span class="secno">3.1.3 </span>Data model requirements</a></li></ul></li><li class="tocline"><a class="tocxref" href="#p-acc-req"><span class="secno">3.2 </span>Partially accepted requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#p-acc-req-data-model"><span class="secno">3.2.1 </span>Data model requirements</a></li></ul></li><li class="tocline"><a class="tocxref" href="#deferred-req"><span class="secno">3.3 </span>Deferred requirements</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#deferred-req-parsing"><span class="secno">3.3.1 </span>CSV parsing requirements</a></li><li class="tocline"><a class="tocxref" href="#deferred-req-applications"><span class="secno">3.3.2 </span>Applications requirements</a></li></ul></li></ul></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><span class="secno">A. </span>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#changes"><span class="secno">B. </span>Changes since previous versions</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#changes-since-working-draft-of-01-july-2014"><span class="secno">B.1 </span>Changes since working draft of 01 July 2014</a></li><li class="tocline"><a class="tocxref" href="#changes-since-first-public-working-draft-of-27-march-2014"><span class="secno">B.2 </span>Changes since first public working draft of 27 March 2014</a></li></ul></li><li class="tocline"><a class="tocxref" href="#references"><span class="secno">C. </span>References</a><ul class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><span class="secno">C.1 </span>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><span class="secno">C.2 </span>Informative references</a></li></ul></li></ul></section>
+
+    <section>
+        [CONTENT]
+    </section>
+
+</body></html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -316,6 +316,7 @@ var tests = {
               , errors: ["sotd.pp"]
             }
         ,   { doc: "headers/ig-note.html", config: { longStatus: "Interest Group Note" } }
+        ,   { doc: "headers/wg-note.html", config: { longStatus: "Working Group Note" } }
         ]
     ,   "charter-disclosure":  [
             { doc: "headers/ig-note.html" }

--- a/test/rules.js
+++ b/test/rules.js
@@ -61,7 +61,9 @@ const compareMetadata = function(url, file, expectedObject) {
     ,   handler = new sink.Sink(function(data) { throw new Error(data); })
     ,   thisFile = file ? 'test/docs/metadata/' + file + '.html' : null
     ;
-    const opts = {events: handler, url: url, file: thisFile};
+    // const opts = {events: handler, url: url, file: thisFile};
+    // test only local fixtures
+    const opts = {events: handler, file: thisFile};
 
     it('Should detect metadata for ' + expectedObject.url, function (done) {
         handler.on('end-all', function () {

--- a/test/rules.js
+++ b/test/rules.js
@@ -368,6 +368,10 @@ var tests = {
     ,       { doc: "sotd/rec-rescind.html", config: { obsoletes: true }, errors: ['sotd.obsl-rescind'] }
     ,       { doc: "sotd/rec-obsl.html", config: { rescinds: true }, errors: ['sotd.obsl-rescind'] }
         ]
+    ,   'deliverer-note':  [
+            { doc: "sotd/note-deliverer.html", config: { status: "WG-NOTE" }}
+    ,       { doc: "sotd/note-deliverer-bad.html", config: { status: "WG-NOTE" }, errors: ['sotd.deliverer-note'] }
+        ]
     }
 ,   heuristic:   {
         'date-format':  [


### PR DESCRIPTION
Based on a discussion with @wseltzer .

New wording for WG Note should only be:
[[
This document was produced by a group operating under the W3C Patent Policy.
]]

(and nothing else following)
