### PR TITLE
chore: Add eslint-plugin-jsdoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,8 +19,11 @@
         "lib/**/*.js",
         "tools/**/*.js"
       ],
-      "plugins": ["node"],
-      "extends": "plugin:node/recommended"
+      "plugins": ["node", "jsdoc"],
+      "extends": [
+        "plugin:node/recommended",
+        "plugin:jsdoc/recommended"
+      ]
     },
     {
       "files": [

--- a/lib/api.js
+++ b/lib/api.js
@@ -19,8 +19,8 @@ const Sink = sink.Sink
  * @param {Array} err - errors.
  * @param {Array} warn - warnings.
  * @param {Array} inf - informative messages.
- * @param {Object} res - Express HTTP response.
- * @param {Object} metadata - dictionary with some found metadata.
+ * @param {object} res - Express HTTP response.
+ * @param {object} metadata - dictionary with some found metadata.
  */
 
 const sendJSONresult = function(err, warn, inf, res, metadata) {
@@ -33,8 +33,8 @@ const sendJSONresult = function(err, warn, inf, res, metadata) {
 /**
  * Handle an API request: parse method and parameters, handle common errors and call the validator.
  *
- * @param {Object} req - Express HTTP request.
- * @param {Object} res - Express HTTP response.
+ * @param {object} req - Express HTTP request.
+ * @param {object} res - Express HTTP response.
  */
 
 const processRequest = function(req, res) {

--- a/lib/l10n.js
+++ b/lib/l10n.js
@@ -24,7 +24,7 @@ for (var t in originalRules)
 /**
  * Set a locale to be used globally by this module.
  *
- * @param {String} language - locale, expressed as a string, eg <code>en_GB</code>.
+ * @param {string} language - locale, expressed as a string, eg <code>en_GB</code>.
  */
 
 exports.setLanguage = function(language) {

--- a/lib/rules/style/meta.js
+++ b/lib/rules/style/meta.js
@@ -1,7 +1,7 @@
 /**
-* Check the presence of this <code>meta</code> tag in the head of the page:
-* <code>&lt;meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"&gt;</code>
-*/
+ * Check the presence of this <code>meta</code> tag in the head of the page:
+ * <code>&lt;meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"&gt;</code>
+ */
 
 const self = {
   name: 'style.meta'

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,7 @@ const files1 = fs.readdirSync(`${__dirname}/profiles/TR/`),
  * @param {Array} err - errors.
  * @param {Array} warn - warnings.
  * @param {Array} inf - informative messages.
- * @param {Object} metadata - dictionary with some found metadata.
+ * @param {object} metadata - dictionary with some found metadata.
  */
 
 const buildJSONresult = function(err, warn, inf, metadata) {
@@ -32,7 +32,7 @@ const buildJSONresult = function(err, warn, inf, metadata) {
 /**
  * Build a function that builds an “options” object based on certain parameters.
  *
- * @param {Object} profiles - valid profiles.
+ * @param {object} profiles - valid profiles.
  *
  * @returns {Function} a function that builds an “options” object based on an HTTP query string or a similar object containing options.
  */
@@ -49,11 +49,11 @@ const buildProcessParamsFunction = function(profiles) {
      *     "allowUnknownParams": true
      * }</pre>/blockquote>
      *
-     * @param {Object} params - an HTTP request query, or a similar object.
-     * @param {Object} base - (<strong>optional</strong>) a template or “base” object to build from.
-     * @param {Object} constraints - (<strong>optional</strong>) an object listing “required” and/or “forbidden” parameters.
+     * @param {object} params - an HTTP request query, or a similar object.
+     * @param {object} base - (<strong>optional</strong>) a template or “base” object to build from.
+     * @param {object} constraints - (<strong>optional</strong>) an object listing “required” and/or “forbidden” parameters.
      *
-     * @returns {Object} an “options” object that can be used by Specberus.
+     * @returns {object} an “options” object that can be used by Specberus.
      *
      * @throws {Error} if there is an error in the parameters.
      */

--- a/lib/views.js
+++ b/lib/views.js
@@ -157,7 +157,7 @@ const retrieveProfile = function(query) {
 /**
  * Set up HTML views using templates and Express Handlebars.
  *
- * @param {Object} app - the Express application.
+ * @param {object} app - the Express application.
  */
 
 const setUp = function(app) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai-as-promised": "7.1.1",
     "cspell": "4.2.2",
     "eslint": "7.14.0",
+    "eslint-plugin-jsdoc": "^30.7.8",
     "eslint-plugin-node": "11.1.0",
     "expect.js": "0.3",
     "husky": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai-as-promised": "7.1.1",
     "cspell": "4.2.2",
     "eslint": "7.14.0",
-    "eslint-plugin-jsdoc": "^30.7.8",
+    "eslint-plugin-jsdoc": "30.7.8",
     "eslint-plugin-node": "11.1.0",
     "expect.js": "0.3",
     "husky": "^4.2.5",


### PR DESCRIPTION
- Only added for the server-side JS files
- It can cleanup and stub in a bunch of the `@TODO` functions by running `npm run lint -- --fix`, but it would increase the number of warnings since it can't auto fix the type or a description