### PR TITLE
Skip CSS validation for the CSS specs

### DIFF
--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -5,6 +5,11 @@
       "type": "at-rule"
     }
   ],
+  "^css.*$": [
+    {
+      "rule": "validation.css"
+    }
+  ],
   "^webrtc$": [
     {
       "rule": "headers.copyright"
@@ -13,12 +18,6 @@
   "^mediacapture-streams$": [
     {
       "rule": "headers.copyright"
-    }
-  ],
-  "^css-tables-3$": [
-    {
-      "rule": "validation.css",
-      "type": "generator.unrecognize"
     }
   ]
 }


### PR DESCRIPTION
It was suggested that we skip the CSS validation or at least ignore the errors for the CSS specs.
That PR adds that exception for all the specs with a shortname starting with `css`.

/cc @svgeesus 