### PR TITLE
fix: don't use intenral puppetter field

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
         "global-require": "off",
         "no-restricted-syntax": "warn",
         "guard-for-in": "warn",
-        "no-underscore-dangle": "warn",
         "prefer-destructuring": "warn"
     },
     "overrides": [

--- a/lib/rules/links/linkchecker.js
+++ b/lib/rules/links/linkchecker.js
@@ -66,7 +66,7 @@ exports.check = async function (sr, done) {
 
     page.on('response', response => {
         const url = simplifyURL(response.url());
-        const { referer } = response.request()._headers;
+        const { referer } = response.request().headers();
         const docPath = sr.url.replace(/\/[^/]+$/, '/');
 
         // check if resource is in same folder as base document


### PR DESCRIPTION
This was the only warning for the rule, so I reenabled it and saw that this was actually using a private field instead of the public function