### PR TITLE
add trailing slashes on allowed assets urls

### DIFF
--- a/lib/rules/links/linkchecker.js
+++ b/lib/rules/links/linkchecker.js
@@ -14,11 +14,11 @@ const compound = {
 };
 
 const allowList = [
-    /^https:\/\/www.w3.org\/StyleSheets/,
-    /^https:\/\/www.w3.org\/scripts/,
+    /^https:\/\/www.w3.org\/StyleSheets\//,
+    /^https:\/\/www.w3.org\/scripts\//,
     'https://www.w3.org/TR/tr-outdated-spec',
-    /^https:\/\/www.w3.org\/analytics\/piwik/,
-    /^https:\/\/test.csswg.org\/harness/,
+    /^https:\/\/www.w3.org\/analytics\/piwik\//,
+    /^https:\/\/test.csswg.org\/harness\//,
     /^https:\/\/cdn.w3.org\/assets\//,
     /^data:/,
 ];


### PR DESCRIPTION
That PR adds a trailing slash to some of the allowed asset URLs.