### PR TITLE
Update copyright-exceptions.json

### DIFF
--- a/lib/copyright-exceptions.json
+++ b/lib/copyright-exceptions.json
@@ -10,7 +10,6 @@
             "epub-a11y-11",
             "epub-a11y-tech-11",
             "epub-aria-authoring-11",
-            "epub-fxl-a11y",
             "epubcfi",
             "epubcfi-11"
         ],


### PR DESCRIPTION
The fixed layout accessibility note of the Publishing Maintenance WG should not be under a joint IDPF copyright. Removing therefore the relevant line from the exceptions' list.

cc: @wareid