### PR TITLE
add exception for all the CSS errors reported by the validator.nu

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -52,7 +52,7 @@ Exceptions.prototype.has = function (shortname, rule, key, extra) {
                     (!exception.message &&
                         compareValue(extra.type, exception.type)) ||
                     (exception.message &&
-                        compareValue(extra.message, exception.message)))
+                        new RegExp(exception.message).test(extra.message)))
             ) {
                 return true;
             }

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -3,7 +3,7 @@
         {
             "rule": "validation.html",
             "type": "noexistence-at-all",
-            "message": "CSS: “caret-shape”: Property “caret-shape” doesn't exist."
+            "message": "^CSS: .*$"
         },
         {
             "rule": "validation.html",


### PR DESCRIPTION
We now rely on validator.nu to report CSS errors. That PR updates the exception system to "ignore" these errors as it was already done when the check was done with the CSS validator.