### PR TITLE
allow groups as editors

### DIFF
--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -367,7 +367,9 @@ export async function check(sr, done) {
         const editors = dts.Editor.dd;
         // 'missingElement' is array of HTML elements without editorId
         const missingElement = editors.filter(
-            editor => !editor.dataset.editorId
+            editor =>
+                !editor.dataset.editorId &&
+                !editor.textContent.match(/(working|interest) group/i)
         );
         if (missingElement.length) {
             sr.error(editorError, 'editor-missing-id', {


### PR DESCRIPTION
Some specs may list the whole group as editor. In this case, there's no editor ID.
This PR adds an exception for Working|Interest groups.

https://github.com/w3c/deviceorientation/issues/100