### PR TITLE
Report better error if the document is TR but not valid (cannot find profile)

### DIFF
--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -149,8 +149,17 @@ exports.check = async function (sr, done) {
                 'link[href^="https://www.w3.org/StyleSheets/TR/"]'
             )
         ) {
+            const { sortedProfiles } = require('../../views');
+            let profileList = '';
+            sortedProfiles.forEach((categary) => {
+                profileList += `${categary.name}<ul>`;
+                categary.profiles.forEach((profile) => {
+                    profileList += `<li>&lt;h2&gt; for <a href="./doc/rules/?profile=${profile.abbr}#dateTitleH2">${profile.name}</a></li>`;
+                });
+                profileList += '</ul>';
+            });
             sr.throw(
-                `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C @@type of the document@@ DD Month YYYY&lt;/h2&gt;</code></pre> Recommendations:<ul><li>Document for <a href="./doc/rules/?profile=FPWD#dateTitleH2">First Public Working Draft</a></li><li>Document for <a href="./doc/rules/?profile=WD#dateTitleH2">Working Draft</a></li><li>Document for <a href="./doc/rules/?profile=CR#dateTitleH2">Candidate Recommendation Snapshot</a></li><li>Document for <a href="./doc/rules/?profile=CRD#dateTitleH2">Candidate Recommendation Draft</a></li><li>Document for <a href="./doc/rules/?profile=CR-AMENDED#dateTitleH2">Candidate Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=PR#dateTitleH2">Proposed Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=PR-AMENDED#dateTitleH2">Proposed Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC#dateTitleH2">Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC-AMENDED#dateTitleH2">Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC-RSCND#dateTitleH2">Rescinded Recommendation</a></li></ul>Notes:<ul><li>Document for <a href="./doc/rules/?profile=FPIG-NOTE#dateTitleH2">First Public Interest Group Note</a></li><li>Document for <a href="./doc/rules/?profile=IG-NOTE#dateTitleH2">Interest Group Note</a></li><li>Document for <a href="./doc/rules/?profile=FPWG-NOTE#dateTitleH2">First Public Working Group Note</a></li><li>Document for <a href="./doc/rules/?profile=WG-NOTE#dateTitleH2">Working Group Note</a></li></ul>Submissions:<ul><li>Document for <a href="./doc/rules/?profile=MEM-SUBM#dateTitleH2">Member Submission</a></li></ul>`
+                `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C @@type of the document@@ DD Month YYYY&lt;/h2&gt;</code></pre>${profileList}`
             );
         } else {
             sr.throw(

--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -119,7 +119,6 @@ exports.check = async function (sr, done) {
         }
         return 'REC';
     };
-
     if (id) {
         if (/-NOTE/.test(id)) {
             checkPreviousVersion(sr).then((hasPreviousVersion) => {
@@ -151,7 +150,7 @@ exports.check = async function (sr, done) {
             )
         ) {
             sr.throw(
-                `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C (type of the document) DD Month YYYY&lt;/h2&gt;</code></pre>`
+                `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C @@type of the document@@ DD Month YYYY&lt;/h2&gt;</code></pre> Recommendations:<ul><li>Document for <a href="./doc/rules/?profile=FPWD#dateTitleH2">First Public Working Draft</a></li><li>Document for <a href="./doc/rules/?profile=WD#dateTitleH2">Working Draft</a></li><li>Document for <a href="./doc/rules/?profile=CR#dateTitleH2">Candidate Recommendation Snapshot</a></li><li>Document for <a href="./doc/rules/?profile=CRD#dateTitleH2">Candidate Recommendation Draft</a></li><li>Document for <a href="./doc/rules/?profile=CR-AMENDED#dateTitleH2">Candidate Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=PR#dateTitleH2">Proposed Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=PR-AMENDED#dateTitleH2">Proposed Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC#dateTitleH2">Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC-AMENDED#dateTitleH2">Amended Recommendation</a></li><li>Document for <a href="./doc/rules/?profile=REC-RSCND#dateTitleH2">Rescinded Recommendation</a></li></ul>Notes:<ul><li>Document for <a href="./doc/rules/?profile=FPIG-NOTE#dateTitleH2">First Public Interest Group Note</a></li><li>Document for <a href="./doc/rules/?profile=IG-NOTE#dateTitleH2">Interest Group Note</a></li><li>Document for <a href="./doc/rules/?profile=FPWG-NOTE#dateTitleH2">First Public Working Group Note</a></li><li>Document for <a href="./doc/rules/?profile=WG-NOTE#dateTitleH2">Working Group Note</a></li></ul>Submissions:<ul><li>Document for <a href="./doc/rules/?profile=MEM-SUBM#dateTitleH2">Member Submission</a></li></ul>`
             );
         } else {
             sr.throw(

--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -145,6 +145,14 @@ exports.check = async function (sr, done) {
             sr.throw(
                 `[EXCEPTION] The document "${docTitle}" seems to be an Editor's Draft, which is not supported.`
             );
+        } else if (
+            sr.jsDocument.querySelector(
+                'link[href^="https://www.w3.org/StyleSheets/TR/"]'
+            )
+        ) {
+            sr.throw(
+                `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C (type of the document) DD Month YYYY&lt;/h2&gt;</code></pre>`
+            );
         } else {
             sr.throw(
                 `[EXCEPTION] The document "${docTitle}" could not be parsed, it's neither a TR document nor a Member Submission.`

--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -151,9 +151,9 @@ exports.check = async function (sr, done) {
         ) {
             const { sortedProfiles } = require('../../views');
             let profileList = '';
-            sortedProfiles.forEach((categary) => {
-                profileList += `${categary.name}<ul>`;
-                categary.profiles.forEach((profile) => {
+            sortedProfiles.forEach((category) => {
+                profileList += `${category.name}<ul>`;
+                category.profiles.forEach((profile) => {
                     profileList += `<li>&lt;h2&gt; for <a href="./doc/rules/?profile=${profile.abbr}#dateTitleH2">${profile.name}</a></li>`;
                 });
                 profileList += '</ul>';

--- a/lib/views.js
+++ b/lib/views.js
@@ -97,7 +97,7 @@ const listProfiles = function () {
 };
 
 const sortedProfiles = listProfiles();
-
+exports.sortedProfiles = sortedProfiles;
 /**
  * @TODO Document.
  */


### PR DESCRIPTION
resolves #1234 with reporting error:

> Pubrules is having a hard time identifying the profile of the document @@docTitle from its &lt;h2&gt;. Please make sure the &lt;h2&gt; is in a valid format: <pre><code>&lt;h2&gt;W3C (type of the document) DD Month YYYY&lt;/h2&gt;</code></pre>


see screenshot:
<img width="1166" alt="Screen Shot 2021-06-07 at 4 32 36 PM" src="https://user-images.githubusercontent.com/8498677/120985945-af0c7c00-c7ae-11eb-9c73-1863602277c8.png">

