### PR TITLE
Add copyright exception for Ruby markup extensions

### DIFF
--- a/lib/copyright-exceptions.json
+++ b/lib/copyright-exceptions.json
@@ -31,5 +31,9 @@
     {
         "specShortnames": ["sdw-bp"],
         "copyright": "Copyright © @YEAR <a href=\"https://www.ogc.org/\">OGC</a> &amp; <a href=\"https://www.w3.org/\">World Wide Web Consortium</a>. <abbr title=\"World Wide Web Consortium\">W3C</abbr><sup>®</sup> <a href=\"https://www.w3.org/policies/#Legal_Disclaimer\">liability</a>, <a href=\"https://www.w3.org/policies/#W3C_Trademarks\">trademark</a>, <a href=\"https://www.w3.org/copyright/document-license/\">W3C</a> and <a href=\"https://www.ogc.org/ogc/document\">OGC</a> document use rules apply."
+    },
+    {
+        "specShortnames": ["html-ruby-extensions"],
+        "copyright": "<a href=\"https://www.w3.org/policies/#copyright\">Copyright</a> © @YEAR <a href=\"https://www.w3.org/\">World Wide Web Consortium</a> and WHATWG (Apple, Google, Mozilla, Microsoft). <abbr title=\"World Wide Web Consortium\">W3C</abbr><sup>®</sup> <a href=\"https://www.w3.org/policies/#Legal_Disclaimer\">liability</a>, and <a href=\"https://www.w3.org/policies/#W3C_Trademarks\">trademark</a> rules apply. This work is licensed under a <a href=\"This work is licensed under a Creative Commons Attribution 4.0 International License.\">Creative Commons Attribution 4.0 International License.</a>"
     }
 ]

--- a/lib/copyright-exceptions.json
+++ b/lib/copyright-exceptions.json
@@ -34,6 +34,6 @@
     },
     {
         "specShortnames": ["html-ruby-extensions"],
-        "copyright": "<a href=\"https://www.w3.org/policies/#copyright\">Copyright</a> © @YEAR <a href=\"https://www.w3.org/\">World Wide Web Consortium</a> and WHATWG (Apple, Google, Mozilla, Microsoft). <abbr title=\"World Wide Web Consortium\">W3C</abbr><sup>®</sup> <a href=\"https://www.w3.org/policies/#Legal_Disclaimer\">liability</a>, and <a href=\"https://www.w3.org/policies/#W3C_Trademarks\">trademark</a> rules apply. This work is licensed under a <a href=\"This work is licensed under a Creative Commons Attribution 4.0 International License.\">Creative Commons Attribution 4.0 International License.</a>"
+        "copyright": "<a href=\"https://www.w3.org/policies/#copyright\">Copyright</a> © @YEAR <a href=\"https://www.w3.org/\">World Wide Web Consortium</a> and WHATWG (Apple, Google, Mozilla, Microsoft). <abbr title=\"World Wide Web Consortium\">W3C</abbr><sup>®</sup> <a href=\"https://www.w3.org/policies/#Legal_Disclaimer\">liability</a>, and <a href=\"https://www.w3.org/policies/#W3C_Trademarks\">trademark</a> rules apply. This work is licensed under a <a href=\"https://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution 4.0 International License</a>."
     }
 ]


### PR DESCRIPTION
This PR adds custom copyright line for HTML Ruby Markup Extensions.

Here's the context which makes this necessary and appropriate:

The Licensing section of the charter of the HTML-WG (https://www.w3.org/2022/06/html-wg-charter.html#licensing) states that:
> This Working Group will use the CC-BY license, and follow the terms of
> WHATWG-W3C Memorandum of Understanding and 2021 Relationship Update

The specify CC-BY license use by HTML
(https://html.spec.whatwg.org/multipage/acknowledgements.html#ipr) is
Attribution International 4.0 (CC BY 4.0).

html-ruby-extensions is an upcoming chartered deliverable of the HTML-WG: https://www.w3.org/2022/06/html-wg-charter.html#ruby

Its content will devrive both from W3C deliverables and from the WHATWG's HTML Standard.

This publication is agreed to by W3C and the WHATWG: https://www.w3.org/2022/02/ruby-agreement


cc: @LJWatson (as chair of the HTML-WG), @siusin (as Team contact of the HTML-WG)