### PR TITLE
restore profiles export

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -53,6 +53,22 @@ export const allProfiles = [
     ...filesSUBM.map(x => `SUBM/${x}`),
 ];
 
+export const profiles = Object.fromEntries(
+    allProfiles
+        .map(file => {
+            const match =
+                /((TR|SUBM)\/([A-Za-z]+\/)?([A-Z][A-Z-]*[A-Z](-Echidna)?))\.js$/.exec(
+                    file
+                );
+            if (match && match[4]) {
+                const key = match[4];
+                return [key, import(`./profiles/${match[0]}`)];
+            }
+            return null;
+        })
+        .filter(Boolean)
+);
+
 /**
  * Build a function that builds an “options” object based on certain parameters.
  *


### PR DESCRIPTION
https://github.com/w3c/specberus/pull/1441 removed the `profiles` export but spec-prod still relies on it.
That PR restores it.