### PR TITLE
chore: Remove and lint unused ESLint ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "audit": "npm audit | grep -oE 'https?\\:\\/\\/(www\\.)?(nodesecurity\\.io|npmjs\\.com)\\/advisories\\/[[:digit:]]+' | rev | cut -d '/' -f 1 | rev | diff known-vulns.txt -",
     "cspell": "cspell **/*.css **/*.js",
-    "lint": "eslint .",
+    "lint": "eslint . --report-unused-disable-directives",
     "spelling": "cspell \"**/*.*\"",
     "test": "mocha --timeout 20000",
     "jsdoc": "jsdoc --configure jsdoc.json -r app.js lib/ public/ test/ tools/",

--- a/test/rules.js
+++ b/test/rules.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unreachable */
 /**
  * Test the rules.
  */


### PR DESCRIPTION
Will warn as old inline disabled sections are no longer required from parent config or code changes