### PR TITLE
webauthn-2 use markup in its <h1> element

### DIFF
--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -36,7 +36,7 @@
   ],
   "^webauthn-2$": [
     {
-      "rule": "metadata.title"
+      "rule": "headers.h1-title"
     }
   ],
   "^did-core$": [

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -34,6 +34,11 @@
       "rule": "headers.copyright"
     }
   ],
+  "^webauthn-2$": [
+    {
+      "rule": "metadata.title"
+    }
+  ],
   "^did-core$": [
     {
       "rule": "heuristic.date-format"


### PR DESCRIPTION
[[
Content of title and h1 do not match.
The document's title must be in the title element and in an h1 element.
]]
from [pubrules](https://www.w3.org/pubrules/?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2019%2FWD-webauthn-2-20191126%2F&profile=WD&validation=simple-validation&noRecTrack=false&informativeOnly=false&echidnaReady=false&patentPolicy=pp2004)

cc @akshayku @wseltzer