### PR TITLE
Fix UI for patent policy

### DIFF
--- a/public/js/specberus.js
+++ b/public/js/specberus.js
@@ -310,17 +310,14 @@ jQuery.extend({
             $validation.find('label').removeClass('active');
             $validation.find('label#simple-validation').addClass('active');
             let patentPolicy;
-            if (
-                data.metadata.patentPolicy &&
-                data.metadata.patentPolicy.length > 0
-            ) {
+            if (data.metadata.patentPolicy) {
                 if (
-                    data.metadata.patentPolicy[0] ===
+                    data.metadata.patentPolicy ===
                     'https://www.w3.org/Consortium/Patent-Policy-20170801/'
                 ) {
                     patentPolicy = 'pp2004';
                 } else if (
-                    data.metadata.patentPolicy[0] ===
+                    data.metadata.patentPolicy ===
                     'https://www.w3.org/Consortium/Patent-Policy-20200915/'
                 ) {
                     patentPolicy = 'pp2020';


### PR DESCRIPTION
The patentPolicy metadata still returns the first PP link. So there's no need for UI to treat patentPolicy as array.
https://github.com/w3c/specberus/blob/f92b6181014a0800334e278b64cc06a37c23c5dd/lib/rules/metadata/patent-policy.js#L9-L12