### PR TITLE
Update dependabot to ignore patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: weekly
     time: "00:00"
   open-pull-requests-limit: 10
+  ignore:
+      - dependency-name: *
+        update-types: ["version-update:semver-patch"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
[specifying-dependencies-and-versions-to-ignore](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore) feature was [introduced](https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/) 5 month ago