### PR TITLE
chore: update cSpell glob and schema

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "words": [
         "ˈspɛk",
         "aboba",
@@ -159,7 +159,8 @@
         "coverage/**",
         "test/**",
         "package-lock.json",
-        "node_modules/**"
+        "node_modules/**",
+        "design/**"
     ],
     "allowCompoundWords": true,
     "ignoreWords": ["en", "gb"]

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "audit": "npm audit | grep -oE 'https?\\:\\/\\/(www\\.)?(nodesecurity\\.io|npmjs\\.com)\\/advisories\\/[[:digit:]]+' | rev | cut -d '/' -f 1 | rev | diff known-vulns.txt -",
     "cspell": "cspell **/*.css **/*.js",
     "lint": "eslint . --report-unused-disable-directives && prettier -c .",
-    "spelling": "cspell \"**/*.*\"",
+    "spelling": "cspell \"**/*\"",
     "test": "mocha --timeout 20000",
     "jsdoc": "jsdoc --configure jsdoc.json -r app.js lib/ public/ test/ tools/",
     "coverage": "nyc npm test",


### PR DESCRIPTION
The newer schema is `0.2`, but shouldn't affect any of the current config.
Expanded the glob and ignored the new issues flagged in the `design` folder