### PR TITLE
Require apiKey in Specberus constructor instead of env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs
 results
 
 package-lock.json
+yarn.lock
 npm-debug.log
 node_modules
 bower_components

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ The interface you get when you `require("specberus")` is that from `lib/validato
 
 (See also [the REST API](#5-rest-api).)
 
+## Creating a Validator instance
+
+```js
+const { Specberus } = require("specberus");
+const specberus = new Specberus(apiKey);
+// specberus.validate(...)
+// specberus.extractMetadata(...)
+```
+
 ### `validate(options)`
 
 This method takes an object with the following fields:

--- a/app.js
+++ b/app.js
@@ -7,6 +7,18 @@
 // Settings:
 const DEFAULT_PORT = 80;
 
+if (!process.env.W3C_API_KEY || process.env.W3C_API_KEY.length < 1) {
+    throw new Error(
+        'Pubrules is missing a valid key for the W3C API; define environment variable “W3C_API_KEY”'
+    );
+}
+
+if (!process.env.BASE_URI || process.env.BASE_URI.length < 1) {
+    console.warn(
+        `Environment variable “BASE_URI” not defined; assuming that Pubrules lives at “/”`
+    );
+}
+
 // Native packages:
 const http = require('http');
 
@@ -36,7 +48,7 @@ app.use(compression());
 app.use('/badterms.json', require('cors')());
 
 app.use(express.static('public'));
-api.setUp(app);
+api.setUp(app, process.env.W3C_API_KEY);
 views.setUp(app);
 
 // @TODO Localise this properly when messages are translated; hard-coded British English for now.
@@ -49,7 +61,7 @@ io.on('connection', socket => {
     socket.on('extractMetadata', data => {
         if (!data.url)
             return socket.emit('exception', { message: 'URL not provided.' });
-        const vali = new validator.Specberus();
+        const vali = new validator.Specberus(process.env.W3C_API_KEY);
         const handler = new Sink();
         handler.on('err', (type, data) => {
             try {
@@ -104,7 +116,7 @@ io.on('connection', socket => {
             return socket.emit('exception', {
                 message: 'Profile does not exist.',
             });
-        const vali = new validator.Specberus();
+        const vali = new validator.Specberus(process.env.W3C_API_KEY);
         const handler = new Sink();
         const profile = util.profiles[data.profile];
         const profileCode = profile.name;

--- a/lib/api.js
+++ b/lib/api.js
@@ -28,11 +28,9 @@ const sendJSONresult = function (err, warn, inf, res, metadata) {
 /**
  * Handle an API request: parse method and parameters, handle common errors and call the validator.
  *
- * @param {object} req - Express HTTP request.
- * @param {object} res - Express HTTP response.
+ * @param {string} apiKey
  */
-
-const processRequest = function (req, res) {
+const processRequest = apiKey => (req, res) => {
     if (req.path === '/api/version') {
         res.status(200).send(version);
     } else if (req.path === '/api/metadata' || req.path === '/api/validate') {
@@ -59,7 +57,7 @@ const processRequest = function (req, res) {
         }
         if (validate && options.profile === 'auto') {
             errors = [];
-            v = new validator.Specberus();
+            v = new validator.Specberus(apiKey);
             handler = new Sink(
                 (...data) => {
                     errors.push(Object.assign({}, ...data));
@@ -89,7 +87,7 @@ const processRequest = function (req, res) {
                         errors2 = [];
                         warnings2 = [];
                         info2 = [];
-                        v2 = new validator.Specberus();
+                        v2 = new validator.Specberus(apiKey);
                         handler2 = new Sink(
                             (...data2) => {
                                 errors2.push(Object.assign({}, ...data2));
@@ -139,7 +137,7 @@ const processRequest = function (req, res) {
             errors = [];
             warnings = [];
             info = [];
-            v = new validator.Specberus();
+            v = new validator.Specberus(apiKey);
             handler = new Sink(
                 (...data) => {
                     errors.push(Object.assign({}, ...data));
@@ -172,8 +170,8 @@ const processRequest = function (req, res) {
     }
 };
 
-const setUp = function (app) {
-    app.get('/api/*', processRequest);
+const setUp = function (app, apiKey) {
+    app.get('/api/*', processRequest(apiKey));
 };
 
 exports.setUp = setUp;

--- a/lib/rules/metadata/dl.js
+++ b/lib/rules/metadata/dl.js
@@ -74,7 +74,7 @@ exports.check = function (sr, done) {
 
     // check same day publications
     const ua = `W3C-Pubrules/${sr.version}`;
-    const apikey = process.env.W3C_API_KEY;
+    const apikey = sr.apiKey;
     const docDate = sr.getDocumentDate();
     if (docDate) {
         const year = docDate.getFullYear();

--- a/lib/rules/metadata/profile.js
+++ b/lib/rules/metadata/profile.js
@@ -99,7 +99,7 @@ exports.check = async function (sr, done) {
             const req = sua
                 .get(`https://api.w3.org/specifications/${shortname}`)
                 .set('User-Agent', `W3C-Pubrules/${sr.version}`);
