### PR TITLE
chore: sort NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,16 +48,16 @@
   },
   "scripts": {
     "audit": "npm audit | grep -oE 'https?\\:\\/\\/(www\\.)?(nodesecurity\\.io|npmjs\\.com)\\/advisories\\/[[:digit:]]+' | rev | cut -d '/' -f 1 | rev | diff known-vulns.txt -",
-    "cspell": "cspell **/*.css **/*.js",
-    "lint": "eslint . --report-unused-disable-directives && prettier -c .",
-    "spelling": "cspell \"**/*\"",
-    "test": "mocha --timeout 20000",
-    "jsdoc": "jsdoc --configure jsdoc.json -r app.js lib/ public/ test/ tools/",
-    "coverage": "nyc npm test",
     "build": "npm run lint && npm run test && npm run jsdoc",
+    "coverage": "nyc npm test",
+    "cspell": "cspell **/*.css **/*.js",
+    "jsdoc": "jsdoc --configure jsdoc.json -r app.js lib/ public/ test/ tools/",
+    "lint": "eslint . --report-unused-disable-directives && prettier -c .",
     "live": "nodemon --use_strict app",
+    "prepare": "husky install",
+    "spelling": "cspell \"**/*\"",
     "start": "node --use_strict app",
-    "prepare": "husky install"
+    "test": "mocha --timeout 20000"
   },
   "engines": {
     "node": "^14 || ^16",


### PR DESCRIPTION
They didn't seem to be grouped in a particular order, so alphabetical is a little easier to find a script instead