### PR TITLE
Add rule to detect echidna deliverer change

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,6 +14,7 @@
         "datedlink",
         "dcterms",
         "deniak",
+        "discr",
         "DNOTE",
         "doasync",
         "doctypes",
@@ -81,6 +82,7 @@
         "vcard",
         "wcag",
         "webidl",
+        "webperf",
         "webrtc",
         "Whut",
         "wrongprocess"

--- a/app.js
+++ b/app.js
@@ -115,7 +115,7 @@ io.on('connection', socket => {
             profile = await import(`./lib/profiles/${profilePath}`);
         } catch (err) {
             return socket.emit('exception', {
-                message: 'Profile does not exist.',
+                message: `Failed to get profile ${profilePath}.`,
             });
         }
         const specberus = new Specberus(process.env.W3C_API_KEY);

--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -360,7 +360,7 @@ export const messages = {
     'echidna.todays-date.date-not-detected':
         'Could not find a publication date in the document.',
     'echidna.deliverer-change.deliverer-changed':
-        'The deliverer has changed compared to the previous version',
+        'The list of groups producing this document has changed since the previous version',
     // Metadata:
     'metadata.deliverers': false,
     'metadata.dl.latest-not-found':

--- a/lib/l10n-en_GB.js
+++ b/lib/l10n-en_GB.js
@@ -359,6 +359,8 @@ export const messages = {
         'The publication date of this document must be set to today (UTC).',
     'echidna.todays-date.date-not-detected':
         'Could not find a publication date in the document.',
+    'echidna.deliverer-change.deliverer-changed':
+        'The deliverer has changed compared to the previous version',
     // Metadata:
     'metadata.deliverers': false,
     'metadata.dl.latest-not-found':

--- a/lib/profiles/TR/Note/DNOTE-Echidna.js
+++ b/lib/profiles/TR/Note/DNOTE-Echidna.js
@@ -1,6 +1,7 @@
 // TODO: merge all Echidna files.
 
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { config as baseConfig, rules as baseRules } from './DNOTE.js';
 
@@ -9,4 +10,5 @@ export const config = baseConfig;
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/profiles/TR/Note/NOTE-Echidna.js
+++ b/lib/profiles/TR/Note/NOTE-Echidna.js
@@ -1,4 +1,5 @@
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { config as baseConfig, rules as baseRules } from './NOTE.js';
 
@@ -7,4 +8,5 @@ export const config = baseConfig;
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/profiles/TR/Recommendation/CR-Echidna.js
+++ b/lib/profiles/TR/Recommendation/CR-Echidna.js
@@ -1,4 +1,5 @@
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { rules as baseRules } from './CR.js';
 
@@ -7,4 +8,5 @@ export { config } from './CR.js';
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/profiles/TR/Recommendation/CRD-Echidna.js
+++ b/lib/profiles/TR/Recommendation/CRD-Echidna.js
@@ -1,4 +1,5 @@
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { rules as baseRules } from './CRD.js';
 
@@ -7,4 +8,5 @@ export const name = 'CRD-Echidna';
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/profiles/TR/Recommendation/REC-Echidna.js
+++ b/lib/profiles/TR/Recommendation/REC-Echidna.js
@@ -1,4 +1,5 @@
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { rules as baseRules } from './REC.js';
 
@@ -7,4 +8,5 @@ export const name = 'REC-Echidna';
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/profiles/TR/Recommendation/WD-Echidna.js
+++ b/lib/profiles/TR/Recommendation/WD-Echidna.js
@@ -1,4 +1,5 @@
 import * as todaysDate from '../../../rules/echidna/todays-date.js';
+import * as delivererChange from '../../../rules/echidna/deliverer-change.js';
 import { insertAfter } from '../../profileUtil.js';
 import { rules as baseRules } from './WD.js';
 
@@ -7,4 +8,5 @@ export { config } from './WD.js';
 
 export const rules = insertAfter(baseRules, 'sotd.process-document', [
     todaysDate,
+    delivererChange,
 ]);

--- a/lib/rules/echidna/deliverer-change.js
+++ b/lib/rules/echidna/deliverer-change.js
@@ -10,7 +10,7 @@ const self = {
 
 export const { name } = self;
 
-async function getPreviousDelivererIDs(shortname, previousUrl) {
+function getPreviousDelivererIDs(shortname, previousUrl) {
     const date = previousUrl.match(/-(\d{8})\/$/);
     if (date)
         return new Promise(resolve => {

--- a/lib/rules/echidna/deliverer-change.js
+++ b/lib/rules/echidna/deliverer-change.js
@@ -11,17 +11,19 @@ const self = {
 export const { name } = self;
 
 async function getPreviousIDs(shortname, previousUrl) {
-    const date = previousUrl.match(/\d{8}/);
-    return new Promise(resolve => {
-        // e.g. https://api.w3.org/specifications/WGSL/versions/20230221/deliverers
-        w3cApi
-            .specification(shortname)
-            .version(date)
-            .deliverers()
-            .fetch({ embed: true }, (err, data) => {
-                resolve(data && data.map(obj => obj.id));
-            });
-    });
+    const date = previousUrl.match(/-(\d{8})\/$/);
+    if (date)
+        return new Promise(resolve => {
+            // e.g. https://api.w3.org/specifications/WGSL/versions/20230221/deliverers
+            w3cApi
+                .specification(shortname)
+                .version(date[1])
+                .deliverers()
+                .fetch({ embed: true }, (err, data) => {
+                    resolve(data && data.map(obj => obj.id));
+                });
+        });
+    return [];
 }
 
 /**

--- a/lib/rules/echidna/deliverer-change.js
+++ b/lib/rules/echidna/deliverer-change.js
@@ -1,0 +1,57 @@
+import w3cApi from 'node-w3capi';
+
+w3cApi.apiKey = process.env.W3C_API_KEY;
+
+const self = {
+    name: 'echidna.deliverer-change',
+    section: 'metadata',
+    rule: 'delivererID',
+};
+
+export const { name } = self;
+
+async function getPreviousIDs(shortname, previousUrl) {
+    const date = previousUrl.match(/\d{8}/);
+    return new Promise(resolve => {
+        // e.g. https://api.w3.org/specifications/WGSL/versions/20230221/deliverers
+        w3cApi
+            .specification(shortname)
+            .version(date)
+            .deliverers()
+            .fetch({ embed: true }, (err, data) => {
+                resolve(data && data.map(obj => obj.id));
+            });
+    });
+}
+
+/**
+ * @param sr
+ * @param done
+ */
+export async function check(sr, done) {
+    const previousVersion = await sr.getPreviousVersion(sr);
+    const shortname = await sr.getShortname(sr);
+
+    if (!previousVersion) {
+        return done();
+    }
+
+    const previousDelivererIDs = await getPreviousIDs(
+        shortname,
+        previousVersion
+    );
+    const delivererIDs = await sr.getDelivererIDs();
+
+    const delivererChanged =
+        delivererIDs.sort().toString() !==
+        previousDelivererIDs.sort().toString();
+
+    if (delivererChanged) {
+        sr.error(self, 'deliverer-changed', {
+            this: delivererIDs.sort().toString(),
+            previous: previousDelivererIDs.sort().toString(),
+        });
+    }
+
+    done();
+}

--- a/lib/rules/echidna/deliverer-change.js
+++ b/lib/rules/echidna/deliverer-change.js
@@ -23,7 +23,9 @@ function getPreviousDelivererIDs(shortname, previousUrl) {
                     resolve(data && data.map(obj => obj.id));
                 });
         });
-    return [];
+    return new Promise(resolve => {
+        resolve([]);
+    });
 }
 
 /**

--- a/lib/rules/echidna/deliverer-change.js
+++ b/lib/rules/echidna/deliverer-change.js
@@ -10,7 +10,7 @@ const self = {
 
 export const { name } = self;
 
-async function getPreviousIDs(shortname, previousUrl) {
+async function getPreviousDelivererIDs(shortname, previousUrl) {
     const date = previousUrl.match(/-(\d{8})\/$/);
     if (date)
         return new Promise(resolve => {
@@ -38,7 +38,7 @@ export async function check(sr, done) {
         return done();
     }
 
-    const previousDelivererIDs = await getPreviousIDs(
+    const previousDelivererIDs = await getPreviousDelivererIDs(
         shortname,
         previousVersion
     );

--- a/test/data/TR/TRBase.js
+++ b/test/data/TR/TRBase.js
@@ -154,6 +154,12 @@ export const echidnaRules = {
             errors: ['echidna.todays-date.wrong-date'],
         },
     ],
+    'deliverer-change': [
+        {
+            data: 'delivererChanged',
+            errors: ['echidna.deliverer-change.deliverer-changed'],
+        },
+    ],
 };
 
 export const draftStabilityRules = [

--- a/test/doc-views/TR/Note/DNOTE-Echidna.js
+++ b/test/doc-views/TR/Note/DNOTE-Echidna.js
@@ -3,7 +3,12 @@ import DNOTE from './DNOTE.js';
 import noteBase from './noteBase.js';
 
 const { good: data } = DNOTE;
-const { buildCommonViewData, buildDraftStability, buildTodaysDate } = noteBase;
+const {
+    buildCommonViewData,
+    buildDraftStability,
+    buildTodaysDate,
+    buildDelivererChange,
+} = noteBase;
 
 const profile = 'DNOTE-Echidna';
 const customData = {
@@ -44,4 +49,5 @@ export default {
     },
     'draft-stability': buildDraftStability(good),
     'todays-date': buildTodaysDate(good),
+    'deliverer-change': buildDelivererChange(good),
 };

--- a/test/doc-views/TR/Note/NOTE-Echidna.js
+++ b/test/doc-views/TR/Note/NOTE-Echidna.js
@@ -3,7 +3,7 @@ import NOTE from './NOTE.js';
 import noteBase from './noteBase.js';
 
 const { good: data } = NOTE;
-const { buildCommonViewData, buildTodaysDate } = noteBase;
+const { buildCommonViewData, buildTodaysDate, buildDelivererChange } = noteBase;
 
 const profile = 'NOTE-Echidna';
 const customData = {
@@ -34,4 +34,5 @@ export default {
         },
     },
     'todays-date': buildTodaysDate(good),
+    'deliverer-change': buildDelivererChange(good),
 };

--- a/test/doc-views/TR/Recommendation/CR-Echidna.js
+++ b/test/doc-views/TR/Recommendation/CR-Echidna.js
@@ -7,6 +7,7 @@ const {
     buildCommonViewData,
     buildSecurityPrivacy,
     buildTodaysDate,
+    buildDelivererChange,
 } = recommendationBase;
 
 const { good: data } = CR;
@@ -64,4 +65,5 @@ export default {
     },
     'todays-date': buildTodaysDate(good),
     'security-privacy': buildSecurityPrivacy(good),
+    'deliverer-change': buildDelivererChange(good),
 };

--- a/test/doc-views/TR/Recommendation/CRD-Echidna.js
+++ b/test/doc-views/TR/Recommendation/CRD-Echidna.js
@@ -8,6 +8,7 @@ const {
     buildDraftStability,
     buildSecurityPrivacy,
     buildTodaysDate,
+    buildDelivererChange,
 } = recommendationBase;
 
 const profile = 'CRD-Echidna';
@@ -45,4 +46,5 @@ export default {
     'draft-stability': buildDraftStability(good),
     'todays-date': buildTodaysDate(good),
     'security-privacy': buildSecurityPrivacy(good),
+    'deliverer-change': buildDelivererChange(good),
 };

--- a/test/doc-views/TR/Recommendation/WD-Echidna.js
+++ b/test/doc-views/TR/Recommendation/WD-Echidna.js
@@ -8,6 +8,7 @@ const {
     buildDraftStability,
     buildSecurityPrivacy,
     buildTodaysDate,
+    buildDelivererChange,
 } = recommendationBase;
 
 const profile = 'WD-Echidna';
@@ -44,4 +45,5 @@ export default {
         },
     },
     'todays-date': buildTodaysDate(good),
+    'deliverer-change': buildDelivererChange(good),
 };

--- a/test/doc-views/TR/TRBase.js
+++ b/test/doc-views/TR/TRBase.js
@@ -261,6 +261,22 @@ export function buildTodaysDate(base) {
     };
 }
 
+export function buildDelivererChange(base) {
+    return {
+        delivererChanged: {
+            ...base,
+            config: {
+                ...base.config,
+                isEchidna: true,
+            },
+            header: {
+                ...base.header,
+                defaultDate: '',
+            },
+        },
+    };
+}
+
 export function buildDraftStability(base) {
     return {
         noDraftEither: {

--- a/test/lib/nockData.js
+++ b/test/lib/nockData.js
@@ -1,4 +1,27 @@
 export const nockData = {
+    deliverers: {
+        page: 1,
+        limit: 100,
+        pages: 1,
+        total: 1,
+        _links: {},
+        _embedded: {
+            deliverers: [
+                {
+                    id: 32113,
+                    name: 'Web Performance Working Group',
+                    is_closed: false,
+                    description:
+                        'The mission of the Web Performance Working Group is to provide methods to measure aspects of application performance of user agent features and APIs.',
+                    shortname: 'webperf',
+                    discr: 'w3cgroup',
+                    type: 'working group',
+                    'start-date': '2010-08-18',
+                    'end-date': '2023-02-28',
+                },
+            ],
+        },
+    },
     versions: {
         page: 1,
         pages: 1,

--- a/test/rules.js
+++ b/test/rules.js
@@ -187,12 +187,6 @@ function buildHandler(test, mock, done) {
             .query({ embed: true })
             .reply(200, versions);
 
-        const { deliverers } = nockData;
-        nock('https://api.w3.org', { allowUnmocked: true })
-            .get(/\/specifications\/hr-time[-0-9a-zA-Z]*\/versions\/w*/)
-            .query({ embed: true })
-            .reply(200, deliverers);
-
         const { groupNames } = nockData;
         Object.keys(groupNames).forEach(groupName => {
             const groupId = groupNames[groupName];
@@ -280,7 +274,14 @@ describe('Making sure good documents pass Specberus...', () => {
         if (testProfile && testProfile !== docProfile) return;
 
         const url = `${ENDPOINT}/${testsGoodDoc[docProfile].url}`;
+
         it(`should pass for ${docProfile} doc with ${url}`, done => {
+            const { deliverers } = nockData;
+            nock('https://api.w3.org', { allowUnmocked: true })
+                .get(/\/specifications\/hr-time[-0-9a-zA-Z]*\/versions\/w*/)
+                .query({ embed: true })
+                .reply(200, deliverers);
+
             const profilePath = allProfiles.find(p =>
                 p.endsWith(`/${docProfile}.js`)
             );
@@ -313,7 +314,7 @@ describe('Making sure good documents pass Specberus...', () => {
                             },
                             events: buildHandler(
                                 { ignoreWarnings: true },
-                                true,
+                                false,
                                 done
                             ),
                             url,

--- a/test/rules.js
+++ b/test/rules.js
@@ -28,6 +28,12 @@ const DEFAULT_PORT = 8001;
 const PORT = process.env.PORT || DEFAULT_PORT;
 const ENDPOINT = `http://localhost:${PORT}`;
 
+// These 3 environment variables are to reduce test documents.
+// e.g. `RULE=copyright TYPE=noCopyright PROFILE=WD npm run test`
+const testRule = process.env.RULE;
+const testType = process.env.TYPE;
+const testProfile = process.env.PROFILE;
+
 /**
  * Assert that metadata detected in a spec is equal to the expected values.
  *
@@ -175,10 +181,17 @@ function buildHandler(test, mock, done) {
             .head('/standards/history/hr-time')
             .reply(200, 'HR Time history page');
         const { versions } = nockData;
+
         nock('https://api.w3.org', { allowUnmocked: true })
             .get('/specifications/hr-time/versions')
             .query({ embed: true })
             .reply(200, versions);
+
+        const { deliverers } = nockData;
+        nock('https://api.w3.org', { allowUnmocked: true })
+            .get(/\/specifications\/hr-time[-0-9a-zA-Z]*\/versions\/w*/)
+            .query({ embed: true })
+            .reply(200, deliverers);
 
         const { groupNames } = nockData;
         Object.keys(groupNames).forEach(groupName => {
@@ -264,6 +277,7 @@ describe('Making sure good documents pass Specberus...', () => {
     Object.keys(testsGoodDoc).forEach(docProfile => {
         // testsGoodDoc[docProfile].profile is used to distinguish multiple cases for same profile.
         docProfile = testsGoodDoc[docProfile].profile || docProfile;
+        if (testProfile && testProfile !== docProfile) return;
 
         const url = `${ENDPOINT}/${testsGoodDoc[docProfile].url}`;
         it(`should pass for ${docProfile} doc with ${url}`, done => {
@@ -299,7 +313,7 @@ describe('Making sure good documents pass Specberus...', () => {
                             },
                             events: buildHandler(
                                 { ignoreWarnings: true },
-                                false,
+                                true,
                                 done
                             ),
                             url,
@@ -316,12 +330,6 @@ describe('Making sure good documents pass Specberus...', () => {
     });
 });
 
-// These 3 environment variables are to reduce test documents.
-// e.g. `RULE=copyright TYPE=noCopyright PROFILE=WD npm run test`
-const testRule = process.env.RULE;
-const testType = process.env.TYPE;
-const testProfile = process.env.PROFILE;
-
 function checkRule(tests, options) {
     const { docType, track, profile, category, rule } = options;
 
@@ -334,7 +342,7 @@ function checkRule(tests, options) {
         if (
             (testRule && rule !== testRule) ||
             (testType && test.data !== testType) ||
-            (testProfile && profile !== 'CR')
+            (testProfile && profile !== testProfile)
         )
             return;
 


### PR DESCRIPTION
Add rule deliverer-change to echidna files, resolves https://github.com/w3c/echidna/issues/581

- Use W3C API to get previous version's deliverer id