### PR TITLE
chore: remove passing ESLint suppressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,6 @@
     "rules": {
         "prettier/prettier": "error",
         "no-shadow": "off",
-        "func-names": "off",
-        "vars-on-top": "off",
         "consistent-return": "warn",
         "no-param-reassign": "off",
         "no-plusplus": "off",


### PR DESCRIPTION
Few rules now have no violations and don't seem like specific style choices anymore