### PR TITLE
ignore editors participation for privacy-principles

### DIFF
--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -15,14 +15,19 @@
             "rule": "sotd.candidate-review-end"
         }
     ],
-    "^pub-manifest$": [
-        {
-            "rule": "sotd.candidate-review-end"
-        }
-    ],
     "^did-core$": [
         {
             "rule": "heuristic.date-format"
+        }
+    ],
+    "^privacy-principles$": [
+        {
+            "rule": "headers.editor-participation"
+        }
+    ],
+    "^pub-manifest$": [
+        {
+            "rule": "sotd.candidate-review-end"
         }
     ]
 }


### PR DESCRIPTION
Discussing with @ylafon and @plehegar, the editors participation rule should not apply to the spec privacy-principles