### PR TITLE
flatten event params for err, warning and info

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -70,8 +70,8 @@ const processRequest = function(req, res) {
         if (validate && 'auto' === options.profile) {
             errors = [];
             v = new validator.Specberus();
-            handler = new Sink(function(data) {
-                errors.push(data);
+            handler = new Sink(function(...data) {
+                errors.push(Object.assign({}, ...data));
             }, function(data) {
                 if (errors.length > 0)
                     sendJSONresult(errors, [], [], res, {});
@@ -97,14 +97,14 @@ const processRequest = function(req, res) {
                     warnings2 = [];
                     info2 = [];
                     v2 = new validator.Specberus();
-                    handler2 = new Sink(function(data2) {
-                        errors2.push(data2);
+                    handler2 = new Sink(function(...data2) {
+                        errors2.push(Object.assign({}, ...data2));
                     }, function() {
                         sendJSONresult(errors2, warnings2, info2, res, meta);
-                    }, function(data2) {
-                        warnings2.push(data2);
-                    }, function(data2) {
-                        info2.push(data2);
+                    }, function(...data2) {
+                        warnings2.push(Object.assign({}, ...data2));
+                    }, function(...data2) {
+                        info2.push(Object.assign({}, ...data2));
                     });
                     options2.events = handler2;
                     v2.validate(options2);
@@ -121,14 +121,14 @@ const processRequest = function(req, res) {
             warnings = [];
             info = [];
             v = new validator.Specberus();
-            handler = new Sink(function(data) {
-                errors.push(data);
+            handler = new Sink(function(...data) {
+                errors.push(Object.assign({}, ...data));
             }, function(data) {
                 sendJSONresult(errors, warnings, info, res, data.metadata);
-            }, function(data) {
-                warnings.push(data);
-            }, function(data) {
-                info.push(data);
+            }, function(...data) {
+                warnings.push(Object.assign({}, ...data));
+            }, function(...data) {
+                info.push(Object.assign({}, ...data));
             });
             handler.on('exception', function(data) {
                 sendJSONresult([data.message ? data.message : data], [], [], res, {});

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -25,7 +25,7 @@ var Sink = function(error, done, warn, inf) {
 
     if(error) {
         this.on('exception', function (data) { error(data); });
-        this.on('err', function (data) { error(data); });
+        this.on('err', function (...data) { error(...data); });
     }
 
     if(done) {
@@ -33,11 +33,11 @@ var Sink = function(error, done, warn, inf) {
     }
 
     if(warn) {
-        this.on('warning', function (data) { warn(data); });
+        this.on('warning', function (...data) { warn(...data); });
     }
 
     if(inf) {
-        this.on('info', function (data) { inf(data); });
+        this.on('info', function (...data) { inf(...data); });
     }
 
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -103,9 +103,9 @@ Specberus.prototype.validate = function (options) {
     var errors = [];
     var warnings = [];
     var infos = [];
-    self.sink.on('err', function (...data) { errors.push(Object.assign(...data)); });
-    self.sink.on('warning', function (...data) { warnings.push(Object.assign(...data)); });
-    self.sink.on('info', function (...data) { infos.push(Object.assign(...data)); });
+    self.sink.on('err', function (...data) { errors.push(Object.assign({}, ...data)); });
+    self.sink.on('warning', function (...data) { warnings.push(Object.assign({}, ...data)); });
+    self.sink.on('info', function (...data) { infos.push(Object.assign({}, ...data)); });
     var doValidation = function (err, query) {
         if (err) return self.throw(err);
         self.$ = query;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -103,9 +103,9 @@ Specberus.prototype.validate = function (options) {
     var errors = [];
     var warnings = [];
     var infos = [];
-    self.sink.on('err', function (data) { errors.push(data); });
-    self.sink.on('warning', function (data) { warnings.push(data); });
-    self.sink.on('info', function (data) { infos.push(data); });
+    self.sink.on('err', function (...data) { errors.push(Object.assign(...data)); });
+    self.sink.on('warning', function (...data) { warnings.push(Object.assign(...data)); });
+    self.sink.on('info', function (...data) { infos.push(Object.assign(...data)); });
     var doValidation = function (err, query) {
         if (err) return self.throw(err);
         self.$ = query;


### PR DESCRIPTION
suggedted by @sidvishnoi in https://github.com/w3c/specberus/issues/706.

We actually rely on the 2 `emit` params for the documentation so I ended up merging both of them in the listeners.
Does that solve your issue @sidvishnoi ?