### PR TITLE
chore: Add GitHub Action Dependabot bumping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,11 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: '10:00'
+    time: "10:00"
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Will bump GitHub Actions version like `actions/setup-node` to later versions on the same schedule as the other Dependabot updates