-            req.query({ apikey: process.env.W3C_API_KEY });
+            req.query({ apikey: sr.apiKey });
             req.end((err, res) => {
                 if (err || !res.ok) {
                     specExists = false;

--- a/lib/rules/sotd/group-homepage.js
+++ b/lib/rules/sotd/group-homepage.js
@@ -13,7 +13,7 @@ exports.check = async function (sr, done) {
     const ua = `W3C-Pubrules/${sr.version}`;
     const sotd = sr.getSotDSection();
     let count = 0;
-    const apikey = process.env.W3C_API_KEY;
+    const apikey = sr.apiKey;
     if (deliverers.length === 0) {
         sr.error(self, 'no-group');
         return done();

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -99,12 +99,12 @@ function findPP(candidates, sr, isIGDeliverable) {
     return { pp, expected };
 }
 
-function fetchGroupNames(deliverIds) {
+function fetchGroupNames(deliverIds, apiKey) {
     const promiseArray = [];
     deliverIds.forEach(deliverId => {
         promiseArray.push(
             new PowerPromise((resolve, reject) => {
-                w3capi.apiKey = process.env.W3C_API_KEY;
+                w3capi.apiKey = apiKey;
                 w3capi.group(deliverId).fetch((err, data) => {
                     if (err) {
                         reject(err);
@@ -174,7 +174,7 @@ exports.check = async function (sr, done) {
         }
 
         // Use Promise.all to get Group Names, if groups include IG, will check `noRec` sentence in patent policy paragraph.
-        await Promise.all(fetchGroupNames(deliverers))
+        await Promise.all(fetchGroupNames(deliverers, sr.apiKey))
             .then(groupNames => {
                 isIGDeliverable = groupNames.some(groupName =>
                     groupName.endsWith('Interest Group')

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -17,7 +17,11 @@ const l10n = require('./l10n');
 
 l10n.setLanguage('en_GB');
 
-const Specberus = function () {
+const Specberus = function (apiKey = process.env.W3C_API_KEY) {
+    if (typeof apiKey !== 'string' || !apiKey.length) {
+        throw new Error('apiKey is required.');
+    }
+    this.apiKey = apiKey;
     this.version = version;
     this.clearCache();
 };
@@ -469,7 +473,7 @@ Specberus.prototype.getDelivererIDs = async function () {
                     const [, type, shortname] =
                         REGEX_DELIVERER_IPR_URL.exec(href);
                     const groupAPIURL = `https://api.w3.org/groups/${type}/${shortname}`;
-                    const apikey = process.env.W3C_API_KEY;
+                    const apikey = this.apiKey;
                     promiseArray.push(
                         sua
                             .get(groupAPIURL)
@@ -519,7 +523,7 @@ Specberus.prototype.getChartersData = async function () {
     const chartersData = [];
 
     if (deliverers.length) {
-        w3capi.apiKey = process.env.W3C_API_KEY;
+        w3capi.apiKey = this.apiKey;
         const delivererPromises = [];
         const { TAG_ID } = util;
         // Get charters data from W3C API
@@ -659,24 +663,4 @@ Specberus.prototype.getRecMetadata = function (meta) {
     return meta;
 };
 
-if (
-    !process ||
-    !process.env ||
-    !process.env.W3C_API_KEY ||
-    process.env.W3C_API_KEY.length < 1
-)
-    throw new Error(
-        'Pubrules is missing a valid key for the W3C API; define environment variable “W3C_API_KEY”'
-    );
-else {
-    if (
-        !process ||
-        !process.env ||
-        !process.env.BASE_URI ||
-        process.env.BASE_URI.length < 1
-    )
-        console.warn(
-            `Environment variable “BASE_URI” not defined; assuming that Pubrules lives at “/”`
-        );
-    exports.Specberus = Specberus;
-}
+exports.Specberus = Specberus;

--- a/test/api.js
+++ b/test/api.js
@@ -30,7 +30,7 @@ let server;
 const launchServer = function () {
     const app = express();
     server = http.createServer(app);
-    api.setUp(app);
+    api.setUp(app, process.env.W3C_API_KEY);
     server.listen(PORT).on('error', err => {
         throw new Error(err);
     });

--- a/test/rules.js
+++ b/test/rules.js
@@ -53,7 +53,7 @@ const equivalentArray = function (a1, a2) {
  */
 
 const compareMetadata = function (url, file, expectedObject) {
-    const specberus = new validator.Specberus();
+    const specberus = new validator.Specberus(process.env.W3C_API_KEY);
     const handler = new sink.Sink(data => {
         throw new Error(data);
     });
@@ -137,7 +137,7 @@ const compareMetadata = function (url, file, expectedObject) {
 };
 
 describe('Basics', () => {
-    const specberus = new validator.Specberus();
+    const specberus = new validator.Specberus(process.env.W3C_API_KEY);
 
     describe('Method "extractMetadata"', () => {
         let i;
@@ -1325,7 +1325,9 @@ describe('Making sure Specberus is not broken...', () => {
 
                             for (const o in test.options)
                                 options[o] = test.options[o];
-                            new validator.Specberus().validate(options);
+                            new validator.Specberus(
+                                process.env.W3C_API_KEY
+                            ).validate(options);
                         });
                     });
                 });


### PR DESCRIPTION
Refactored code to better support Node API:
- `apiKey` is required when creating `new Specberus` instance (instead of when importing).
- Specberus instance doesn't rely on `process.env`
- `process.env.W3C_API_KEY` is required only in tests and server.
- `process.env.BASE_URI` is required only in server.
- Avoiding API breaking change by using `process.env.W3C_API_KEY` as
    default during construction.

Closes https://github.com/w3c/specberus/issues/783
Ref: Adding specberus to spec-prod GitHub action (https://github.com/w3c/spec-prod/pull/100)