### PR TITLE
ci: unpin actions/checkout to v2

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: Checkout PR from dependabot
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Should remove any Dependabot updates till there is a new major version