### PR TITLE
Tests: Deny unmocked non-localhost requests

### DIFF
--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -71,6 +71,7 @@ function warnOnNonLocalRequest(req) {
 export function setupMocks(overrides) {
     // Report non-local URLs that were not mocked during test runs
     nock.emitter.on('no match', warnOnNonLocalRequest);
+    nock.enableNetConnect('localhost'); // Only allow localhost requests to proceed unmocked
 
     /** @type {typeof nockData} */
     const mockData = overrides ? merge({}, nockData, overrides) : nockData;
@@ -201,5 +202,6 @@ export function setupMocks(overrides) {
 /** Cleans up mocks and event handler from setupMocks. */
 export function cleanupMocks() {
     nock.emitter.off('no match', warnOnNonLocalRequest);
+    nock.enableNetConnect();
     nock.cleanAll();
 }


### PR DESCRIPTION
This will completely block any unmocked requests to anything besides localhost while mocks are hooked up. (localhost is excluded in order for requests to specberus' own API server and test server to work.)

Verified by commenting out some of the mocks to confirm that tests start failing; the "Unmocked local request" warnings from the existing `no match` event handler also still print.