### PR TITLE
Allow CR&REC to not have implementation report

### DIFF
--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -107,6 +107,8 @@ exports.messages = {
         'The document was already published today.',
     'headers.dl.implelink-should-be-https':
         'Implementation report link should start with <em>https://</em>, current link in <code>&lt;dl&gt;</code> is: `${link}`.',
+    'headers.dl.implelink-comfirm-no':
+        "Pubrules found 'There is no preliminary implementation report.' sentence in the 'Status of this Document' section, please confirm the implementation link is not needed.",
     'headers.dl.editors-draft-should-be-https':
         "Editor's draft link should start with <em>https://</em>, current link is: `${link}`.",
     'headers.dl.editor-not-found': 'Cannot find any editors for this document.',

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -294,9 +294,14 @@ exports.check = function (sr, done) {
         }
     }
 
-    // check "Implementation report" link
+    // check "Implementation report" link. Unless in Sotd saying there's none.
     const needImple =
         ['CR', 'CRD', 'PR', 'REC'].indexOf(sr.config.status) !== -1;
+    const sotd = sr.getSotDSection();
+    const noImple =
+        sr
+            .norm(sotd && sotd.textContent)
+            .indexOf('There is no preliminary implementation report.') > -1;
     const linkImple =
         dts.Implementation && dts.Implementation.dd.querySelector('a');
     const impleExist = checkLink({
@@ -304,13 +309,16 @@ exports.check = function (sr, done) {
         rule: self,
         element: linkImple,
         linkName: 'Implementation report',
-        mustHave: needImple,
+        mustHave: noImple ? false : needImple,
     });
     if (
         impleExist &&
         !linkImple.href.trim().toLowerCase().startsWith('https://')
     ) {
         sr.error(self, 'implelink-should-be-https', { link: linkImple });
+    }
+    if (noImple && needImple) {
+        sr.warning(self, 'implelink-comfirm-no');
     }
 
     // check "Editor's draft" link

--- a/test/docs/headers/dl-mismatch.html
+++ b/test/docs/headers/dl-mismatch.html
@@ -25,8 +25,11 @@
       </dl>
       <hr>
     </div>
-    <p>
-      We are the internets!
-    </p>
+    <section id="sotd" class="introductory">
+        <h2>Status of This Document</h2>
+        <p>
+            We are the internets!
+        </p>
+    </section>
   </body>
 </html>

--- a/test/docs/headers/dl-no-implelink.html
+++ b/test/docs/headers/dl-no-implelink.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="http://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="http://www.w3.org/Icons/w3c_home">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 15 March 1977</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='https://www.w3.org/TR/1977/CR-specberus-19770315/'>https://www.w3.org/TR/1977/CR-specberus-19770315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
+        <dt>Editor's Draft:</dt>
+        <dd><a href="https://w3c.github.io/html/">https://w3c.github.io/html/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='https://www.w3.org/TR/1977/WD-specberus-19770312/'>https://www.w3.org/TR/1977/WD-specberus-19770312/</a></dd>
+        <dt>Editor:</dt>
+        <dd data-editor-id="3902">Specberus The Cranky</dd>
+
+        <!-- <dt>Implementation report:</dt>
+        <dd>
+          <a href="http://w3c.github.io/json-ld-api/reports/">http://w3c.github.io/json-ld-api/reports/</a>
+        </dd> -->
+      </dl>
+      <hr>
+    </div>
+    <section id="sotd" class="introductory">
+        <h2>Status of This Document</h2>
+        <!-- warning: headers.dl.implelink-comfirm-no -->
+        <p>There is no preliminary
+            implementation report.</p>
+    </section>
+  </body>
+</html>

--- a/test/docs/headers/dl-order.html
+++ b/test/docs/headers/dl-order.html
@@ -33,8 +33,11 @@
       </dl>
       <hr>
     </div>
-    <p>
-      We are the internets!
-    </p>
+    <section id="sotd" class="introductory">
+        <h2>Status of This Document</h2>
+        <p>
+            We are the internets!
+        </p>
+    </section>
   </body>
 </html>

--- a/test/docs/headers/dl-untrimmed-text.html
+++ b/test/docs/headers/dl-untrimmed-text.html
@@ -43,5 +43,11 @@
       </p>
       <hr>
     </div>
+    <section id="sotd" class="introductory">
+        <h2>Status of This Document</h2>
+        <p>
+            We are the internets!
+        </p>
+    </section>
   </body>
 </html>

--- a/test/docs/headers/fails.html
+++ b/test/docs/headers/fails.html
@@ -10,8 +10,11 @@
     <section id="toc">
       <h2>Table of Contents</h2>
     </section>
-    <p>
-      We are the internets!
-    </p>
+    <section id="sotd" class="introductory">
+        <h2>Status of This Document</h2>
+        <p>
+            We are the internets!
+        </p>
+    </section>
   </body>
 </html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -326,6 +326,12 @@ const tests = {
                 config: { previousVersion: true, status: 'WD' },
                 errors: ['headers.dl.cant-retrieve'],
             },
+            {
+                doc: 'headers/dl-no-implelink.html',
+                config: { previousVersion: true, status: 'CR' },
+                warnings: ['headers.dl.implelink-comfirm-no'],
+                errors: ['headers.dl.cant-retrieve'],
+            },
         ],
         'github-repo': [
             {


### PR DESCRIPTION
resolves #1080. The rule is described in https://github.com/w3c/specberus/issues/1080#issuecomment-888856289
<img width="844" alt="Screen Shot 2021-08-03 at 3 18 22 PM" src="https://user-images.githubusercontent.com/8498677/127977170-3e1b0ca2-626f-437b-90b3-97faa2c187f6.png">
