### PR TITLE
title: format title containing <br>

### DIFF
--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -49,11 +49,6 @@
       "rule": "headers.copyright"
     }
   ],
-  "^webauthn-2$": [
-    {
-      "rule": "headers.h1-title"
-    }
-  ],
   "^audiobooks$": [
     {
       "rule": "sotd.cr-end"

--- a/lib/rules/headers/h1-title.js
+++ b/lib/rules/headers/h1-title.js
@@ -12,7 +12,7 @@ exports.check = function (sr, done) {
     var title = sr.jsDocument.querySelector("head > title")
     ,   h1 = sr.jsDocument.querySelector("body div.head h1")
     ;
-    if (!title || !h1 || sr.norm(title.textContent) !== sr.norm(h1.textContent)) {
+    if (!title || !h1 || sr.norm(title.textContent) !== sr.norm(h1.innerHTML.replace(/:<br>/g, ": ").replace(/<br>/g, " - "))) {
         sr.error(self, "title");
     }
     done();

--- a/lib/rules/metadata/title.js
+++ b/lib/rules/metadata/title.js
@@ -8,9 +8,10 @@ exports.name = "metadata.title";
 
 exports.check = function(sr, done) {
     var title = sr.jsDocument.querySelector("body div.head h1");
+    ;
     if (!title) {
         return done();
     } else {
-        return done({title: sr.norm(title.textContent)});
+        return done({title: sr.norm(title.innerHTML.replace(/:<br>/g, ": ").replace(/<br>/g, " - "))});
     }
 };


### PR DESCRIPTION
Some specs (eg. [webauthn-2](https://www.w3.org/TR/2020/WD-webauthn-2-20201116/) have titles contains breaking lines. jsdom simply strips them which breaks the title scrapping.
The PR tries to format the title correctly.