### PR TITLE
normalize text before filtering

### DIFF
--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -98,7 +98,7 @@ export function check(sr, done) {
             ) {
                 const review = Array.prototype.find.call(
                     sw.querySelectorAll('a'),
-                    ele => ele.textContent === 'wide review'
+                    ele => sr.norm(ele.textContent) === 'wide review'
                 );
                 if (!review) sr.error(self, 'no-cr-review');
                 else if (


### PR DESCRIPTION
If there's a breaking line between "wide" and "review", the test will fail. That PR addresses that issue.