### PR TITLE
fix translation recommended text

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -74,7 +74,7 @@ exports.messages = {
     // headers/translations
 ,   "headers.translations.found":                   "Translations link <a href='${link}'>found</a>."
 ,   "headers.translations.not-found":               "Translations link not found."
-,   "headers.translations.not-recommended-link":    "The recommended link is not used (<code>http[s]://[www.]w3.org/2003/03/Translations/byTechnology?technology=[shortname]</code>)"
+,   "headers.translations.not-recommended-link":    "The recommended link is not used (<code>https://[www.]w3.org/2003/03/Translations/byTechnology?technology=[shortname]</code>)"
     // headers/div-head
 ,   "headers.div-head.not-found":           "No div.head found."
     // headers/copyright


### PR DESCRIPTION
The recommended text for the translation warning doesn't match the rule.