### PR TITLE
Statement stability: allow both document and specification wordings

### DIFF
--- a/lib/rules/sotd/stability.js
+++ b/lib/rules/sotd/stability.js
@@ -19,7 +19,7 @@ async function findSW(candidates, sr) {
         wanted = `(${sr.config.longStatus}s are not endorsed by W3C nor its Members|This ${sr.config.longStatus} is endorsed by the ${groups}, but is not endorsed by W3C itself nor its Members).`;
     } else if (sr.config.longStatus === 'Statement') {
         wanted =
-            'A W3C Statement is a specification that, after extensive consensus-building, is endorsed by W3C and its Members.';
+            'A W3C Statement is a (specification|document) that, after extensive consensus-building, is endorsed by W3C and its Members.';
     } else if (sr.config.longStatus === 'Discontinued Draft') {
         wanted =
             'Publication as a Discontinued Draft implies that this document is no longer intended to advance or to be maintained. It is inappropriate to cite this document as other than abandoned work.';
@@ -58,16 +58,18 @@ async function findSW(candidates, sr) {
         }${cryType ? CRY_INTRO : ''}`;
     }
 
+    const wantedRE = new RegExp(wanted);
+
     // TODO: better some
     Array.prototype.some.call(candidates, p => {
         const text = sr.norm(p.textContent);
-        if (text.match(wanted)) {
+        if (text.match(wantedRE)) {
             sw = p;
             return true;
         }
         return false;
     });
-    return { sw, expected: wanted };
+    return { sw, expected: wantedRE };
 }
 
 const self = {


### PR DESCRIPTION
Based on a discussion with @koalie and @plehegar, we should allow describe a statement as a "document" or a "specification".
That PR updates the stability check to allow both words