### PR TITLE
chore: Use lint-staged for husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint && npm run cspell
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "expect.js": "0.3",
     "husky": "7.0.4",
     "jsdoc": "3.6.7",
+    "lint-staged": "^12.1.2",
     "minami": "1.2.3",
     "mocha": "9.1.3",
     "nodemon": "2.0.15",
@@ -57,12 +58,16 @@
     "build": "npm run lint && npm run test && npm run jsdoc",
     "live": "nodemon --use_strict app",
     "start": "node --use_strict app",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },
   "engines": {
     "node": "^14 || ^16",
     "npm": ">=6"
+  },
+  "lint-staged": {
+    "*.js": "eslint --cache --fix",
+    "*": "cspell"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "expect.js": "0.3",
     "husky": "7.0.4",
     "jsdoc": "3.6.7",
-    "lint-staged": "^12.1.2",
+    "lint-staged": "12.1.2",
     "minami": "1.2.3",
     "mocha": "9.1.3",
     "nodemon": "2.0.15",


### PR DESCRIPTION
Makes the current commit hook a little faster by just running the linting and spellchecking on files being changed, and auto fix the ESLint issues