### PR TITLE
shortname change for epub-a11y and epub-a11y-tech

### DIFF
--- a/lib/copyright-exceptions.json
+++ b/lib/copyright-exceptions.json
@@ -11,9 +11,9 @@
             "epub-tts-10",
             "epub-ssv-11",
             "epub-a11y-11",
-            "epub-a11y-111",
+            "epub-a11y-12",
             "epub-a11y-tech-11",
-            "epub-a11y-tech-111",
+            "epub-a11y-tech-12",
             "epub-aria-authoring-11",
             "epubcfi",
             "epubcfi-11"


### PR DESCRIPTION
Replaced deprecated copyright exceptions with updated versions.