### PR TITLE
Mention w3.org/pubrules API endpoint in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Similar to the [JS API](#4-js-api), Specberus exposes a REST API via HTTP too.
 The endpoint is `<host>/api/`.
 Use either `url` or `file` to pass along the document (neither `source` nor `document` are allowed).
 
-Note: If you want to use the public W3C instance of Specberus, you can replace `<host>` with `https://www.w3.org/pubrules/`.
+Note: If you want to use the public W3C instance of Specberus, you can replace `<host>` with `https://www.w3.org/pubrules`.
 
 There are three `GET` methods available.
 

--- a/views/help.handlebars
+++ b/views/help.handlebars
@@ -14,7 +14,10 @@
     <p>[@TODO]</p>
 
     <h3 id="reference"><a href="#reference">Reference (manual use and <abbr title="Application Programming Interface">API</abbr>)</a></h3>
-    <p>[@TODO]</p>
+    <ul>
+      <li>See the <a href="https://github.com/w3c/specberus/blob/master/README.md">README</a></li>
+      <li>REST API endpoint: <a href="{{BASE_URI}}api/"><code>{{BASE_URI}}api/</code></a></li>
+    </ul>
 
     <h3 id="channels"><a href="#channels">Channels</a></h3>
     <ul>

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -122,5 +122,8 @@
 </div>
 
 <div class="alert alert-info" role="alert">
-  Graphical UI's not your thing? Check out the <a href="https://github.com/w3c/specberus/blob/master/README.md#5-rest-api">REST interface of Pubrules</a>.
+  Graphical UI's not your thing? Check out the
+  <a href="https://github.com/w3c/specberus/blob/master/README.md#5-rest-api">REST interface</a>
+  against the
+  <a href="{{BASE_URI}}api/">endpoint of this instance (<code>{{BASE_URI}}api/</code>)</a>.
 </div>


### PR DESCRIPTION
Specifically, addresses https://github.com/w3c/specberus/issues/705#issuecomment-343625898

Fixes #705