### PR TITLE
Remove Node v20 from CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         if: ${{ github.event_name != 'pull_request_target' }}


### PR DESCRIPTION
This removes Node v20 from the CI workflow so that automated tests can run properly on PRs against the typescript branch.

This PR does not remove v20 from `engines` yet, to allow for continuing to provide fixes within the 12.x line.

Node v20 just reached end-of-life for security updates last week, and we do plan to remove support for v20 in the next major release, when the TypeScript migration and related API updates are merged.