### PR TITLE
chore: remove pinst

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "mocha": "9.1.3",
         "nodemon": "2.0.15",
         "nyc": "15.1.0",
-        "pinst": "2.1.6",
         "prettier": "2.5.0"
       },
       "engines": {
@@ -6837,21 +6836,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.3.2"
-      },
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -14120,15 +14104,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "pkg-dir": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "mocha": "9.1.3",
     "nodemon": "2.0.15",
     "nyc": "15.1.0",
-    "pinst": "2.1.6",
     "prettier": "2.5.0"
   },
   "scripts": {
@@ -58,9 +57,7 @@
     "build": "npm run lint && npm run test && npm run jsdoc",
     "live": "nodemon --use_strict app",
     "start": "node --use_strict app",
-    "prepare": "husky install",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepare": "husky install"
   },
   "engines": {
     "node": "^14 || ^16",


### PR DESCRIPTION
Was previously required for the husky install scripts.
Husky now uses `prepare` instead of `postinstall`