### PR TITLE
Remove Node.js version 20 from CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         if: ${{ github.event_name != 'pull_request_target' }}


### PR DESCRIPTION
We are going to remove support for node 20 in an upcoming release.
That PR updates the CI to only run with node 22 and 24 to avoid blocking the PR for that future release.