### PR TITLE
allow links to cdn.w3.org/assets

### DIFF
--- a/lib/rules/links/linkchecker.js
+++ b/lib/rules/links/linkchecker.js
@@ -19,6 +19,7 @@ const allowList = [
     'https://www.w3.org/TR/tr-outdated-spec',
     /^https:\/\/www.w3.org\/analytics\/piwik/,
     /^https:\/\/test.csswg.org\/harness/,
+    /^https:\/\/cdn.w3.org\/assets\//,
     /^data:/,
 ];
 const noRespondAllowList = [


### PR DESCRIPTION
Browsers logos are now available on our cdn, e.g. https://cdn.w3.org/assets/logos/w3c/browser-logos/android-webview-beta/android-webview-beta.png.
The PR allows the use of these logos
Fix #1543 