### PR TITLE
Add note-stability sentence

### DIFF
--- a/lib/rules.json
+++ b/lib/rules.json
@@ -600,7 +600,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -511,7 +511,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,
@@ -600,7 +600,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -511,7 +511,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -600,7 +600,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group (and the @@@ Working/Interest Group), but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Note is endorsed by the @@@ Working/Interest Group (and the @@@ Working/Interest Group), but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,

--- a/lib/rules.json
+++ b/lib/rules.json
@@ -511,7 +511,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Draft Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group (and the @@@ Working/Interest Group), but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,
@@ -600,7 +600,7 @@
                                 "&lt;a href=\"https://www.w3.org/2021/Process-20211102/#recs-and-notes\"&gt;Note track&lt;/a&gt;"
                             ],
                             "customParagraph": true,
-                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group, but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
+                            "stability": "It <span class=\"rfc2119\">must</span> set expectations about the (in)stability of the document. The <span class=\"rfc2119\">recommended</span> text is: <blockquote class=\"boilerplate\"> <p>Group Notes are not endorsed by W3C nor its Members.</p> </blockquote> or <blockquote class=\"boilerplate\"> <p>This Group Draft Note is endorsed by the @@@ Working/Interest Group (and the @@@ Working/Interest Group), but is not endorsed by W3C itself nor its Members.</p> </blockquote>",
                             "draftStability": true,
                             "knownDisclosureNumber": true,
                             "patPolReq": true,

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -70,7 +70,7 @@ function buildWanted(groups, sr, ppLink) {
  */
 function findPP(candidates, sr, isIGDeliverable) {
     let pp = null;
-    const delivererGroups = sr.getDelivererGroups();
+    const delivererGroups = sr.getDelivererNames();
     if (delivererGroups.length > 1) sr.warning(self, 'joint-publication');
 
     const wanted = buildWanted(delivererGroups, sr, isIGDeliverable);

--- a/lib/rules/sotd/pp.js
+++ b/lib/rules/sotd/pp.js
@@ -70,22 +70,10 @@ function buildWanted(groups, sr, ppLink) {
  */
 function findPP(candidates, sr, isIGDeliverable) {
     let pp = null;
-    const groups = [];
-    const jointRegex = new RegExp(
-        'This document was (?:produced|published) by the (.+? Working Group|Technical Architecture Group|Advisory Board)' +
-            ' and the (.+? Working Group|Technical Architecture Group|Advisory Board)'
-    );
-    Array.prototype.some.call(candidates, p => {
-        const text = sr.norm(p.textContent);
-        if (jointRegex.test(text)) {
-            const matches = text.match(jointRegex);
-            groups.push(matches[1]);
-            groups.push(matches[2]);
-            sr.warning(self, 'joint-publication');
-            return true;
-        }
-    });
-    const wanted = buildWanted(groups, sr, isIGDeliverable);
+    const delivererGroups = sr.getDelivererGroups();
+    if (delivererGroups.length > 1) sr.warning(self, 'joint-publication');
+
+    const wanted = buildWanted(delivererGroups, sr, isIGDeliverable);
     const expected = wanted.text;
     Array.prototype.some.call(candidates, p => {
         const text = sr.norm(p.textContent);

--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -1,7 +1,7 @@
 // SotD
 //  stability warning
 // <p>Publication as a Working Draft does not imply endorsement by W3C and its Members.</p>
-import { filter, getDelivererNames } from '../../util.js';
+import { filter } from '../../util.js';
 
 /**
  * @param candidates
@@ -15,9 +15,8 @@ function findSW(candidates, sr) {
         sr.config.longStatus === 'Group Draft Note'
     ) {
         // Find the sentence of 'Group Notes are not endorsed by W3C nor its Members.' or 'This Group Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.'
-        wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the \\w+ [Working|Interest] Group, but is not endorsed by W3C itself nor its Members).`;
-        const groups = getDelivererNames(sr);
-        console.log('\ngroups: ', groups);
+        const groups = sr.getDelivererNames().join(' and the ');
+        wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the ${groups}, but is not endorsed by W3C itself nor its Members).`;
     } else if (sr.config.longStatus === 'Statement') {
         wanted =
             'A W3C Statement is a specification that, after extensive consensus-building, is endorsed by W3C and its Members.';

--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -1,7 +1,7 @@
 // SotD
 //  stability warning
 // <p>Publication as a Working Draft does not imply endorsement by W3C and its Members.</p>
-import { filter } from '../../util.js';
+import { filter, getDelivererNames } from '../../util.js';
 
 /**
  * @param candidates
@@ -15,7 +15,9 @@ function findSW(candidates, sr) {
         sr.config.longStatus === 'Group Draft Note'
     ) {
         // Find the sentence of 'Group Notes are not endorsed by W3C nor its Members.' or 'This Group Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.'
-        wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the \\w+ Group, but is not endorsed by W3C itself nor its Members).`;
+        wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the \\w+ [Working|Interest] Group, but is not endorsed by W3C itself nor its Members).`;
+        const groups = getDelivererNames(sr);
+        console.log('\ngroups: ', groups);
     } else if (sr.config.longStatus === 'Statement') {
         wanted =
             'A W3C Statement is a specification that, after extensive consensus-building, is endorsed by W3C and its Members.';

--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -14,8 +14,8 @@ function findSW(candidates, sr) {
         sr.config.longStatus === 'Group Note' ||
         sr.config.longStatus === 'Group Draft Note'
     ) {
-        // Find the sentence of 'Group Notes are not endorsed by W3C nor its Members.'
-        wanted = `${sr.config.longStatus}s are not endorsed by W3C nor its Members.`;
+        // Find the sentence of 'Group Notes are not endorsed by W3C nor its Members.' or 'This Group Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.'
+        wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the \\w+ Group, but is not endorsed by W3C itself nor its Members).`;
     } else if (sr.config.longStatus === 'Statement') {
         wanted =
             'A W3C Statement is a specification that, after extensive consensus-building, is endorsed by W3C and its Members.';

--- a/lib/util.js
+++ b/lib/util.js
@@ -237,3 +237,18 @@ export const REC_TEXT = {
     SOTD_C_COR_ADD:
         'It includes candidate amendment(s)?, introducing substantive change(s)? and new feature(s)? since the previous Recommendation.',
 };
+
+export const getDelivererNames = function (sr) {
+    const sotd = sr.getSotDSection();
+    const delivererNamesRegex =
+        /This document was (?:produced|published) by the ([^Group]+ Working Group|[^Group]+ Interest Group|Technical Architecture Group|Advisory Board)( and the (.+? Working Group|.+? Interest Group|Technical Architecture Group|Advisory Board))?/;
+
+    const text = sr.norm(sotd.textContent);
+    const matches = text.match(delivererNamesRegex);
+    const groups = [];
+    if (matches) {
+        groups.push(matches[1]);
+        if (matches[2]) groups.push(matches[2]);
+    }
+    return groups;
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -237,18 +237,3 @@ export const REC_TEXT = {
     SOTD_C_COR_ADD:
         'It includes candidate amendment(s)?, introducing substantive change(s)? and new feature(s)? since the previous Recommendation.',
 };
-
-export const getDelivererNames = function (sr) {
-    const sotd = sr.getSotDSection();
-    const delivererNamesRegex =
-        /This document was (?:produced|published) by the ([^Group]+ Working Group|[^Group]+ Interest Group|Technical Architecture Group|Advisory Board)( and the (.+? Working Group|.+? Interest Group|Technical Architecture Group|Advisory Board))?/;
-
-    const text = sr.norm(sotd.textContent);
-    const matches = text.match(delivererNamesRegex);
-    const groups = [];
-    if (matches) {
-        groups.push(matches[1]);
-        if (matches[2]) groups.push(matches[2]);
-    }
-    return groups;
-};

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -513,7 +513,7 @@ Specberus.prototype.getFeedbackDueDate = function () {
 Specberus.prototype.getDelivererNames = function () {
     const sotd = this.getSotDSection();
     const delivererNamesRegex =
-        /This document was (?:produced|published) by the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board)( and the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board))?/;
+        /This document was (?:produced|published) by the (.+? Working Group|.+? Interest Group|Technical Architecture Group|Advisory Board)( and the (.+? Working Group|.+? Interest Group|Technical Architecture Group|Advisory Board))? as/;
 
     const text = this.norm(sotd.textContent);
     const matches = text.match(delivererNamesRegex);

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -509,6 +509,22 @@ Specberus.prototype.getFeedbackDueDate = function () {
     return dates;
 };
 
+// Return array of group names, e.g. ['Internationalization Working Group', 'Technical Architecture Group']
+export const getDelivererNames = function () {
+    const sotd = this.getSotDSection();
+    const delivererNamesRegex =
+        /This document was (?:produced|published) by the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board)( and the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board))?/;
+
+    const text = this.norm(sotd.textContent);
+    const matches = text.match(delivererNamesRegex);
+    const groups = [];
+    if (matches) {
+        groups.push(matches[1]);
+        if (matches[3]) groups.push(matches[3]);
+    }
+    return groups;
+};
+
 /**
  * getDelivererGroups get deliverers groupNames and types
  *

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -510,7 +510,7 @@ Specberus.prototype.getFeedbackDueDate = function () {
 };
 
 // Return array of group names, e.g. ['Internationalization Working Group', 'Technical Architecture Group']
-export const getDelivererNames = function () {
+Specberus.prototype.getDelivererNames = function () {
     const sotd = this.getSotDSection();
     const delivererNamesRegex =
         /This document was (?:produced|published) by the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board)( and the (\w+ Working Group|\w+ Interest Group|Technical Architecture Group|Advisory Board))?/;

--- a/test/data/TR/Note/NOTE.js
+++ b/test/data/TR/Note/NOTE.js
@@ -13,4 +13,17 @@ export const rules = {
             },
         ],
     },
+    sotd: {
+        ...baseRules.sotd,
+        stability: [
+            {
+                data: 'noStability',
+                errors: ['sotd.stability.no-stability'],
+            },
+            {
+                data: 'supportAnotherSW',
+                errors: [],
+            },
+        ],
+    },
 };

--- a/test/data/TR/Note/NOTE.js
+++ b/test/data/TR/Note/NOTE.js
@@ -24,6 +24,10 @@ export const rules = {
                 data: 'supportAnotherSW',
                 errors: [],
             },
+            {
+                data: 'supportAnotherSWJoint',
+                errors: [],
+            },
         ],
     },
 };

--- a/test/doc-views/TR/Note/noteBase.js
+++ b/test/doc-views/TR/Note/noteBase.js
@@ -38,8 +38,8 @@ const buildCommonViewData = base => {
                 sotd: {
                     ...base.sotd,
                     noteNotEndorsedText:
-                        'This Group Note is endorsed by the Internationalization Working Group and the Technical Architecture Group, but is not endorsed by W3C itself nor its Members',
-                    group: 'Internationalization Working Group and the Technical Architecture Group',
+                        'This Group Note is endorsed by the Decentralized Identifier Working Group and the Technical Architecture Group, but is not endorsed by W3C itself nor its Members',
+                    group: 'Decentralized Identifier Working Group and the Technical Architecture Group',
                 },
             },
         },

--- a/test/doc-views/TR/Note/noteBase.js
+++ b/test/doc-views/TR/Note/noteBase.js
@@ -22,7 +22,15 @@ const buildCommonViewData = base => {
                 sotd: {
                     ...base.sotd,
                     noteNotEndorsedText:
-                        'are not endorsed by FAKE nor its Members',
+                        'Group Notes are not endorsed by FAKE nor its Members',
+                },
+            },
+            supportAnotherSW: {
+                ...base,
+                sotd: {
+                    ...base.sotd,
+                    noteNotEndorsedText:
+                        'This Group Note is endorsed by the XXX Group, but is not endorsed by W3C itself nor its Members',
                 },
             },
         },

--- a/test/doc-views/TR/Note/noteBase.js
+++ b/test/doc-views/TR/Note/noteBase.js
@@ -30,7 +30,16 @@ const buildCommonViewData = base => {
                 sotd: {
                     ...base.sotd,
                     noteNotEndorsedText:
-                        'This Group Note is endorsed by the XXX Group, but is not endorsed by W3C itself nor its Members',
+                        'This Group Note is endorsed by the Internationalization Working Group, but is not endorsed by W3C itself nor its Members',
+                },
+            },
+            supportAnotherSWJoint: {
+                ...base,
+                sotd: {
+                    ...base.sotd,
+                    noteNotEndorsedText:
+                        'This Group Note is endorsed by the Internationalization Working Group and the Technical Architecture Group, but is not endorsed by W3C itself nor its Members',
+                    group: 'Internationalization Working Group and the Technical Architecture Group',
                 },
             },
         },

--- a/test/doc-views/partials/stability.handlebars
+++ b/test/doc-views/partials/stability.handlebars
@@ -4,7 +4,7 @@
         Group Draft Notes are not endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members. <span class="handlebars-data">{{sotd.draftText}}{{! This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.}}</span>
     {{/config.isDNOTE}}
     {{#config.isNOTE}}
-        Group Notes {{sotd.noteNotEndorsedText}}{{! are not endorsed by W3C nor its Members}}.
+        {{sotd.noteNotEndorsedText}}{{! are not endorsed by W3C nor its Members}}.
     {{/config.isNOTE}}
     {{#config.isSTMT}}
         A W3C Statement is a specification that, <span class="handlebars-data">{{sotd.recConsensusText}}{{! after extensive consensus-building}}</span>, is endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.

--- a/test/doc-views/specBase.js
+++ b/test/doc-views/specBase.js
@@ -134,7 +134,8 @@ export const data = {
         extra1: '',
         noEndorsementHTML:
             'does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members',
-        noteNotEndorsedText: 'are not endorsed by W3C nor its Members',
+        noteNotEndorsedText:
+            'Group Notes are not endorsed by W3C nor its Members',
 
         draftText:
             'This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.',


### PR DESCRIPTION
Allow both sentence A and B in DNOTE and NOTE:
A: This Group (Draft )?Note is endorsed by the XXX Group, but is not endorsed by W3C itself nor its Members.
B: Group (Draft )?Notes are not endorsed by W3C nor its Members.

For case A, also support joint publication: 
> This Group (Draft )?Note is endorsed by the AA Working Group and the BB Working Group, but is not endorsed by W3C itself nor its Members.

resolves #1075 