### PR TITLE
we no longer serve assets from cdn.w3.org

### DIFF
--- a/lib/rules/links/linkchecker.js
+++ b/lib/rules/links/linkchecker.js
@@ -19,7 +19,7 @@ const allowList = [
     'https://www.w3.org/TR/tr-outdated-spec',
     /^https:\/\/www.w3.org\/analytics\/piwik\//,
     /^https:\/\/test.csswg.org\/harness\//,
-    /^https:\/\/cdn.w3.org\/assets\//,
+    /^https:\/\/www.w3.org\/assets\//,
     /^data:/,
 ];
 const noRespondAllowList = [


### PR DESCRIPTION
Assets are now served from www.w3.org. That PR updates the reference to cdn.w3.org