### PR TITLE
allow dark css to overide the default W3C stylsheet

### DIFF
--- a/lib/rules/style/sheet.js
+++ b/lib/rules/style/sheet.js
@@ -17,16 +17,23 @@ exports.name = rule;
 exports.check = function (sr, done) {
     if (!sr.config.styleSheet) return done();
     const url = `https://www.w3.org/StyleSheets/TR/2016/${sr.config.styleSheet}`;
+    const dark = 'https://www.w3.org/StyleSheets/TR/2016/dark';
     const sels = [
         `head > link[rel=stylesheet][href='${url}']`,
-        `head > link[rel=stylesheet][href='https:${url}']`,
         `head > link[rel=stylesheet][href='${url}.css']`,
-        `head > link[rel=stylesheet][href='https:${url}.css']`,
     ];
     const lnk = sr.jsDocument.querySelectorAll(sels.join(', '));
     if (!lnk.length) sr.error(missing, 'not-found');
-    else if (util.nextAll(lnk, 'link[rel=stylesheet], style').length) {
-        sr.error(notLast, 'last');
+    else {
+        const siblings = util.nextAll(lnk, 'link[rel=stylesheet], style');
+        if (
+            siblings.length ||
+            (siblings.length === 1 &&
+                (siblings[0].href !== dark ||
+                    siblings[0].href !== `${dark}.css`))
+        ) {
+            sr.error(notLast, 'last');
+        }
     }
     done();
 };

--- a/test/docs/headers/simple-dark-mode.html
+++ b/test/docs/headers/simple-dark-mode.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>Simple baseline headers valid document</title>
+    <!-- remove the below when CSS Validator is fixed -->
+    <style></style>
+    <link rel='stylesheet' href='https://www.w3.org/StyleSheets/TR/2016/W3C-WD'>
+    <link rel='stylesheet' href='https://www.w3.org/StyleSheets/TR/2016/dark'>
+  </head>
+  <body>
+    <div class='head'>
+      <a href="https://www.w3.org/">
+        <img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C">
+      </a>
+      <h1>Simple baseline headers valid document</h1>
+      <h2>W3C Working Draft 15 March 2017, edited in place 01 April 2014</h2>
+      <dl>
+        <dt>This Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170315/'>https://www.w3.org/TR/2017/WD-specberus-20170315/</a></dd>
+        <dt>Latest Version:</dt>
+        <dd><a href='https://www.w3.org/TR/specberus/'>https://www.w3.org/TR/specberus/</a></dd>
+        <dt>Previous Version:</dt>
+        <dd><a href='https://www.w3.org/TR/2017/WD-specberus-20170312/'>https://www.w3.org/TR/2017/WD-specberus-20170312/</a></dd>
+        <dt>Editor:</dt>
+        <dd>Specberus The Cranky</dd>
+        <!--headers.dl.implelink-should-be-https pass-->
+        <dt>Implementation report:</dt>
+        <dd>
+          <a href="https://w3c.github.io/json-ld-api/reports/">https://w3c.github.io/json-ld-api/reports/</a>
+        </dd>
+        <dt>Participate:</dt><dd>
+          <a href="https://lists.w3.org/Archives/Public/public-html/">Mail archives</a>
+        </dd><dd>
+          <a href="mailto:public-html@w3.org">public-html@w3.org</a>
+        </dd><dd>
+          <a href="mailto:public-html-request@w3.org?subject=subscribe">Subscribe</a>,
+        </dd>
+      </dl>
+      <p>
+        Please check the <a href="https://w3c.github.io/specberus/errata/"><strong>errata</strong></a> for any errors or issues reported since publication.
+      </p>
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2017
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>).
+        <abbr title="World Wide Web Consortium">W3C</abbr>
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+        rules apply.
+      </p>
+      <hr>
+    </div>
+    <h2>Abstract</h2>
+    <p>
+      We are the internets!
+    </p>
+    <h2>Status of This Document</h2>
+    <p><em>This section describes the status of this document at the time of its publication.
+    Other documents may supersede this document. A list of current W3C publications and the
+    latest revision of this technical report can be found in the
+    <a href="https://www.w3.org/TR/">W3C technical reports index</a> at
+    https://www.w3.org/TR/.</em></p>
+    <p>
+      If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-html@w3.org">public-html@w3.org</a>
+      (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="https://lists.w3.org/Archives/Public/public-html/">archives</a>).
+    </p>
+    <p>
+      It's a valid test!
+    </p>
+    <p>
+      Publication as a Working Draft does not imply endorsement by the W3C Membership. This is a
+      draft document and may be updated, replaced or obsoleted by other documents at any time. It is
+      inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" about="" rel="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+      <a href="https://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of
+      any patent disclosures</a> made in connection with the deliverables of the group; that page
+      also includes instructions for disclosing a patent. An individual who has actual knowledge of
+      a patent which the individual believes contains
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      Claim(s)</a> must disclose the information in accordance with
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the
+      <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    </p>
+    <nav id="toc">
+      <h2>Table of Contents</h2>
+      <ul>
+        <li>Nothing</li>
+      </ul>
+    </nav>
+  </body>
+</html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -476,6 +476,10 @@ const tests = {
         sheet: [
             { doc: 'headers/simple.html', config: { styleSheet: 'W3C-WD' } },
             {
+                doc: 'headers/simple-dark-mode.html',
+                config: { styleSheet: 'W3C-WD' },
+            },
+            {
                 doc: 'headers/fails.html',
                 config: { styleSheet: 'W3C-WD' },
                 errors: ['style.sheet.not-found'],


### PR DESCRIPTION
Dark mode can now be used by include the dark.css (see https://github.com/w3c/tr-design/pull/243)
However, that stylesheet needs to be include *after* the W3C stylesheet.
The PR allows that exception.