### PR TITLE
fix: relative path before BASE_URI

### DIFF
--- a/views/doc/index.handlebars
+++ b/views/doc/index.handlebars
@@ -13,7 +13,7 @@
       <h4 id="{{this.abbr}}"><a href="#{{this.abbr}}">{{this.name}}</a></h4>
       <ul>
       {{#each this.profiles}}
-        <li><a href="{{../../BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
+        <li><a href="{{BASE_URI}}doc/rules/?profile={{this.abbr}}"><span class="profile-abbr">{{this.abbr}}</span> {{this.name}}</a></li>
       {{/each}}
       </ul>
     {{/each}}


### PR DESCRIPTION
Noticed this because pretty was crashing trying to parse it. The other reference to these URIs don't have that relative path in the front, so I dropped it