### PR TITLE
ci: only lint on the current LTS used by actions

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -15,16 +15,12 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
Unlike the CI testing, linting only really needs to be run once, since the node version shouldn't matter beyond the `engine` support used by eslint-plugin-node which doesn't matter the version it's run on