### PR TITLE
Add post checkout hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm run hint && npm run cspell"
+      "pre-commit": "npm run lint && npm run hint && npm run cspell",
+      "post-checkout": "echo \"\\033[36mAuto installing dependencies after checkout...\\033[0m\"  && npm i"
     }
   },
   "engines": {


### PR DESCRIPTION
Every time we `git checkout` a branch, running `npm i` will keep our dependencies up-to-date. 

But maybe should also run when 'git pull' when dependencies in packages.json change. [This question on stackoverflow](https://stackoverflow.com/questions/52466740/npm-install-if-package-json-was-modified) also tries to solve this problem.