### PR TITLE
allow exceptions for all profiles

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -206,12 +206,6 @@ Specberus.prototype.error = function (rule, key, extra) {
     else name = rule.name;
     if (
         this.shortname !== undefined &&
-        (this.config.status === 'WD' ||
-            this.config.status === 'CR' ||
-            this.config.status === 'CRD' ||
-            this.config.status === 'DRY' ||
-            this.config.status === 'DNOTE' ||
-            this.config.status === 'NOTE') &&
         this.exceptions.has(this.shortname, name, key, extra)
     )
         this.warning(rule, key, extra);


### PR DESCRIPTION
In the past, we only allowed rule exceptions for WD, Notes, CR, CRD and DRY.
Looking at the current exceptions, I think that restriction can now be removed.

This will allow the publications of some edited RECs (that have an exception) with echidna.

@plehegar, how does that sound?