### PR TITLE
add exception on implementation report for webgpu and WGSL

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -91,11 +91,13 @@
         "vcard",
         "WHATWG",
         "wcag",
+        "webgpu",
         "webidl",
         "webperf",
         "webrtc",
         "Whut",
-        "wrongprocess"
+        "wrongprocess",
+        "WGSL"
     ],
     "dictionaries": ["html", "js", "css", "npm", "en-gb"],
     "ignorePaths": [

--- a/lib/exceptions.json
+++ b/lib/exceptions.json
@@ -29,5 +29,11 @@
         {
             "rule": "sotd.candidate-review-end"
         }
+    ],
+    "^webgpu|WGSL$": [
+        {
+            "rule": "headers.dl",
+            "message": "Implementation report"
+        }
     ]
 }

--- a/lib/rules/headers/dl.js
+++ b/lib/rules/headers/dl.js
@@ -39,7 +39,8 @@ export const name = self.name;
  */
 function checkLink({ sr, rule = self, element, linkName, mustHave = true }) {
     if (!element || !element.href) {
-        if (mustHave) sr.error(rule, 'not-found', { linkName });
+        if (mustHave)
+            sr.error(rule, 'not-found', { linkName, message: linkName });
         return false;
     }
     const text = sr.norm(element.textContent).trim();

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -195,11 +195,11 @@ Specberus.prototype.validate = function (options) {
         .catch(err => this.throw(err.toString()));
 };
 
-Specberus.prototype.error = async function (rule, key, extra) {
+Specberus.prototype.error = function (rule, key, extra) {
     let name;
     if (typeof rule === 'string') name = rule;
     else name = rule.name;
-    const shortname = this.shortname || (await this.getShortname());
+    const shortname = this.getShortname();
     if (
         shortname !== undefined &&
         this.exceptions.has(this.shortname, name, key, extra)
@@ -449,7 +449,7 @@ Specberus.prototype.getEditorIDs = function () {
     return result;
 };
 
-Specberus.prototype.getShortname = async function () {
+Specberus.prototype.getShortname = function () {
     if (undefined !== this.shortname) {
         return this.shortname;
     }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -195,12 +195,13 @@ Specberus.prototype.validate = function (options) {
         .catch(err => this.throw(err.toString()));
 };
 
-Specberus.prototype.error = function (rule, key, extra) {
+Specberus.prototype.error = async function (rule, key, extra) {
     let name;
     if (typeof rule === 'string') name = rule;
     else name = rule.name;
+    const shortname = this.shortname || (await this.getShortname());
     if (
-        this.shortname !== undefined &&
+        shortname !== undefined &&
         this.exceptions.has(this.shortname, name, key, extra)
     )
         this.warning(rule, key, extra);


### PR DESCRIPTION
webgpu and WGSL are transitioning to CR but the implementation report will be published later on.
That PR adds an exception to pubrules to allow subsequent CRD publications.
I will remove the exception once the implementation report is ready.