### PR TITLE
do not check editors' participation to the group producing the spec

### DIFF
--- a/lib/profiles/TR/Recommendation/DISC.js
+++ b/lib/profiles/TR/Recommendation/DISC.js
@@ -14,6 +14,7 @@ export const config = {
 };
 
 export const rules = removeRules(baseRules, [
+    'headers.editor-participation',
     'structure.security-privacy',
     'sotd.diff',
 ]);


### PR DESCRIPTION
Discontinued specs should not require the editors to be participating in the group.

/cc @svgeesus @plehegar 