### PR TITLE
chore: Pull JS linting to separate CI job

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -1,0 +1,35 @@
+name: Lint JS
+
+on:
+  push:
+    paths:
+      - "**/*.js"
+      - "jsdoc.json"
+      - "package.json"
+  pull_request:
+    paths:
+      - "**/*.js"
+      - "jsdoc.json"
+      - "package.json"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2.1.2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - run: npm install
+
+    - run: npm run lint
+
+    - run: npm run hint
+
+    - run: npm run jsdoc

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,7 @@
 name: Specberus tests
 
 on:
-  push
+  push:
 
 jobs:
   test:
@@ -20,12 +20,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - run: npm install
-
-    - run: npm run lint
-
-    - run: npm run hint
-
-    - run: npm run jsdoc
 
     - run: npm run coverage
       if: env.W3C_API_KEY != ''


### PR DESCRIPTION
Allows the linting to run for external forks without trying to resolve the issue around the tests requiring the SECRET in the nodejs.yml job.
The JSDoc part could also probably be moved to a separate job with a smaller `paths` target, and upload the results