### PR TITLE
'npm run audit': make more robust (improve regex)

### DIFF
--- a/known-vulns.txt
+++ b/known-vulns.txt
@@ -1,1 +1,1 @@
-https://nodesecurity.io/advisories/577
+577

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "5.2.0"
   },
   "scripts": {
-    "audit": "npm audit | grep -oP 'https://nodesecurity.io/advisories/(\\d+)' | diff known-vulns.txt -",
+    "audit": "npm audit | grep -oE 'https?\\:\\/\\/(www\\.)?(nodesecurity\\.io|npmjs\\.com)\\/advisories\\/[[:digit:]]+' | rev | cut -d '/' -f 1 | rev | diff known-vulns.txt -",
     "lint": "eslint app.js lib/ public/ test/ tools/",
     "hint": "jshint app.js lib/ public/ test/ tools/",
     "test": "mocha",


### PR DESCRIPTION
The issue was a recent switch from vulns of the form
`https://nodesecurity.io/advisories/xxx`
to
`https://npmjs.com/advisories/xxx`
:P

This should fix it.

Closes #796 