### PR TITLE
chore: ignore nyc coverage dir from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 *.html
 *.handlebars
 lib/rules/structure/display-only.js
+.nyc_output


### PR DESCRIPTION
Doesn't really slow it down as there isn't much in the directory from the code coverage generation