### PR TITLE
chore: re-add eslint-plugin-jsdoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
         {
             "files": ["app.js", "lib/**/*.js", "tools/**/*.js"],
             "plugins": ["node"],
-            "extends": ["plugin:node/recommended"]
+            "extends": ["plugin:node/recommended", "plugin:jsdoc/recommended"]
         },
         {
             "files": ["test/**/*.js"],


### PR DESCRIPTION
It's still in the devDependencies, but wasn't actually configured right now