### PR TITLE
Tests: Add mock for Nu HTML checker requests

### DIFF
--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -189,6 +189,13 @@ export function setupMocks(overrides) {
                 );
         }
     }
+
+    // Mock Nu HTML Checker requests to return no messages
+    // (without mocks, the validate API tests result in an error from the service anyway)
+    nock('https://validator.w3.org')
+        .persist()
+        .post('/nu/?out=json')
+        .reply(200, { messages: [] });
 }
 
 /** Cleans up mocks and event handler from setupMocks. */


### PR DESCRIPTION
This adds a mock for the few requests I had intentionally de-scoped from #2048.

The tests in `rules.js` already de-scope the HTML validation test, and as it turns out, the few API tests that do end up invoking it haven't particularly checked its results, and the requests to the service were resulting in errors yielding `validHTML: 'no-response'` within `warnings` anyway. This mock suppresses that warning while also avoiding the network requests.