### PR TITLE
chore: Allow Dependabot semver patch monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+      time: '00:00'
+    open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
Keeps the reduced noise from the weekly semver-patch restricted PRs, but
with a monthly catchup for the patches