### PR TITLE
new metadata to detect if a document was already published

### DIFF
--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -55,5 +55,22 @@ exports.check = function(sr, done) {
         result.sameWorkAs = 'https://www.w3.org/TR/'+previousShortname+'/';  // TODO use api to get the previous shortlink
     }
 
-    return done(result);
+    // check same day publications
+    var ua            = "W3C-Pubrules/" + sr.version,
+        apikey        = process.env.API_KEY,
+        docDate       = sr.getDocumentDate(),
+        year          = docDate.getFullYear(),
+        month         = (docDate.getMonth() + 1).toString(),
+        day           = (docDate.getDate()).toString(),
+        formattedDate = year + (month[1]?month:"0"+month[0]) + (day[1]?day:"0"+day[0]),
+        endpoint      = 'https://api.w3.org/specifications/' + latestShortname + '/versions/' + formattedDate,
+        sua           = require("../../throttled-ua");
+
+        var req = sua.get(endpoint)
+                     .set("User-Agent", ua);
+        req.query({apikey: apikey});
+        req.end(function(err, res) {
+          result.updated = !(err || !res.ok);
+          return done(result);
+        });
 };


### PR DESCRIPTION
That metadata will be used in Echidna to detect if it's an updated document or not.