### PR TITLE
Prevent exception on null values

### DIFF
--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -14,6 +14,17 @@ const previousRule = {
 ,   rule: 'docIDFormat'
 };
 
+function getHref($link) {
+    return ($link && $link.attr('href') || '').trim();
+}
+
+function getFirstLink(header) {
+    if (header && header.dd) {
+        return header.dd.find("a").first();
+    }
+    return null;
+}
+
 exports.name = "metadata.dl";
 
 exports.check = function(sr, done) {
@@ -23,33 +34,33 @@ exports.check = function(sr, done) {
     ,   previousShortname
     ,   latestShortname;
 
-    var $linkThis = (dts.This) ? dts.This.dd.find("a").first() : null;
+    var $linkThis = getFirstLink(dts.This);
     if ($linkThis && $linkThis.length)
-      result.thisVersion = $linkThis.attr('href').trim();
+      result.thisVersion = getHref($linkThis);
 
-    var $linkLate = (dts.Latest) ? dts.Latest.dd.find("a").first() : null;
+    var $linkLate = getFirstLink(dts.Latest);
     if ($linkLate && $linkLate.length) {
-        result.latestVersion = $linkLate.attr('href').trim();
-        var latestRegex = $linkLate.attr("href").trim().match(new RegExp(/.*\/([^/]+)\/$/));
+        var lateHref = result.latestVersion = getHref($linkLate);
+        var latestRegex = lateHref.match(new RegExp(/.*\/([^/]+)\/$/));
         if (latestRegex && latestRegex.length > 0)
             latestShortname = latestRegex[1];
         else
             sr.error(latestRule, 'latest-not-found');
     }
 
-    var $linkPrev = (dts.Previous) ? dts.Previous.dd.find("a").first() : null;
+    var $linkPrev = getFirstLink(dts.Previous);
     if ($linkPrev && $linkPrev.length) {
-        result.previousVersion = $linkPrev.attr('href').trim();
-        var previousRegex = $linkPrev.attr("href").trim().match(new RegExp(/.*\/[^/-]+-(.*)-\d{8}\/$/));
+        var prevHref = result.previousVersion = getHref($linkPrev);
+        var previousRegex = prevHref.match(new RegExp(/.*\/[^/-]+-(.*)-\d{8}\/$/));
         if (previousRegex && previousRegex.length > 0)
             previousShortname = previousRegex[1];
         else
             sr.error(previousRule, 'previous-not-found');
     }
 
-    var $linkEd = (dts.EditorDraft) ? dts.EditorDraft.dd.find("a").first() : null;
+    var $linkEd = getFirstLink(dts.EditorDraft);
     if ($linkEd && $linkEd.length)
-        result.editorsDraft = $linkEd.attr('href').trim();
+        result.editorsDraft = getHref($linkEd);
 
     if (previousShortname && latestShortname && previousShortname !== latestShortname) {
         result.sameWorkAs = 'https://www.w3.org/TR/'+previousShortname+'/';  // TODO use api to get the previous shortlink


### PR DESCRIPTION
If `href` accepts an empty value, these changes should fix #820. 