### PR TITLE
Add support for errata as a dd

### DIFF
--- a/lib/rules/metadata/errata.js
+++ b/lib/rules/metadata/errata.js
@@ -9,7 +9,7 @@ exports.name = 'metadata.errata';
 exports.check = function (sr, done) {
     const errataRegex = /errata/i;
     const linkElement = sr.jsDocument.querySelectorAll(
-        'body div.head dl + p > a'
+        'body div.head dl + p > a, body div.head dl dd a'
     );
     const errata = Array.prototype.filter.call(linkElement, element =>
         errataRegex.test(element.textContent)


### PR DESCRIPTION
Add support for errata appearing as a dd in the head, as per:
https://w3c.github.io/tr-design/p2021mockup/rec-6.3.10.html

Happy to add a test, but could use some guidance 🙏 

Also, I was unsure if we want to continue to support `<p>`. 