### PR TITLE
Convert validate, extractMetadata, and rule check APIs to return promises

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,7 +18,6 @@
         "deniak",
         "discr",
         "DNOTE",
-        "doasync",
         "doctypes",
         "domhandler",
         "dvcs",
@@ -126,13 +125,7 @@
     "overrides": [
         {
             "filename": ["package.json"],
-            "words": [
-                "capi",
-                "doasync",
-                "metaviewport",
-                "nodesecurity",
-                "vulns"
-            ]
+            "words": ["capi", "metaviewport", "nodesecurity", "vulns"]
         }
     ],
     "ignoreWords": ["en", "gb"]

--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ This method returns a Promise that resolves with errors, warnings, and informati
 - `source`: A `String` with the content to check.
 - `file`: A file system path to the content to check.
 - `profile`: A profile object which defines the validation. Required. See below.
-- `events`: An event sink which supports the same interface as the Node.js `EventEmitter`. Required. See
-  below for the events that get generated.
 
 ### `extractMetadata(options)`
 
@@ -400,20 +398,24 @@ Profiles that are identical to its parent profile, ie that do not add any new ru
 
 ## 7. Validation events
 
-For a given checking run, the event sink you specify will be receiving a bunch of events as
+For a given checking run, the Specberus instance will fire events as
 indicated below. Events are shown as having parameters since those are passed to the event handler.
 
-- `done(rule-name)`: Fired when a specific rule has finished processing, including its asynchronous
+- `done(ruleName)`: Fired when a specific rule has finished processing, including its asynchronous
   tasks.
-- `err(error-name, data)`: Fired when an error is detected. The `data` contains further details,
+- `err(rule, data)`: Fired when an error is detected. The `data` contains further details,
   that depend on the error but _should_ feature a `message` field. There can be multiple errors for
-  a given rule. There cannot also be `ok` events but there can be `warning`s.
-- `warning(warning-name, data)`: Fired for non-fatal problems with the document that may
-  nevertheless require investigation. There may be several for a rule.
-- `info(info-name, data)`: Fired for additional information items detected by the validator.
-- `exception(message)`: Fired when there is a system error, such as a _File not found_ error. `message`
+  each rule.
+- `warning(rule, data)`: Fired for non-fatal problems with the document that may
+  nevertheless require investigation. There can be multiple warnings for each rule.
+- `info(rule, data)`: Fired for additional information items detected by the validator.
+- `exception({ message })`: Fired when there is a system error, such as a _File not found_ error. `message`
   contains details about this error. All exceptions are displayed on the error console in addition to
   this event being fired.
+
+The `rule` object passed to `err`, `warning` and `info` events will always contain a `name` string,
+and may also contain `rule` and `section` strings. The `data` object passed to these events will contain
+`key` and `detailMessage` strings, and may also contain an `extra` object with additional fields.
 
 ## 8. Writing rules
 
@@ -425,7 +427,7 @@ The Specberus object exposes the following API that's useful for validation:
 
 - `source`. The HTML source of the document being processed
 - `url`. The URL of the document being processed, only applicable if `options.url` was specified
-- `error`, `warn`, `info`. Methods for firing respective levels of events to the instance's sink.
+- `error`, `warn`, `info`. Methods for firing respective levels of events on the instance.
   All three methods accept the same arguments:
     - `rule` object: at minimum, an object with a `name` string. May also contain `rule` and `section` strings.
     - `key` string: specifies the precise occurrence within the particular `rule`

--- a/README.md
+++ b/README.md
@@ -398,32 +398,46 @@ Profiles that are identical to its parent profile, ie that do not add any new ru
 
 ## 7. Validation events
 
-For a given checking run, the Specberus instance will fire events as
-indicated below. Events are shown as having parameters since those are passed to the event handler.
+When using the JS API, the Specberus instance will fire various events.
+The `Specberus` class extends [`EventEmitter`](https://nodejs.org/dist/latest/docs/api/events.html#class-eventemitter),
+so listeners can be registered using the `on` API.
+
+```js
+const specberus = new Specberus();
+specberus.on('error', (rule, data) => {
+    // ...
+});
+```
+
+Events listed below are expressed with parameters to reflect what is passed to the event handler.
 
 - `done(ruleName)`: Fired when a specific rule has finished processing, including its asynchronous
-  tasks.
-- `err(rule, data)`: Fired when an error is detected. The `data` contains further details,
-  that depend on the error but _should_ feature a `message` field. There can be multiple errors for
-  each rule.
+  tasks. This fires regardless of whether the rule passes, fails, or encounters an unexpected
+  system error (exception).
+- `err(rule, data)`: Fired when an error is detected. There can be multiple errors for each rule.
+    - `rule` contains information on which rule failed validation;
+      always includes a `name` string, and may also include `rule` and `section` strings
+    - `data` contains further details; always includes `key` and `detailMessage` strings,
+      and optionally includes an `extra` object with additional fields that vary by error
 - `warning(rule, data)`: Fired for non-fatal problems with the document that may
   nevertheless require investigation. There can be multiple warnings for each rule.
+  `rule` and `data` follow the same format as for `err` events.
 - `info(rule, data)`: Fired for additional information items detected by the validator.
-- `exception({ message })`: Fired when there is a system error, such as a _File not found_ error. `message`
-  contains details about this error. All exceptions are displayed on the error console in addition to
+  `rule` and `data` follow the same format as for `err` and `warning` events.
+- `exception({ message })`: Fired when there is an unexpected system error, such as a
+  _File not found_ error. The event passes an object with a `message` property containing
+  details about this error. All exceptions are displayed on the error console in addition to
   this event being fired.
-
-The `rule` object passed to `err`, `warning` and `info` events will always contain a `name` string,
-and may also contain `rule` and `section` strings. The `data` object passed to these events will contain
-`key` and `detailMessage` strings, and may also contain an `extra` object with additional fields.
 
 ## 8. Writing rules
 
-Rules are simple modules that just expose a `check(sr, cb)` method. They receive a Specberus object
-and a callback, use the Specberus object to fire validation events and call the callback when
-they're done.
+Rules are simple modules that just expose a `check(sr)` method. They receive a Specberus object,
+which they use to examine the document and fire validation events. They return a promise which
+resolves on completion (regardless of pass or fail) or rejects on unexpected system error
+(exception). Usually, they are written as `async` functions to automatically handle the
+resolve vs. reject distinction.
 
-The Specberus object exposes the following API that's useful for validation:
+The Specberus object exposes the following APIs useful for validation:
 
 - `source`. The HTML source of the document being processed
 - `url`. The URL of the document being processed, only applicable if `options.url` was specified
@@ -433,9 +447,9 @@ The Specberus object exposes the following API that's useful for validation:
     - `key` string: specifies the precise occurrence within the particular `rule`
     - `extra` object (optional): any additional fields to include within the event
 - `version`. The Specberus version.
-- `checkSelector(selector, rule-name, cb)`. Some rules need to do nothing other than to check that a
-  selector returns some content. For this case, the rule can just call this method with the selector
-  and its callback, and Specberus will conveniently take care of all the rest.
+- `checkSelector(selector, ruleName)`. Some rules need to do nothing other than to check that a
+  selector returns some content. This handles checking the selector, reporting an error if it is
+  not found, or throwing an error if the selector is invalid.
 - `norm(text)`. Returns a whitespace-normalized version of the text.
 - `getDocumentDate()`. Returns a Date object that matches the document's date as specified in the
   headers' `stateElement` (id="w3c-state").

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This method returns a Promise that resolves with errors, warnings, and informati
 
 ### `extractMetadata(options)`
 
-This method returns a Promise that resolves with with metadata inferred from the document.
+This method returns a Promise that resolves with metadata inferred from the document.
 
 The `options` accepted are equal to those in `validate()`, with the following differences:
 
@@ -226,7 +226,7 @@ The following is an example of the value of the `metadata` object after the exec
 Similar to the [JS API](#4-js-api), Specberus exposes a REST API via HTTP too.
 
 The base path is `<host>/api/`.
-Use either `url` or `file` to pass along the document (neither `source` nor `document` are allowed).
+Use either `url` or `file` to pass along the document (`source` is not allowed).
 
 Note: If you want to use the public W3C instance of Specberus, you can replace `<host>` with `https://www.w3.org/pubrules`.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The `options` accepted are equal to those in `validate()`, with the following di
 - Optional `additionalMetadata` property, which performs additional checks (e.g. errata URL)
 - No `profile` or `validation` properties (this method can be used to _determine_ profile)
 
-The resolved object may include up to 20 properties described below:
+The resolved object's `metadata` property points to an object with up to 20 properties, described below:
 
 - `profile`
 - `title`: The (possible) title of the document
@@ -205,7 +205,7 @@ The resolved object may include up to 20 properties described below:
 
 If some of these pieces of metadata cannot be deduced, that key will not exist, or its value will not be defined.
 
-This is an example of the value of `Specberus.meta` after the execution of `Specberus.extractMetadata()`:
+The following is an example of the value of the `metadata` object after the execution of `Specberus.extractMetadata()`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -159,26 +159,28 @@ const specberus = new Specberus();
 
 ### `validate(options)`
 
-This method takes an object with the following fields:
+This method returns a Promise that resolves with errors, warnings, and informative messages resulting from relevant checks.
+
+`options` is an object accepting the following fields:
 
 - `url`: URL of the content to check. One of `url`, `source`, `file`, or `document` must be
   specified and if several are they will be used in this order.
 - `source`: A `String` with the content to check.
 - `file`: A file system path to the content to check.
-- `document`: A DOM `Document` object to be checked.
 - `profile`: A profile object which defines the validation. Required. See below.
 - `events`: An event sink which supports the same interface as the Node.js `EventEmitter`. Required. See
   below for the events that get generated.
 
 ### `extractMetadata(options)`
 
-This method eventually extends `this` with metadata inferred from the document.
-Once the [event `end-all`](#validation-events) is emitted, the metadata should be available in a new property called `meta`.
+This method returns a Promise that resolves with with metadata inferred from the document.
 
-The `options` accepted are equal to those in `validate()`, except that a `profile` is not necessary and will be ignored (finding out the profile is one of the
-goals of this method).
+The `options` accepted are equal to those in `validate()`, with the following differences:
 
-`this.meta` will be an `Object` and may include up to 20 properties described below:
+- Optional `additionalMetadata` property, which performs additional checks (e.g. errata URL)
+- No `profile` or `validation` properties (this method can be used to _determine_ profile)
+
+The resolved object may include up to 20 properties described below:
 
 - `profile`
 - `title`: The (possible) title of the document
@@ -225,7 +227,7 @@ This is an example of the value of `Specberus.meta` after the execution of `Spec
 
 Similar to the [JS API](#4-js-api), Specberus exposes a REST API via HTTP too.
 
-The endpoint is `<host>/api/`.
+The base path is `<host>/api/`.
 Use either `url` or `file` to pass along the document (neither `source` nor `document` are allowed).
 
 Note: If you want to use the public W3C instance of Specberus, you can replace `<host>` with `https://www.w3.org/pubrules`.
@@ -401,21 +403,14 @@ Profiles that are identical to its parent profile, ie that do not add any new ru
 For a given checking run, the event sink you specify will be receiving a bunch of events as
 indicated below. Events are shown as having parameters since those are passed to the event handler.
 
-- `start-all(profile-name)`: Fired first to indicate that the profile's checking has started.
-- `end-all(profile-name)`: Fired last to indicate that the profile's checking has completed. When
-  you receive this you are promised that all testing operations, including asynchronous ones, have
-  terminated.
 - `done(rule-name)`: Fired when a specific rule has finished processing, including its asynchronous
   tasks.
-- `ok(rule-name)`: Fired to indicate that a rule has succeeded. There is only one `ok` per rule.
-  There cannot also be `err` events but there can be `warning` events.
 - `err(error-name, data)`: Fired when an error is detected. The `data` contains further details,
   that depend on the error but _should_ feature a `message` field. There can be multiple errors for
   a given rule. There cannot also be `ok` events but there can be `warning`s.
-- `warning(warnings-name, data)`: Fired for non-fatal problems with the document that may
+- `warning(warning-name, data)`: Fired for non-fatal problems with the document that may
   nevertheless require investigation. There may be several for a rule.
 - `info(info-name, data)`: Fired for additional information items detected by the validator.
-- `metadata(key, value)`: Fired for every piece of document metadata found by the validator.
 - `exception(message)`: Fired when there is a system error, such as a _File not found_ error. `message`
   contains details about this error. All exceptions are displayed on the error console in addition to
   this event being fired.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This method returns a Promise that resolves with errors, warnings, and informati
 
 `options` is an object accepting the following fields:
 
-- `url`: URL of the content to check. One of `url`, `source`, `file`, or `document` must be
+- `url`: URL of the content to check. One of `url`, `source`, or `file` must be
   specified and if several are they will be used in this order.
 - `source`: A `String` with the content to check.
 - `file`: A file system path to the content to check.

--- a/app.ts
+++ b/app.ts
@@ -7,7 +7,6 @@ import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import fileUpload from 'express-fileupload';
-import EventEmitter from 'events';
 import { writeFile } from 'fs';
 import http from 'http';
 // @ts-ignore (no typings)
@@ -67,8 +66,7 @@ io.on('connection', socket => {
                 message: 'URL or file not provided.',
             });
         const specberus = new Specberus();
-        const handler = new EventEmitter();
-        handler.on('err', (type, data) => {
+        specberus.on('err', (type, data) => {
             try {
                 socket.emit(
                     'err',
@@ -78,7 +76,7 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('warning', (type, data) => {
+        specberus.on('warning', (type, data) => {
             try {
                 socket.emit(
                     'warning',
@@ -88,7 +86,7 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('info', (type, data) => {
+        specberus.on('info', (type, data) => {
             try {
                 socket.emit(
                     'info',
@@ -98,10 +96,9 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('exception', data => {
+        specberus.on('exception', data => {
             socket.emit('exception', data);
         });
-        data.events = handler;
         try {
             const metadata = await specberus.extractMetadata(data);
             socket.emit('finishedExtraction', {
@@ -135,12 +132,11 @@ io.on('connection', socket => {
             });
         }
         const specberus = new Specberus();
-        const handler = new EventEmitter();
         const profileCode = profile.name;
         socket.emit('start', {
             rules: (profile.rules || []).map(rule => rule.name),
         });
-        handler.on('err', (type, data) => {
+        specberus.on('err', (type, data) => {
             try {
                 socket.emit(
                     'err',
@@ -150,7 +146,7 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('warning', (type, data) => {
+        specberus.on('warning', (type, data) => {
             try {
                 socket.emit(
                     'warning',
@@ -160,7 +156,7 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('info', (type, data) => {
+        specberus.on('info', (type, data) => {
             try {
                 socket.emit(
                     'info',
@@ -170,10 +166,10 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('done', name => {
+        specberus.on('done', name => {
             socket.emit('done', { name });
         });
-        handler.on('exception', data => {
+        specberus.on('exception', data => {
             socket.emit('exception', data);
         });
 
@@ -192,7 +188,6 @@ io.on('connection', socket => {
                             await specberus.validate({
                                 url: data.url,
                                 profile,
-                                events: handler,
                                 validation: data.validation,
                             });
                         } catch (e) {
@@ -220,7 +215,6 @@ io.on('connection', socket => {
                 await specberus.validate({
                     file: data.file,
                     profile,
-                    events: handler,
                     validation: data.validation,
                 });
             } finally {

--- a/app.ts
+++ b/app.ts
@@ -12,14 +12,14 @@ import http from 'http';
 // @ts-ignore (no typings)
 import insafe from 'insafe';
 import morgan from 'morgan';
-import { Server } from 'socket.io';
+import { Server, type Socket } from 'socket.io';
 import tmp from 'tmp';
 
 import * as api from './lib/api.js';
 import badterms from './lib/badterms.js';
 import * as l10n from './lib/l10n.js';
 import { allProfiles, specberusVersion } from './lib/util.js';
-import { Specberus } from './lib/validator.js';
+import { ExceptionsError, Specberus } from './lib/validator.js';
 import * as views from './lib/views.js';
 import type { ProfileModule } from './lib/types.js';
 
@@ -57,6 +57,18 @@ views.setUp(app);
 l10n.setLanguage('en_GB');
 
 server.listen(process.argv[2] || process.env.PORT || DEFAULT_PORT);
+
+/** Emits misc. errors, for cases where 'exception' handler already emits individual exceptions. */
+function reportNonExceptionsError(
+    socket: Socket,
+    e: any,
+    subject: 'Metadata extraction' | 'Validation'
+) {
+    if (!(e instanceof ExceptionsError))
+        socket.emit('exception', {
+            message: `${subject} encountered an unexpected error: ${e}`,
+        });
+}
 
 io.on('connection', socket => {
     socket.emit('handshake', { version: specberusVersion });
@@ -105,8 +117,8 @@ io.on('connection', socket => {
                 ...metadata,
                 url: data.url,
             });
-        } catch {
-            // exceptions already emitted from event handler
+        } catch (e) {
+            reportNonExceptionsError(socket, e, 'Metadata extraction');
         }
     });
     socket.on('validate', async data => {
@@ -191,9 +203,7 @@ io.on('connection', socket => {
                                 validation: data.validation,
                             });
                         } catch (e) {
-                            socket.emit('exception', {
-                                message: `Validation blew up: ${e}`,
-                            });
+                            reportNonExceptionsError(socket, e, 'Validation');
                         } finally {
                             socket.emit('finished');
                         }
@@ -217,6 +227,8 @@ io.on('connection', socket => {
                     profile,
                     validation: data.validation,
                 });
+            } catch (e) {
+                reportNonExceptionsError(socket, e, 'Validation');
             } finally {
                 // Exceptions already emitted from event handler
                 socket.emit('finished');

--- a/app.ts
+++ b/app.ts
@@ -61,7 +61,7 @@ server.listen(process.argv[2] || process.env.PORT || DEFAULT_PORT);
 
 io.on('connection', socket => {
     socket.emit('handshake', { version: specberusVersion });
-    socket.on('extractMetadata', data => {
+    socket.on('extractMetadata', async data => {
         if (!data.url && !data.file)
             return socket.emit('exception', {
                 message: 'URL or file not provided.',
@@ -98,15 +98,19 @@ io.on('connection', socket => {
                 socket.emit('exception', err.message);
             }
         });
-        handler.on('end-all', metadata => {
-            metadata.url = data.url;
-            socket.emit('finishedExtraction', metadata);
-        });
         handler.on('exception', data => {
             socket.emit('exception', data);
         });
         data.events = handler;
-        specberus.extractMetadata(data);
+        try {
+            const metadata = await specberus.extractMetadata(data);
+            socket.emit('finishedExtraction', {
+                ...metadata,
+                url: data.url,
+            });
+        } catch {
+            // exceptions already emitted from event handler
+        }
     });
     socket.on('validate', async data => {
         if (!data.url && !data.file)
@@ -169,9 +173,6 @@ io.on('connection', socket => {
         handler.on('done', name => {
             socket.emit('done', { name });
         });
-        handler.on('end-all', () => {
-            socket.emit('finished');
-        });
         handler.on('exception', data => {
             socket.emit('exception', data);
         });
@@ -185,10 +186,10 @@ io.on('connection', socket => {
                     url: data.url,
                     statusCodesAccepted: ['301', '406'],
                 })
-                .then((res: any) => {
+                .then(async (res: any) => {
                     if (res.status) {
                         try {
-                            specberus.validate({
+                            await specberus.validate({
                                 url: data.url,
                                 profile,
                                 events: handler,
@@ -198,6 +199,7 @@ io.on('connection', socket => {
                             socket.emit('exception', {
                                 message: `Validation blew up: ${e}`,
                             });
+                        } finally {
                             socket.emit('finished');
                         }
                     } else {
@@ -215,16 +217,14 @@ io.on('connection', socket => {
                 });
         } else {
             try {
-                specberus.validate({
+                await specberus.validate({
                     file: data.file,
                     profile,
                     events: handler,
                     validation: data.validation,
                 });
-            } catch (e) {
-                socket.emit('exception', {
-                    message: `Validation blew up: ${e}`,
-                });
+            } finally {
+                // Exceptions already emitted from event handler
                 socket.emit('finished');
             }
         }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,8 +35,8 @@ const sendResult = function (res: Response, result: SpecberusResult) {
  * @param res Express Response
  * @param error An ExceptionsError (yields HTTP 500), or any other error (yields HTTP 400)
  */
-function sendErrors(res: Response, error: Error | ExceptionsError) {
-    res.status(error instanceof ExceptionsError ? 400 : 500).json({
+function sendErrors(res: Response, error: ExceptionsError | Error) {
+    res.status(error instanceof ExceptionsError ? 500 : 400).json({
         errors:
             error instanceof ExceptionsError
                 ? error.exceptions.map(exception => ({ exception }))

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,35 +5,39 @@
 import { fileTypeFromFile } from 'file-type';
 import type { Express, Request, Response } from 'express';
 
-import { buildJSONresult, processParams, specberusVersion } from './util.js';
+import { processParams, specberusVersion } from './util.js';
 import {
     ExceptionsError,
     Specberus,
+    type SpecberusResult,
     type ValidateOptions,
 } from './validator.js';
-import type { HandlerMessage } from './types.js';
+
+/** Sends the result to the client. */
+const sendResult = function (res: Response, result: SpecberusResult) {
+    delete result.metadata.file;
+    res.status(result.success ? 200 : 400).json(result);
+};
 
 /**
- * Send the JSON result to the client.
- *
- * @param errors - errors
- * @param warnings - warnings
- * @param info - informative messages
- * @param res - Express HTTP response
- * @param metadata - dictionary with some found metadata
+ * Sends a list of validation errors or processing exceptions to the client.
+ * @param res Express Response
+ * @param errors Array of error message strings
+ * @param type 'error' to indicate invalid input, or 'exception' to indicate unexpected internal errors
  */
-const sendJSONresult = function (
+function sendErrors(
     res: Response,
-    errors: HandlerMessage[] = [],
-    warnings: HandlerMessage[] = [],
-    info: HandlerMessage[] = [],
-    metadata: Record<string, string> = {}
+    errors: string[],
+    type: 'error' | 'exception'
 ) {
-    delete metadata.file;
-    // TODO(kgf): Is buildJSONresult no longer needed once promise-based APIs are used?
-    const wrapper = buildJSONresult(errors, warnings, info, metadata);
-    res.status(wrapper.success ? 200 : 400).json(wrapper);
-};
+    res.status(type === 'error' ? 400 : 500).json({
+        errors: errors.map(error => ({ [type]: error })),
+        info: [],
+        metadata: {},
+        success: false,
+        warnings: [],
+    } satisfies SpecberusResult);
+}
 
 const getFullUrl = (req: Request) =>
     new URL(`${req.protocol}://${req.host}${req.url}`);
@@ -92,25 +96,21 @@ const processPost = () => async (req: Request, res: Response) => {
 };
 
 function handlePromise(
-    promise: Promise<ReturnType<typeof buildJSONresult>>,
+    promise: Promise<SpecberusResult>,
     res: Response,
     metadataOverride?: Record<string, any>
 ) {
     return promise.then(
         result => {
-            sendJSONresult(
+            sendResult(
                 res,
-                result.errors,
-                result.warnings,
-                result.info,
-                metadataOverride || result.metadata
+                metadataOverride
+                    ? { ...result, metadata: metadataOverride }
+                    : result
             );
         },
         (error: ExceptionsError) => {
-            sendJSONresult(
-                res,
-                error.exceptions.map(exception => ({ exception }))
-            );
+            sendErrors(res, error.exceptions, 'exception');
         }
     );
 }
@@ -129,14 +129,14 @@ const processRequest = async (
             forbidden: ['source'],
         });
     } catch (err) {
-        return sendJSONresult(res, [err.toString()]);
+        return sendErrors(res, [err.toString()], 'error');
     }
 
     if (shouldValidate && options.profile === 'auto') {
         const sr = new Specberus();
         try {
             const result = await sr.extractMetadata(options);
-            if (result.errors.length) return sendJSONresult(res, result.errors);
+            if (result.errors.length) return sendResult(res, result);
             const meta = result.metadata;
             if (options.url) meta.url = options.url;
             else meta.file = options.file;
@@ -146,13 +146,13 @@ const processRequest = async (
                     allowUnknownParams: true,
                 });
             } catch (error) {
-                return sendJSONresult(res, [error.toString()]);
+                return sendErrors(res, [error.toString()], 'error');
             }
 
             const metaSr = new Specberus();
             return handlePromise(metaSr.validate(metaOptions), res, meta);
         } catch (error) {
-            sendJSONresult(res, [error.message]);
+            sendErrors(res, [error.message], 'exception');
         }
     } else {
         options.additionalMetadata = req.query.additionalMetadata === 'true';

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,6 +5,7 @@
 import { fileTypeFromFile } from 'file-type';
 import type { Express, Request, Response } from 'express';
 
+import type { HandlerMessage } from './types.js';
 import { processParams, specberusVersion } from './util.js';
 import {
     ExceptionsError,
@@ -12,6 +13,16 @@ import {
     type SpecberusResult,
     type ValidateOptions,
 } from './validator.js';
+
+/** Data types emitted by error events */
+type ErrorHandlerMessage =
+    | { error: string }
+    | { exception: string }
+    | HandlerMessage;
+
+interface ApiResult extends Omit<SpecberusResult, 'errors'> {
+    errors: ErrorHandlerMessage[];
+}
 
 /** Sends the result to the client. */
 const sendResult = function (res: Response, result: SpecberusResult) {
@@ -22,21 +33,26 @@ const sendResult = function (res: Response, result: SpecberusResult) {
 /**
  * Sends a list of validation errors or processing exceptions to the client.
  * @param res Express Response
- * @param errors Array of error message strings
+ * @param messages Array of error message strings
  * @param type 'error' to indicate invalid input, or 'exception' to indicate unexpected internal errors
  */
 function sendErrors(
     res: Response,
-    errors: string[],
+    messages: string[],
     type: 'error' | 'exception'
 ) {
+    const errors =
+        type === 'error'
+            ? messages.map(error => ({ error }))
+            : messages.map(exception => ({ exception }));
+
     res.status(type === 'error' ? 400 : 500).json({
-        errors: errors.map(error => ({ [type]: error })),
+        errors,
         info: [],
         metadata: {},
         success: false,
         warnings: [],
-    } satisfies SpecberusResult);
+    } satisfies ApiResult);
 }
 
 const getFullUrl = (req: Request) =>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,21 +33,14 @@ const sendResult = function (res: Response, result: SpecberusResult) {
 /**
  * Sends a list of validation errors or processing exceptions to the client.
  * @param res Express Response
- * @param messages Array of error message strings
- * @param type 'error' to indicate invalid input, or 'exception' to indicate unexpected internal errors
+ * @param error An ExceptionsError (yields HTTP 500), or any other error (yields HTTP 400)
  */
-function sendErrors(
-    res: Response,
-    messages: string[],
-    type: 'error' | 'exception'
-) {
-    const errors =
-        type === 'error'
-            ? messages.map(error => ({ error }))
-            : messages.map(exception => ({ exception }));
-
-    res.status(type === 'error' ? 400 : 500).json({
-        errors,
+function sendErrors(res: Response, error: Error | ExceptionsError) {
+    res.status(error instanceof ExceptionsError ? 400 : 500).json({
+        errors:
+            error instanceof ExceptionsError
+                ? error.exceptions.map(exception => ({ exception }))
+                : [{ error: error.toString() }],
         info: [],
         metadata: {},
         success: false,
@@ -126,7 +119,7 @@ function handlePromise(
             );
         },
         (error: ExceptionsError) => {
-            sendErrors(res, error.exceptions, 'exception');
+            sendErrors(res, error);
         }
     );
 }
@@ -144,8 +137,8 @@ const processRequest = async (
             required: shouldValidate ? ['profile'] : [],
             forbidden: ['source'],
         });
-    } catch (err) {
-        return sendErrors(res, [err.toString()], 'error');
+    } catch (error) {
+        return sendErrors(res, error);
     }
 
     if (shouldValidate && options.profile === 'auto') {
@@ -153,7 +146,7 @@ const processRequest = async (
         const result = await sr
             .extractMetadata(options)
             .catch((error: ExceptionsError) => {
-                sendErrors(res, error.exceptions, 'exception');
+                sendErrors(res, error);
             });
         if (!result) return;
         if (result.errors.length) return sendResult(res, result);
@@ -167,7 +160,7 @@ const processRequest = async (
                 allowUnknownParams: true,
             });
         } catch (error) {
-            return sendErrors(res, [error.toString()], 'error');
+            return sendErrors(res, error);
         }
 
         const metaSr = new Specberus();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,13 +2,15 @@
  * @file REST API.
  */
 
-import EventEmitter from 'events';
-
 import { fileTypeFromFile } from 'file-type';
 import type { Express, Request, Response } from 'express';
 
 import { buildJSONresult, processParams, specberusVersion } from './util.js';
-import { Specberus, type ValidateOptions } from './validator.js';
+import {
+    ExceptionsError,
+    Specberus,
+    type ValidateOptions,
+} from './validator.js';
 import type { HandlerMessage } from './types.js';
 
 /**
@@ -89,21 +91,28 @@ const processPost = () => async (req: Request, res: Response) => {
     }
 };
 
-function createHandler(res: Response, metadataOverride?: Record<string, any>) {
-    const handler = new EventEmitter();
-    handler.on('exception', data => {
-        sendJSONresult(res, [data.message ? data.message : data]);
-    });
-    handler.on('end-all', data => {
-        sendJSONresult(
-            res,
-            data.errors,
-            data.warnings,
-            data.info,
-            metadataOverride || data.metadata
-        );
-    });
-    return handler;
+function handlePromise(
+    promise: Promise<ReturnType<typeof buildJSONresult>>,
+    res: Response,
+    metadataOverride?: Record<string, any>
+) {
+    return promise.then(
+        result => {
+            sendJSONresult(
+                res,
+                result.errors,
+                result.warnings,
+                result.info,
+                metadataOverride || result.metadata
+            );
+        },
+        (error: ExceptionsError) => {
+            sendJSONresult(
+                res,
+                error.exceptions.map(exception => ({ exception }))
+            );
+        }
+    );
 }
 
 const processRequest = async (
@@ -125,39 +134,34 @@ const processRequest = async (
 
     if (shouldValidate && options.profile === 'auto') {
         const sr = new Specberus();
-        const handler = new EventEmitter();
-        handler.on('exception', data => {
-            sendJSONresult(res, [data.message ? data.message : data]);
-        });
-        handler.on('end-all', async data => {
-            if (data.errors.length) sendJSONresult(res, data.errors);
-            else {
-                const meta = data.metadata;
-                if (options.url) meta.url = options.url;
-                else meta.file = options.file;
-                let metaOptions: ValidateOptions;
-                try {
-                    metaOptions = await processParams(meta, undefined, {
-                        allowUnknownParams: true,
-                    });
-                } catch (err) {
-                    return sendJSONresult(res, [err.toString()]);
-                }
-                metaOptions.events = createHandler(res, meta);
-
-                const metaSr = new Specberus();
-                metaSr.validate(metaOptions);
+        try {
+            const result = await sr.extractMetadata(options);
+            if (result.errors.length) return sendJSONresult(res, result.errors);
+            const meta = result.metadata;
+            if (options.url) meta.url = options.url;
+            else meta.file = options.file;
+            let metaOptions: ValidateOptions;
+            try {
+                metaOptions = await processParams(meta, undefined, {
+                    allowUnknownParams: true,
+                });
+            } catch (error) {
+                return sendJSONresult(res, [error.toString()]);
             }
-        });
-        options.events = handler;
-        sr.extractMetadata(options);
+
+            const metaSr = new Specberus();
+            return handlePromise(metaSr.validate(metaOptions), res, meta);
+        } catch (error) {
+            sendJSONresult(res, [error.message]);
+        }
     } else {
-        options.events = createHandler(res);
         options.additionalMetadata = req.query.additionalMetadata === 'true';
 
         const sr = new Specberus();
-        if (shouldValidate) sr.validate(options);
-        else sr.extractMetadata(options);
+        return handlePromise(
+            shouldValidate ? sr.validate(options) : sr.extractMetadata(options),
+            res
+        );
     }
 };
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -150,26 +150,28 @@ const processRequest = async (
 
     if (shouldValidate && options.profile === 'auto') {
         const sr = new Specberus();
-        try {
-            const result = await sr.extractMetadata(options);
-            if (result.errors.length) return sendResult(res, result);
-            const meta = result.metadata;
-            if (options.url) meta.url = options.url;
-            else meta.file = options.file;
-            let metaOptions: ValidateOptions;
-            try {
-                metaOptions = await processParams(meta, undefined, {
-                    allowUnknownParams: true,
-                });
-            } catch (error) {
-                return sendErrors(res, [error.toString()], 'error');
-            }
+        const result = await sr
+            .extractMetadata(options)
+            .catch((error: ExceptionsError) => {
+                sendErrors(res, error.exceptions, 'exception');
+            });
+        if (!result) return;
+        if (result.errors.length) return sendResult(res, result);
 
-            const metaSr = new Specberus();
-            return handlePromise(metaSr.validate(metaOptions), res, meta);
+        const meta = result.metadata;
+        if (options.url) meta.url = options.url;
+        else meta.file = options.file;
+        let metaOptions: ValidateOptions;
+        try {
+            metaOptions = await processParams(meta, undefined, {
+                allowUnknownParams: true,
+            });
         } catch (error) {
-            sendErrors(res, [error.message], 'exception');
+            return sendErrors(res, [error.toString()], 'error');
         }
+
+        const metaSr = new Specberus();
+        return handlePromise(metaSr.validate(metaOptions), res, meta);
     } else {
         options.additionalMetadata = req.query.additionalMetadata === 'true';
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -28,6 +28,7 @@ const sendJSONresult = function (
     metadata: Record<string, string> = {}
 ) {
     delete metadata.file;
+    // TODO(kgf): Is buildJSONresult no longer needed once promise-based APIs are used?
     const wrapper = buildJSONresult(errors, warnings, info, metadata);
     res.status(wrapper.success ? 200 : 400).json(wrapper);
 };

--- a/lib/rules/echidna/deliverer-change.ts
+++ b/lib/rules/echidna/deliverer-change.ts
@@ -31,13 +31,11 @@ async function getPreviousDelivererIDs(
  * @param sr
  * @param done
  */
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const previousVersion = await sr.getPreviousVersion();
     const shortname = await sr.getShortname();
 
-    if (!previousVersion || !shortname) {
-        return done();
-    }
+    if (!previousVersion || !shortname) return;
 
     const previousDelivererIDs = await getPreviousDelivererIDs(
         shortname,
@@ -55,6 +53,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
             previous: previousDelivererIDs.sort().toString(),
         });
     }
-
-    done();
 };

--- a/lib/rules/echidna/todays-date.ts
+++ b/lib/rules/echidna/todays-date.ts
@@ -9,7 +9,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     /**
      * Get the timestamp of a day, regardless the time of the day.
      * This function creates a new `Date` to avoid modifying the original one.
@@ -27,6 +27,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     } else if (getDateTime(documentDate) !== getDateTime(new Date())) {
         sr.error(self, 'wrong-date');
     }
-
-    done();
 };

--- a/lib/rules/headers/copyright.ts
+++ b/lib/rules/headers/copyright.ts
@@ -148,31 +148,31 @@ function checkLatestCopyright(
     });
 }
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const $copyright = sr.$('body div.head p.copyright').first();
 
     if (!$copyright.length) {
         sr.error(self, 'not-found');
-        return done();
+        return;
     }
     if (await isOnlyPublishedByTagOrAb(sr)) {
-        return done();
+        return;
     }
 
     const chartersData = await sr.getChartersData();
     if (!chartersData || !chartersData.length) {
         sr.error(self, 'no-data-from-API');
-        return done();
+        return;
     }
 
     const allowedLicenses = getCommonLicenseUri(chartersData);
     if (!allowedLicenses.length && chartersData.length > 1) {
         sr.error(self, 'no-license-found-joint');
-        return done();
+        return;
     }
     if (!allowedLicenses.length) {
         sr.error(self, 'no-license-found');
-        return done();
+        return;
     }
 
     // licenseTexts: ['permissive document license'] or ['document use'] or ['document use', 'permissive document license']
@@ -191,6 +191,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
     } else {
         checkLatestCopyright(sr, $copyright, licenseTexts);
     }
-
-    return done();
 };

--- a/lib/rules/headers/details-summary.ts
+++ b/lib/rules/headers/details-summary.ts
@@ -10,11 +10,11 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $details = sr.$('.head details').first();
     if (!$details.length) {
         sr.error(self, 'no-details');
-        return done();
+        return;
     }
 
     if (!$details.attr('open')) {
@@ -23,19 +23,17 @@ export const check: RuleCheckFunction = (sr, done) => {
 
     if (!sr.$('.head details dl').length) {
         sr.error(self, 'no-details-dl');
-        return done();
+        return;
     }
 
     const $summary = sr.$('.head details summary').first();
     if (!$summary.length) {
         sr.error(self, 'no-details-summary');
-        return done();
+        return;
     }
 
     const summaryText = sr.norm($summary.text());
     if (summaryText !== 'More details about this document') {
         sr.error(self, 'wrong-summary-text');
     }
-
-    return done();
 };

--- a/lib/rules/headers/div-head.ts
+++ b/lib/rules/headers/div-head.ts
@@ -10,6 +10,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction<void> = (sr, done) => {
-    sr.checkSelector('body div.head', self, done);
+export const check: RuleCheckFunction = sr => {
+    sr.checkSelector('body div.head', self);
 };

--- a/lib/rules/headers/dl.ts
+++ b/lib/rules/headers/dl.ts
@@ -69,7 +69,7 @@ function checkLink({
     return true;
 }
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const { rescinds, status, submissionType } = sr.config!;
     let topLevel = 'TR';
 
@@ -271,6 +271,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
         // should at least have 1 editor
         sr.error(editorError, 'editor-not-found');
     }
-
-    done();
 };

--- a/lib/rules/headers/editor-participation.ts
+++ b/lib/rules/headers/editor-participation.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 };
 export const name = self.name;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const groups = await sr.getDelivererIDs();
     const editors = sr.extractHeaders()?.Editor;
     const editorsToCheck = [];
@@ -52,6 +52,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
             sr.error(self, 'not-participating', { id });
         }
     });
-
-    done();
 };

--- a/lib/rules/headers/errata.ts
+++ b/lib/rules/headers/errata.ts
@@ -19,17 +19,11 @@ function isRECWithChanges(sr: Specberus) {
     return Object.values(recMeta).length !== 0;
 }
 
-export const check: RuleCheckFunction<void> = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     // for REC with Candidate/Proposed changes, no need to check errata link
-    if (isRECWithChanges(sr)) {
-        return done();
-    }
+    if (isRECWithChanges(sr)) return;
 
     const dts = sr.extractHeaders();
     // Check 'Errata:' exist, don't check any further.
-    if (!dts.Errata) {
-        sr.error(self, 'no-errata');
-        return done();
-    }
-    return done();
+    if (!dts.Errata) sr.error(self, 'no-errata');
 };

--- a/lib/rules/headers/github-repo.ts
+++ b/lib/rules/headers/github-repo.ts
@@ -12,11 +12,11 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const dts = sr.extractHeaders();
     if (!dts.Feedback) {
         sr.error(self, 'no-feedback');
-        return done();
+        return;
     }
 
     // Check 'github repo' exist in 'Feedback:'
@@ -38,6 +38,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         // );
     });
     if (!foundRepo) sr.error(self, 'no-repo');
-
-    done();
 };

--- a/lib/rules/headers/h1-title.ts
+++ b/lib/rules/headers/h1-title.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $title = sr.$('head > title').first();
     const $h1 = sr.$('body div.head h1').first();
     if (!$title.length || !$h1.length) {
@@ -22,5 +22,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         if (titleText !== h1Text)
             sr.error(self, 'not-match', { titleText, h1Text });
     }
-    done();
 };

--- a/lib/rules/headers/h2-toc.ts
+++ b/lib/rules/headers/h2-toc.ts
@@ -14,7 +14,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const EXPECTED_HEADING = /^table\s+of\s+contents$/i;
     const $tocNav = sr.$('nav#toc > h2');
     const $tocDiv = sr.$('div#toc > h2');
@@ -36,6 +36,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         if (matches > 1) sr.error(self, 'too-many');
         else if (matches === 0) sr.error(self, 'not-found');
     }
-
-    done();
 };

--- a/lib/rules/headers/hr.ts
+++ b/lib/rules/headers/hr.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const hasHrLastChild = sr.$('body div.head > hr:last-child').length === 1;
     const hasHrNextSibling = sr.$('body div.head + hr').length === 1;
     if (hasHrLastChild && hasHrNextSibling) {
@@ -16,5 +16,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     } else if (!hasHrLastChild && !hasHrNextSibling) {
         sr.error(self, 'not-found');
     }
-    done();
 };

--- a/lib/rules/headers/logo.ts
+++ b/lib/rules/headers/logo.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $logo = sr.$("body div.head a[href] > img[src][alt='W3C']").first();
     if (
         !$logo.length ||
@@ -21,5 +21,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     ) {
         sr.error(self, 'not-found');
     }
-    done();
 };

--- a/lib/rules/headers/memsub-copyright.ts
+++ b/lib/rules/headers/memsub-copyright.ts
@@ -6,7 +6,7 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $copyright = sr.$('body div.head p.copyright').first();
     if ($copyright.length) {
         // ,   "https://www.w3.org/copyright/document-license/":           "document use"
@@ -21,5 +21,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             );
         if (!seen) sr.error(self, 'not-found');
     } else sr.error(self, 'not-found');
-    done();
 };

--- a/lib/rules/headers/ol-toc.ts
+++ b/lib/rules/headers/ol-toc.ts
@@ -13,10 +13,8 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $toc = sr.$('nav#toc ol.toc, div#toc ol.toc');
 
     if (!$toc.length) sr.warning(self, 'not-found');
-
-    done();
 };

--- a/lib/rules/headers/secno.ts
+++ b/lib/rules/headers/secno.ts
@@ -10,7 +10,7 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     // TODO: once supported, use: ":is(h2, h3, h4, h5, h6) :is(bdi.secno,span.secno)"
     const $secnos = sr.$(
         'h1 span.secno, h2 span.secno, h3 span.secno, h4 span.secno, h5 span.secno, h6 span.secno, #toc span.secno,' +
@@ -18,6 +18,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     );
 
     if (!$secnos.length) sr.warning(self, 'not-found');
-
-    done();
 };

--- a/lib/rules/headers/shortname.ts
+++ b/lib/rules/headers/shortname.ts
@@ -25,7 +25,7 @@ const historyError: RuleMeta = {
 };
 export const name = self.name;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     let topLevel = 'TR';
 
     if (sr.config!.submissionType === 'member') topLevel = 'submissions';
@@ -197,6 +197,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
             status: sr.config!.longStatus,
         });
     }
-
-    done();
 };

--- a/lib/rules/headers/shortname.ts
+++ b/lib/rules/headers/shortname.ts
@@ -3,9 +3,6 @@
 //  latest version is https://www.w3.org/TR/shortname/
 
 import superagent from 'superagent';
-// TODO(kgf): Replace with promisify?
-// @ts-ignore (no typings)
-import doAsync from 'doasync';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 const self: RuleMeta = {
@@ -71,12 +68,11 @@ export const check: RuleCheckFunction = async sr => {
 
     if (dts.Latest) {
         const $linkLate = dts.Latest.$dd.find('a').first();
+        const lateHref = $linkLate.attr('href');
 
-        if ($linkLate.attr('href')) {
+        if (lateHref) {
             const lateRex = `^https:\\/\\/www\\.w3\\.org\\/${topLevel}\\/(.+?)\\/?$`;
-            const matches = ($linkLate.attr('href') || '')
-                .trim()
-                .match(new RegExp(lateRex));
+            const matches = lateHref.trim().match(new RegExp(lateRex));
             if (matches) {
                 sn = matches[1];
                 // latest version link mention either shortlink or the series shortlink
@@ -91,24 +87,22 @@ export const check: RuleCheckFunction = async sr => {
 
     if (dts.History) {
         const $linkHistory = dts.History.$dd.find('a').first();
+        const historyHref = $linkHistory.attr('href');
 
-        if ($linkHistory.attr('href')) {
+        if (historyHref) {
             // e.g. https://www.w3.org/standards/history/hr-time-10086/
             const historyReg =
                 /^https:\/\/www\.w3\.org\/standards\/history\/(.+?)\/?$/;
-            const matches = ($linkHistory.attr('href') || '')
-                .trim()
-                .match(historyReg);
+            const matches = historyHref.trim().match(historyReg);
             if (matches) {
                 const [, historyShortname] = matches;
                 if (historyShortname !== shortname) {
                     sr.error(historyError, 'history-syntax', { shortname });
                 } else {
-                    const historyHref = $linkHistory.attr('href');
                     // Check if the history link exist
                     let historyStatusCode;
                     try {
-                        const res = await doAsync(superagent).head(historyHref);
+                        const res = await superagent.head(historyHref);
                         historyStatusCode = res.statusCode;
                     } catch (err) {
                         historyStatusCode = err.status;
@@ -133,9 +127,7 @@ export const check: RuleCheckFunction = async sr => {
                             let previousHistoryStatusCode;
                             try {
                                 const res =
-                                    await doAsync(superagent).head(
-                                        previousHistoryHref
-                                    );
+                                    await superagent.head(previousHistoryHref);
                                 previousHistoryStatusCode = res.statusCode;
                             } catch (err) {
                                 previousHistoryStatusCode = err.status;
@@ -156,9 +148,10 @@ export const check: RuleCheckFunction = async sr => {
 
     if (dts.Rescinds) {
         const $linkRescinds = dts.Rescinds.$dd.find('a').first();
+        const rescindsHref = $linkRescinds.attr('href');
 
-        if ($linkRescinds.attr('href')) {
-            const matches = ($linkRescinds.attr('href') || '')
+        if (rescindsHref) {
+            const matches = rescindsHref
                 .trim()
                 .match(
                     /^https:\/\/www\.w3\.org\/TR\/\d{4}\/REC-(.+)-\d{8}\/?$/

--- a/lib/rules/headers/subm-logo.ts
+++ b/lib/rules/headers/subm-logo.ts
@@ -6,7 +6,7 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $logo = sr
         .$("body div.head a[href] > img[src][height='48'][width='211'][alt]")
         .first();
@@ -28,5 +28,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             type: type.charAt(0).toUpperCase() + type.slice(1),
         });
     }
-    done();
 };

--- a/lib/rules/headers/translation.ts
+++ b/lib/rules/headers/translation.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const translationLink = sr
         .$('body div.head a')
         .toArray()
@@ -18,7 +18,7 @@ export const check: RuleCheckFunction = (sr, done) => {
 
     if (!translationLink) {
         sr.error(self, 'not-found');
-        return done();
+        return;
     }
 
     const href = translationLink.attribs.href;
@@ -31,6 +31,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     ) {
         sr.warning(self, 'not-recommended-link');
     }
-
-    done();
 };

--- a/lib/rules/headers/w3c-state.ts
+++ b/lib/rules/headers/w3c-state.ts
@@ -9,15 +9,15 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const config = sr.config!;
     let profileFound = false;
 
-    if (config.longStatus) return done();
+    if (config.longStatus) return;
     const $stateEl = sr.getDocumentStateElement();
     if (!$stateEl) {
         sr.error(self, 'no-w3c-state');
-        return done();
+        return;
     }
     const txt = sr.norm($stateEl.text());
     // crType/cryType: Add 'Draft', 'Snapshot' suffix to title.
@@ -61,6 +61,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             });
         }
     }
-
-    done();
 };

--- a/lib/rules/heuristic/date-format.ts
+++ b/lib/rules/heuristic/date-format.ts
@@ -9,7 +9,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     // Pseudo-constants:
     const POSSIBLE_DATE = new RegExp(
         `\\b([0123]?\\d|${possibleMonths})[\\ \\-\\/–—]([0123]?\\d|${possibleMonths})[\\ \\-\\/–—]([\\'‘’]?\\d{2})(\\d\\d)?\\b`,
@@ -38,6 +38,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             sr.error(self, 'wrong', { text: date });
         }
     }
-
-    return done();
 };

--- a/lib/rules/links/compound.ts
+++ b/lib/rules/links/compound.ts
@@ -1,3 +1,4 @@
+import type { ResponseError } from 'superagent';
 import { get } from '../../throttled-ua.js';
 import type { RuleCheckFunction } from '../../types.js';
 
@@ -8,13 +9,13 @@ const TIMEOUT = 10000;
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const { validation } = sr.config!;
     const url = sr.url!;
 
     if (validation !== 'recursive') {
         sr.warning(self, 'skipped');
-        return done();
+        return;
     }
 
     let links: string[] = [];
@@ -29,13 +30,13 @@ export const check: RuleCheckFunction = (sr, done) => {
     // sort and remove duplicates
     links = links.sort().filter((item, pos) => !pos || item !== links[pos - 1]);
 
+    if (!links.length) return;
+
     const markupService = 'https://validator.w3.org/nu/';
-    let count = 0;
-    if (links.length > 0) {
-        links.forEach(l => {
-            if (validation === 'recursive') {
+    if (validation === 'recursive') {
+        return Promise.all(
+            links.map(l => {
                 const ua = `W3C-Pubrules/${sr.version}`;
-                let isMarkupValid = false;
                 const req = get(markupService)
                     .set('User-Agent', ua)
                     .query({ doc: l, out: 'json' })
@@ -45,43 +46,50 @@ export const check: RuleCheckFunction = (sr, done) => {
                             link: l,
                             errMsg: err,
                         });
-                        count += 1;
-                    });
-                req.timeout(TIMEOUT);
-                req.end((err1, res) => {
-                    if (err1 && err1.timeout === TIMEOUT)
-                        sr.warning(self, 'html-timeout');
-                    const json = res ? res.body : null;
-                    if (!json) return sr.throw('No JSON input.');
-                    if (json.messages) {
-                        const errors = json.messages.filter(
-                            (msg: { type: string }) => msg.type === 'error'
-                        );
-                        if (errors.length === 0) isMarkupValid = true;
+                    })
+                    .timeout(TIMEOUT);
+                return req.then(
+                    res => {
+                        const json = res.body;
+                        if (!json)
+                            throw new Error(
+                                'No JSON returned from HTML validator.'
+                            );
+
+                        const errors =
+                            json.messages?.filter(
+                                (msg: { type: string }) => msg.type === 'error'
+                            ) || [];
+                        if (errors.length === 0) {
+                            sr.info(self, 'link', {
+                                file: l.split('/').pop(),
+                                link: l,
+                                markup: '\u2714',
+                            });
+                        } else {
+                            sr.error(self, 'link', {
+                                file: l.split('/').pop(),
+                                link: l,
+                                markup: '\u2718',
+                            });
+                        }
+                    },
+                    (err: ResponseError) => {
+                        if (err.timeout) sr.warning(self, 'html-timeout');
+                        else
+                            throw new Error(
+                                `HTML validator error: ${err.message}`
+                            );
                     }
-                    if (isMarkupValid) {
-                        sr.info(self, 'link', {
-                            file: l.split('/').pop(),
-                            link: l,
-                            markup: '\u2714',
-                        });
-                    } else {
-                        const details = {
-                            file: l.split('/').pop(),
-                            link: l,
-                            markup: isMarkupValid ? '\u2714' : '\u2718',
-                        };
-                        sr.error(self, 'link', details);
-                    }
-                    count += 1;
-                    if (count === links.length) return done();
-                });
-            } else {
-                sr.info(self, 'no-validation', {
-                    file: l.split('/').pop(),
-                    link: l,
-                });
-            }
-        });
-    } else return done();
+                );
+            })
+        ).then(() => {});
+    } else {
+        for (const l of links) {
+            sr.info(self, 'no-validation', {
+                file: l.split('/').pop(),
+                link: l,
+            });
+        }
+    }
 };

--- a/lib/rules/links/internal.ts
+++ b/lib/rules/links/internal.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     sr.$("a[href^='#']").each((_, el) => {
         const id = el.attribs.href.replace('#', '');
         const escId = id.replace(/([.()#:[\]+*])/g, '\\$1');
@@ -17,5 +17,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             sr.error(self, 'anchor', { id });
         }
     });
-    done();
 };

--- a/lib/rules/links/linkchecker.ts
+++ b/lib/rules/links/linkchecker.ts
@@ -53,11 +53,11 @@ function includedByReg(url: string, regArray = allowList) {
     );
 }
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     // send out warning for /nu W3C link checker.
     sr.warning(self, 'display', { link: sr.url });
 
-    if (!sr.url) return done();
+    if (!sr.url) return;
 
     // sr.url is used as base url. Every other resource should use in same folder as base. e.g.
     // - spec doc: https://www.w3.org/TR/2021/WD-pubrules-20210401/
@@ -113,5 +113,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
     await page.goto(sr.url, { waitUntil: 'load', timeout: 60000 });
 
     await browser.close();
-    done();
 };

--- a/lib/rules/links/reliability.ts
+++ b/lib/rules/links/reliability.ts
@@ -20,7 +20,7 @@ const unreliableServices = [
     // { domain: 'w3.org', path: /track(er)?\/(actions|issues|resolutions)/}
 ];
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     sr.$('a').each((_, el) => {
         const $el = sr.$(el);
         const href = $el.attr('href');
@@ -54,5 +54,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             return false;
         });
     });
-    done();
 };

--- a/lib/rules/metadata/abstract.ts
+++ b/lib/rules/metadata/abstract.ts
@@ -7,26 +7,23 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'metadata.abstract';
 
-export const check: RuleCheckFunction<{ abstract: string }> = (sr, done) => {
+export const check: RuleCheckFunction<{ abstract: string }> = sr => {
     const abstractHeadingEl = sr
         .$('h2')
         .toArray()
         .find(el => sr.norm(sr.$(el).text()).toLowerCase() === 'abstract');
 
-    if (abstractHeadingEl) {
-        const $div = load('<div></div>', null, false)('div');
-        sr.$(abstractHeadingEl)
-            .parent()
-            .children()
-            .each((_, child) => {
-                {
-                    if (child !== abstractHeadingEl) {
-                        $div.append(child.cloneNode(true));
-                    }
-                }
-            });
-        return done({ abstract: sr.norm($div.html()!) });
-    } else {
-        return done({ abstract: 'Not found' });
-    }
+    if (!abstractHeadingEl) return { abstract: 'Not found' };
+
+    const $div = load('<div></div>', null, false)('div');
+    sr.$(abstractHeadingEl)
+        .parent()
+        .children()
+        .each((_, child) => {
+            {
+                if (child !== abstractHeadingEl)
+                    $div.append(child.cloneNode(true));
+            }
+        });
+    return { abstract: sr.norm($div.html()!) };
 };

--- a/lib/rules/metadata/charters.ts
+++ b/lib/rules/metadata/charters.ts
@@ -10,4 +10,4 @@ export const name = 'metadata.charters';
 
 export const check: RuleCheckFunction<{
     charters: string[];
-}> = async (sr, done) => done({ charters: await sr.getCharters() });
+}> = async sr => ({ charters: await sr.getCharters() });

--- a/lib/rules/metadata/deliverers.ts
+++ b/lib/rules/metadata/deliverers.ts
@@ -13,4 +13,4 @@ export const name = 'metadata.deliverers';
  */
 export const check: RuleCheckFunction<{
     delivererIDs: number[];
-}> = async (sr, done) => done({ delivererIDs: await sr.getDelivererIDs() });
+}> = async sr => ({ delivererIDs: await sr.getDelivererIDs() });

--- a/lib/rules/metadata/dl.ts
+++ b/lib/rules/metadata/dl.ts
@@ -23,7 +23,7 @@ interface DlMetadata {
     updated?: boolean;
 }
 
-export const check: RuleCheckFunction<DlMetadata> = async (sr, done) => {
+export const check: RuleCheckFunction<DlMetadata> = async sr => {
     const dts = sr.extractHeaders();
     const result: DlMetadata = {};
     let shortname;
@@ -83,11 +83,17 @@ export const check: RuleCheckFunction<DlMetadata> = async (sr, done) => {
         const endpoint = `https://api.w3.org/specifications/${latestShortname}/versions/${formattedDate}`;
 
         const req = get(endpoint).set('User-Agent', ua);
-        req.end((err, res) => {
-            result.updated = !(err || !res.ok);
-            return done(result);
-        });
+        return req.then(
+            res => {
+                result.updated = res.ok;
+                return result;
+            },
+            () => {
+                result.updated = false;
+                return result;
+            }
+        );
     } else {
-        sr.throw('[EXCEPTION] The document date could not be parsed.');
+        throw new Error('The document date could not be parsed.');
     }
 };

--- a/lib/rules/metadata/dl.ts
+++ b/lib/rules/metadata/dl.ts
@@ -17,7 +17,7 @@ interface DlMetadata {
     editorsDraft?: string | undefined;
     history?: string;
     latestVersion?: string;
-    previousVersion?: string | undefined;
+    previousVersion?: string | null | undefined;
     sameWorkAs?: string;
     thisVersion?: string;
     updated?: boolean;

--- a/lib/rules/metadata/docDate.ts
+++ b/lib/rules/metadata/docDate.ts
@@ -11,10 +11,10 @@ interface DocDateMetadata {
     docDate: `${number}-${number}-${number}`;
 }
 
-export const check: RuleCheckFunction<DocDateMetadata | void> = (sr, done) => {
+export const check: RuleCheckFunction<DocDateMetadata | void> = sr => {
     const docDate = sr.getDocumentDate();
-    if (!docDate) return done();
-    return done({
-        docDate: `${docDate.getFullYear()}-${docDate.getMonth() + 1}-${docDate.getDate()}`,
-    });
+    if (docDate)
+        return {
+            docDate: `${docDate.getFullYear()}-${docDate.getMonth() + 1}-${docDate.getDate()}`,
+        };
 };

--- a/lib/rules/metadata/editor-ids.ts
+++ b/lib/rules/metadata/editor-ids.ts
@@ -18,7 +18,7 @@ interface EditorIDsMetadata {
     editorIDs: number[];
 }
 
-export const check: RuleCheckFunction<EditorIDsMetadata> = async (sr, done) => {
+export const check: RuleCheckFunction<EditorIDsMetadata> = async sr => {
     const dts = sr.extractHeaders();
     const editorIds: number[] = [];
     const unresolvedUsernames = [];
@@ -50,12 +50,12 @@ export const check: RuleCheckFunction<EditorIDsMetadata> = async (sr, done) => {
         }
 
         // remove duplicates
-        done({
+        return {
             editorIDs: editorIds.filter(
                 (item, pos) => editorIds.indexOf(item) === pos
             ),
-        });
+        };
     } else {
-        done({ editorIDs: [] });
+        return { editorIDs: [] };
     }
 };

--- a/lib/rules/metadata/editor-names.ts
+++ b/lib/rules/metadata/editor-names.ts
@@ -11,7 +11,7 @@ interface EditorNamesMetadata {
     editorNames: string[];
 }
 
-export const check: RuleCheckFunction<EditorNamesMetadata> = (sr, done) => {
+export const check: RuleCheckFunction<EditorNamesMetadata> = sr => {
     const dts = sr.extractHeaders();
     const editorNames: string[] = [];
     if (dts.Editor) {
@@ -25,5 +25,5 @@ export const check: RuleCheckFunction<EditorNamesMetadata> = (sr, done) => {
             if (editor) editorNames.push(editor);
         });
     }
-    return done({ editorNames });
+    return { editorNames };
 };

--- a/lib/rules/metadata/errata.ts
+++ b/lib/rules/metadata/errata.ts
@@ -12,12 +12,12 @@ interface ErrataMetadata {
     errata: string;
 }
 
-export const check: RuleCheckFunction<ErrataMetadata | void> = (sr, done) => {
+export const check: RuleCheckFunction<ErrataMetadata | void> = sr => {
     const errataRegex = /errata/i;
     const $links = sr.$('body div.head details + p > a');
     const errata = $links
         .toArray()
         .filter(el => errataRegex.test(sr.$(el).text()));
-    if (!errata.length || !errata[0].attribs.href) done();
-    else done({ errata: errata[0].attribs.href });
+    if (errata.length && errata[0].attribs.href)
+        return { errata: errata[0].attribs.href };
 };

--- a/lib/rules/metadata/informative.ts
+++ b/lib/rules/metadata/informative.ts
@@ -11,19 +11,16 @@ interface InformativeMetadata {
     informative: boolean;
 }
 
-export const check: RuleCheckFunction<InformativeMetadata | void> = (
-    sr,
-    done
-) => {
+export const check: RuleCheckFunction<InformativeMetadata | void> = sr => {
     const $sotd = sr.getSotDSection();
     const expected = /This\s+document\s+is\s+informative\s+only\./;
-    if (!$sotd) return done();
+    if (!$sotd) return;
 
     const $stateEl = sr.getDocumentStateElement();
     const candidate = $stateEl && sr.norm($stateEl.text()).toLowerCase();
     const isInformative = !!candidate && candidate.indexOf('group note') !== -1;
 
-    return done({
+    return {
         informative: expected.test($sotd && $sotd.text()) || isInformative,
-    });
+    };
 };

--- a/lib/rules/metadata/process.ts
+++ b/lib/rules/metadata/process.ts
@@ -16,11 +16,10 @@ interface ProcessMetadata {
     process: string;
 }
 
-export const check: RuleCheckFunction<ProcessMetadata | void> = (sr, done) => {
+export const check: RuleCheckFunction<ProcessMetadata | void> = sr => {
     const $processDocument = sr.$('a#w3c_process_revision').first();
     const processDocumentHref =
         $processDocument.length && $processDocument.attr('href');
 
-    if (!processDocumentHref) return done();
-    return done({ process: processDocumentHref });
+    if (processDocumentHref) return { process: processDocumentHref };
 };

--- a/lib/rules/metadata/profile.ts
+++ b/lib/rules/metadata/profile.ts
@@ -6,7 +6,6 @@ import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
 import { allProfiles } from '../../util.js';
-import type { Specberus } from '../../validator.js';
 import { sortedProfiles } from '../../views.js';
 import type { RecMetadata, RuleCheckFunction } from '../../types.js';
 import { check as getTitle } from './title.js';
@@ -16,7 +15,7 @@ import rules from '../../rules-track.js';
 // 'self.name' would be 'metadata.profile'
 export const name = 'metadata.profile';
 
-export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
+export const check: RuleCheckFunction<RecMetadata> = async sr => {
     let matchedLength = 0;
     let id;
     let $profileEl: Cheerio<Element> | undefined;
@@ -28,7 +27,7 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
 
     const $stateEl = sr.getDocumentStateElement();
     if (!$stateEl) {
-        sr.throw(
+        throw new Error(
             'Cannot find the <code>&lt;p id="w3c-state"&gt;</code> element for profile and date.<br><br>Please make sure the <code>&lt;p id="w3c-state"&gt;<a href="https://www.w3.org/standards/types#@@Profile">W3C @@Profile</a>, DD Month Year&lt;/p&gt;</code> element can be selected by <code>document.getElementById(\'w3c-state\')</code>; <br>If you are using bikeshed, please update to the latest version.'
         );
     }
@@ -49,13 +48,13 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
         }
     }
 
-    function assembleMeta(id: string, sr: Specberus) {
+    function assembleMeta(id: string) {
         let meta: RecMetadata = { profile: id };
         if (id in reviewStatus) {
             const dueDate = sr.getFeedbackDueDate();
             const dates = dueDate && dueDate.valid;
             let res = dates[0];
-            if (dates.length === 0 || !res) return done({ profile: id });
+            if (dates.length === 0 || !res) return { profile: id };
             if (dates.length > 1)
                 res = new Date(Math.min(...dates.map(d => +d)));
 
@@ -90,7 +89,7 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
         const track = profileMatch && profileMatch[profileMatch.length - 2];
         meta.rectrack = track;
 
-        return done(meta);
+        return meta;
     }
 
     function checkRecType() {
@@ -104,6 +103,7 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
         }
         return 'REC';
     }
+
     if (id) {
         // W3C Candidate Recommendation (CR before 2020/CR snapshot/CR draft), W3C Recommendation will have "REC"
         if (id === 'REC' || id === 'CR') {
@@ -118,15 +118,12 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
                     ? 'CRYD'
                     : 'CRY';
         }
-        assembleMeta(id, sr);
+        return assembleMeta(id);
     } else {
-        let docTitle;
-        await getTitle(sr, result => {
-            docTitle = result && result.title;
-        });
+        const docTitle = (await getTitle(sr))?.title;
         if (candidate && candidate.indexOf("editor's draft") > -1) {
-            sr.throw(
-                `[EXCEPTION] The document "${docTitle}" seems to be an Editor's Draft, which is not supported.`
+            throw new Error(
+                `The document "${docTitle}" seems to be an Editor's Draft, which is not supported.`
             );
         } else if (
             sr.$('link[href^="https://www.w3.org/StyleSheets/TR/"]').length
@@ -139,12 +136,12 @@ export const check: RuleCheckFunction<RecMetadata> = async (sr, done) => {
                 });
                 profileList += '</ul>';
             });
-            sr.throw(
+            throw new Error(
                 `Pubrules is having a hard time identifying the profile of the document "${docTitle}" from its w3c-state element; Please make sure the &lt;p id="w3c-state"&gt; is in a valid format: <pre><code>&lt;p id="w3c-state"&gt;<a href="https://www.w3.org/standards/types#@@Profile">W3C @@type of the document@@</a> DD Month YYYY&lt;/p&gt;</code></pre>${profileList}`
             );
         } else {
-            sr.throw(
-                `[EXCEPTION] The document "${docTitle}" could not be parsed, it's neither a TR document nor a Member Submission.`
+            throw new Error(
+                `The document "${docTitle}" could not be parsed, it's neither a TR document nor a Member Submission.`
             );
         }
     }

--- a/lib/rules/metadata/sotd.ts
+++ b/lib/rules/metadata/sotd.ts
@@ -10,7 +10,7 @@ interface SotdMetadata {
     sotd: string;
 }
 
-export const check: RuleCheckFunction<SotdMetadata> = (sr, done) => {
+export const check: RuleCheckFunction<SotdMetadata> = sr => {
     const $sotd = sr.getSotDSection();
-    return done({ sotd: $sotd ? sr.norm($sotd.html()!) : 'Not found' });
+    return { sotd: $sotd ? sr.norm($sotd.html()!) : 'Not found' };
 };

--- a/lib/rules/metadata/title.ts
+++ b/lib/rules/metadata/title.ts
@@ -8,15 +8,12 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'metadata.title';
 
-export const check: RuleCheckFunction<{ title: string } | void> = (
-    sr,
-    done
-) => {
+export const check: RuleCheckFunction<{ title: string } | void> = sr => {
     const $title = sr.$('body div.head h1').first();
-    if (!$title.length) return done();
+    if (!$title.length) return;
 
     $title.html($title.html()!.replace(/:<br>/g, ': ').replace(/<br>/g, ' - '));
-    return done({
+    return {
         title: sr.norm($title.text()),
-    });
+    };
 };

--- a/lib/rules/sotd/candidate-review-end.ts
+++ b/lib/rules/sotd/candidate-review-end.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const isEditorial =
         (sr.config!.editorial && /^true$/i.test(sr.config!.editorial)) || false;
     if (isEditorial) {
@@ -33,5 +33,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             }
         }
     }
-    done();
 };

--- a/lib/rules/sotd/charter.ts
+++ b/lib/rules/sotd/charter.ts
@@ -13,14 +13,14 @@ export const { name } = self;
 const charterText =
     /The disclosure obligations of the Participants of this group are described in the charter\./;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         const deliverIds = await sr.getDelivererIDs();
 
         if (!deliverIds.length) {
             sr.error(self, 'no-group');
-            return done();
+            return;
         }
 
         // Skip check if the document is only published by TAG and/or AB
@@ -30,12 +30,12 @@ export const check: RuleCheckFunction = async (sr, done) => {
         const groupIds = deliverIds.filter(
             deliverer => !([TagID, AbID] as number[]).includes(deliverer)
         );
-        if (!groupIds.length) return done();
+        if (!groupIds.length) return;
 
         const charters = await sr.getCharters();
         if (!charters.length) {
             sr.error(self, 'no-charter');
-            return done();
+            return;
         }
 
         if (sr.config!.longStatus === 'Interest Group Note') {
@@ -44,7 +44,7 @@ export const check: RuleCheckFunction = async (sr, done) => {
             const txt = sr.norm($sotd && $sotd.text());
             if (!charterText.test(txt)) {
                 sr.error(self, 'text-not-found');
-                return done();
+                return;
             }
 
             // check "charter" link is found and correct
@@ -69,7 +69,5 @@ export const check: RuleCheckFunction = async (sr, done) => {
                 });
             }
         }
-
-        return done();
     }
 };

--- a/lib/rules/sotd/deliverer-note.ts
+++ b/lib/rules/sotd/deliverer-note.ts
@@ -8,9 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const deliverers = sr.getDataDelivererIDs();
-
     if (deliverers.length === 0) sr.error(self, 'not-found');
-    done();
 };

--- a/lib/rules/sotd/deployment.ts
+++ b/lib/rules/sotd/deployment.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
 
     if ($sotd) {
@@ -21,10 +21,6 @@ export const check: RuleCheckFunction = (sr, done) => {
             .find('p')
             .toArray()
             .find(p => sr.norm(sr.$(p).text()) === depText);
-        if (!paragraph) {
-            sr.error(self, 'not-found');
-            return done();
-        }
+        if (!paragraph) sr.error(self, 'not-found');
     }
-    return done();
 };

--- a/lib/rules/sotd/diff.ts
+++ b/lib/rules/sotd/diff.ts
@@ -8,7 +8,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     sr.info(self, 'note');
-    return done();
 };

--- a/lib/rules/sotd/draft-stability.ts
+++ b/lib/rules/sotd/draft-stability.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     const { crType, cryType } = sr.config!;
     const STABILITY_REX =
@@ -32,12 +32,10 @@ export const check: RuleCheckFunction = (sr, done) => {
                     expected2: STABILITY_2,
                 });
         }
-
         // while other profiles allows only 'STABILITY' sentence
         else if (!txt.match(STABILITY_REX))
             sr.error(self, 'not-found', {
                 expected: STABILITY_REX,
             });
     }
-    done();
 };

--- a/lib/rules/sotd/new-features.ts
+++ b/lib/rules/sotd/new-features.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     const docType = `${sr.config!.status !== 'REC' ? 'upcoming ' : ''}Recommendation`;
     const warning = new RegExp(
@@ -33,5 +33,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     } else {
         sr.warning(self, 'no-warning');
     }
-    done();
 };

--- a/lib/rules/sotd/obsl-rescind.ts
+++ b/lib/rules/sotd/obsl-rescind.ts
@@ -37,7 +37,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         const $rationale =
@@ -58,5 +58,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             }
         }
     }
-    done();
 };

--- a/lib/rules/sotd/pp.ts
+++ b/lib/rules/sotd/pp.ts
@@ -76,7 +76,7 @@ function findPP($candidates: Cheerio<Element>, sr: Specberus) {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     const track = sr.config!.track;
     const isRecTrack = track === 'Recommendation';
@@ -88,7 +88,7 @@ export const check: RuleCheckFunction = async (sr, done) => {
         );
         if (!$pp) {
             sr.error(self, 'no-pp', { expected });
-            return done();
+            return;
         }
 
         let foundLink = false;
@@ -154,6 +154,5 @@ export const check: RuleCheckFunction = async (sr, done) => {
             sr.error(self, 'no-section6', {
                 link: `${ppLink}#sec-Disclosure`,
             });
-        return done();
     }
 };

--- a/lib/rules/sotd/process-document.ts
+++ b/lib/rules/sotd/process-document.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     const BOILERPLATE_PREFIX = 'This document is governed by the ';
     const BOILERPLATE_SUFFIX = ' W3C Process Document.';
@@ -70,5 +70,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         });
         if (!found) sr.error(self, 'not-found', { process: newProc });
     }
-    done();
 };

--- a/lib/rules/sotd/publish.ts
+++ b/lib/rules/sotd/publish.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const $sotd = sr.getSotDSection();
     const { crType, cryType, longStatus, status, track } = sr.config!;
     let docType = longStatus;
@@ -29,7 +29,7 @@ export const check: RuleCheckFunction = async (sr, done) => {
             .find(p => sr.norm(sr.$(p).text()).match(publishReg));
         if (!paragraph) {
             sr.error(self, 'not-found', { publishReg });
-            return done();
+            return;
         }
 
         const $sotdLinks = $sotd.find('a[href]');
@@ -144,5 +144,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
                 });
         }
     }
-    done();
 };

--- a/lib/rules/sotd/rec-addition.ts
+++ b/lib/rules/sotd/rec-addition.ts
@@ -55,7 +55,7 @@ function checkSection(sr: Specberus, options: CheckSectionOptions) {
         });
 }
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         const recType = sr.getRecMetadata();
@@ -100,5 +100,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             sectionClass: 'addition',
         });
     }
-    return done();
 };

--- a/lib/rules/sotd/rec-comment-end.ts
+++ b/lib/rules/sotd/rec-comment-end.ts
@@ -9,7 +9,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         const recType = sr.getRecMetadata();
@@ -54,5 +54,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             }
         }
     }
-    done();
 };

--- a/lib/rules/sotd/stability.ts
+++ b/lib/rules/sotd/stability.ts
@@ -74,7 +74,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     const { crType, cryType, status } = sr.config!;
     const $sotd = sr.getSotDSection();
     if ($sotd) {
@@ -124,5 +124,4 @@ export const check: RuleCheckFunction = async (sr, done) => {
                 });
         }
     }
-    return done();
 };

--- a/lib/rules/sotd/submission.ts
+++ b/lib/rules/sotd/submission.ts
@@ -34,7 +34,7 @@ function findSubmText($candidates: Cheerio<Element>, sr: Specberus) {
     return null;
 }
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         const $st =
@@ -42,7 +42,7 @@ export const check: RuleCheckFunction = (sr, done) => {
             findSubmText($sotd.find('p'), sr);
         if (!$st) {
             sr.error(self, 'no-submission-text');
-            return done();
+            return;
         }
 
         // check the links
@@ -119,5 +119,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         if (!foundSubmMembers) sr.error(self, 'no-sm-link');
         if (!foundComment) sr.error(self, 'no-tc-link');
     }
-    done();
 };

--- a/lib/rules/sotd/supersedable.ts
+++ b/lib/rules/sotd/supersedable.ts
@@ -15,7 +15,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
     if ($sotd) {
         let $em = $sotd.filter('p').children('em').first();
@@ -43,5 +43,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         const $a = $em.find("a[href='https://www.w3.org/TR/']");
         if (!$a.length) sr.error(self, 'no-sotd-tr');
     }
-    done();
 };

--- a/lib/rules/sotd/usage.ts
+++ b/lib/rules/sotd/usage.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $sotd = sr.getSotDSection();
 
     if ($sotd) {
@@ -20,10 +20,6 @@ export const check: RuleCheckFunction = (sr, done) => {
             .find('p')
             .toArray()
             .find(p => sr.norm(sr.$(p).text()) === usageText);
-        if (!paragraph) {
-            sr.error(self, 'not-found');
-            return done();
-        }
+        if (!paragraph) sr.error(self, 'not-found');
     }
-    return done();
 };

--- a/lib/rules/structure/canonical.ts
+++ b/lib/rules/structure/canonical.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const checkCanonical = function () {
         const $lnk = sr.$('head > link[rel=canonical]').first();
         if (!$lnk.length || !$lnk.attr('href')) sr.error(self, 'not-found');
@@ -21,6 +21,4 @@ export const check: RuleCheckFunction = (sr, done) => {
         doMeanwhile: () => {},
         doAfter: checkCanonical,
     });
-
-    done();
 };

--- a/lib/rules/structure/display-only.ts
+++ b/lib/rules/structure/display-only.ts
@@ -2,7 +2,7 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'structure.display-only';
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     if (sr.config!.status !== 'DISC')
         sr.info(
             { name, section: 'document-status', rule: 'customParagraph' },
@@ -19,5 +19,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     sr.info({ name }, 'special-box-markup');
     sr.info({ name }, 'index-list-tables');
     sr.info({ name }, 'fit-in-a4');
-    done();
 };

--- a/lib/rules/structure/h2.ts
+++ b/lib/rules/structure/h2.ts
@@ -18,7 +18,7 @@ const toc = {
     rule: 'toc',
 };
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const h2s: string[] = [];
     sr.$('h2').each((_, h2) => {
         const $h2 = sr.$(h2);
@@ -31,5 +31,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     // cspell:disable-next-line
     if (!/^Table [Oo]f [Cc]ontents$/.test(h2s[2]))
         sr.error(toc, 'toc', { was: h2s[2] });
-    done();
 };

--- a/lib/rules/structure/name.ts
+++ b/lib/rules/structure/name.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = async sr => {
     // Pseudo-constants:
     const EXPECTED_NAME = /\/Overview\.html$/;
     const OVERVIEW = 'Overview.html';
@@ -20,7 +20,7 @@ export const check: RuleCheckFunction = (sr, done) => {
     let fileName;
 
     if (!sr || !sr.url || EXPECTED_NAME.test(sr.url)) {
-        return done();
+        return;
     }
 
     if (!ALTERNATIVE_ENDING.test(sr.url)) {
@@ -33,21 +33,15 @@ export const check: RuleCheckFunction = (sr, done) => {
         } else {
             sr.warning(self, 'wrong', { note: '' });
         }
-        return done();
+        return;
     }
 
-    superagent.get(sr.url).end((_, result1) => {
-        superagent.get(sr.url + OVERVIEW).end((_, result2) => {
-            if (
-                !result1 ||
-                !result2 ||
-                !result1.ok ||
-                !result2.ok ||
-                result1.text !== result2.text
-            ) {
-                sr.warning(self, 'wrong', { note: '' });
-            }
-            return done();
-        });
-    });
+    try {
+        const result1 = await superagent.get(sr.url);
+        const result2 = await superagent.get(sr.url + OVERVIEW);
+        if (!result1.ok || !result2.ok || result1.text !== result2.text)
+            sr.warning(self, 'wrong', { note: '' });
+    } catch (error) {
+        sr.warning(self, 'wrong', { note: '' });
+    }
 };

--- a/lib/rules/structure/neutral.ts
+++ b/lib/rules/structure/neutral.ts
@@ -17,7 +17,7 @@ for (const item of badterms) {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const blocklistReg = new RegExp(`\\b${blocklist.join('\\b|\\b')}\\b`, 'ig');
     const unneutralList: string[] = [];
     // Use a cloned body instead of the original one, prevent '.remove()' side effects.
@@ -33,17 +33,13 @@ export const check: RuleCheckFunction = (sr, done) => {
         }
     });
 
-    const text = $body.text();
-    const regResult = text.match(blocklistReg);
-    if (regResult) {
+    const regResult = $body.text().match(blocklistReg);
+    if (regResult)
         regResult.forEach(word => {
             if (unneutralList.indexOf(word.toLowerCase()) < 0) {
                 unneutralList.push(word.toLowerCase());
             }
         });
-    }
-    if (unneutralList.length) {
+    if (unneutralList.length)
         sr.warning(self, 'neutral', { words: unneutralList.join('", "') });
-    }
-    done();
 };

--- a/lib/rules/structure/section-ids.ts
+++ b/lib/rules/structure/section-ids.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $ignoreH3 = sr.$('.head > h3').first();
 
     sr.$('h2, h3, h4, h5, h6').each((_, el) => {
@@ -43,5 +43,4 @@ export const check: RuleCheckFunction = (sr, done) => {
 
         sr.error(self, 'no-id', { text: el.name });
     });
-    done();
 };

--- a/lib/rules/structure/security-privacy.ts
+++ b/lib/rules/structure/security-privacy.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     let security = false;
     let privacy = false;
 
@@ -30,6 +30,4 @@ export const check: RuleCheckFunction = (sr, done) => {
 
         if (!privacy) sr.warning(self, 'no-privacy');
     }
-
-    done();
 };

--- a/lib/rules/style/back-to-top.ts
+++ b/lib/rules/style/back-to-top.ts
@@ -10,12 +10,10 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $candidates = sr.$(
         "body p#back-to-top[role='navigation'] a[href='#title']"
     );
 
     if ($candidates.length !== 1) sr.warning(self, 'not-found');
-
-    done();
 };

--- a/lib/rules/style/body-toc-sidebar.ts
+++ b/lib/rules/style/body-toc-sidebar.ts
@@ -6,11 +6,10 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     try {
         if (sr.$('body').hasClass('toc-sidebar')) sr.error(self, 'class-found');
     } catch (e) {
         sr.error(self, 'selector-fail');
     }
-    done();
 };

--- a/lib/rules/style/meta.ts
+++ b/lib/rules/style/meta.ts
@@ -17,7 +17,7 @@ export const { name } = self;
 const width = /^device-width$/i;
 const shrinkToFit = /^no$/i;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const $meta = sr.$("head > meta[name='viewport'][content]");
     if ($meta.length !== 1) {
         sr.error(self, 'not-found');
@@ -40,5 +40,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             sr.error(self, 'not-found');
         }
     }
-    done();
 };

--- a/lib/rules/style/script.ts
+++ b/lib/rules/style/script.ts
@@ -10,7 +10,7 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const PATTERN_SCRIPT =
         /^(https?:)?\/\/(www\.)?w3\.org\/scripts\/tr\/2021\/fixup\.js$/i;
 
@@ -22,6 +22,4 @@ export const check: RuleCheckFunction = (sr, done) => {
     });
 
     if (found !== 1) sr.error(self, 'not-found');
-
-    done();
 };

--- a/lib/rules/style/sheet.ts
+++ b/lib/rules/style/sheet.ts
@@ -13,9 +13,9 @@ const notLast = {
     rule: 'lastStylesheet',
 };
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const { styleSheet } = sr.config!;
-    if (!styleSheet) return done();
+    if (!styleSheet) return;
     const url = `https://www.w3.org/StyleSheets/TR/2021/${styleSheet}`;
     const dark = 'https://www.w3.org/StyleSheets/TR/2021/dark';
     const stylesheetLinks = [
@@ -35,5 +35,4 @@ export const check: RuleCheckFunction = (sr, done) => {
             sr.error(notLast, 'last');
         }
     }
-    done();
 };

--- a/lib/rules/validation/html.ts
+++ b/lib/rules/validation/html.ts
@@ -1,3 +1,4 @@
+import type { ResponseError } from 'superagent';
 import { get, post } from '../../throttled-ua.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
@@ -10,16 +11,16 @@ const TIMEOUT = 10000;
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     const { htmlValidator, skipValidation } = sr.config!;
     const service = htmlValidator || 'https://validator.w3.org/nu/';
     if (skipValidation) {
         sr.warning(self, 'skipped');
-        return done();
+        return;
     }
     if (!sr.url && !sr.source) {
         sr.warning(self, 'no-source');
-        return done();
+        return;
     }
     let req;
     const ua = `W3C-Pubrules/${sr.version}`;
@@ -34,18 +35,13 @@ export const check: RuleCheckFunction = (sr, done) => {
             .query({ out: 'json' });
     }
     req.timeout(TIMEOUT);
-    req.end((err, res) => {
-        if (err) {
-            if (err.timeout === TIMEOUT) {
-                sr.warning(self, 'timeout');
-            } else {
-                sr.error(self, 'no-response');
-            }
-        } else if (!res.ok) {
-            sr.error(self, 'failure', { status: res.status });
-        } else {
+    return req.then(
+        res => {
+            if (!res.ok)
+                return sr.error(self, 'failure', { status: res.status });
+
             const json = res.body;
-            if (!json) return sr.throw('No JSON input.');
+            if (!json) throw new Error('No JSON returned from HTML validator.');
 
             if (json.messages && json.messages.length) {
                 for (let i = 0, n = json.messages.length; i < n; i += 1) {
@@ -95,7 +91,10 @@ export const check: RuleCheckFunction = (sr, done) => {
                     }
                 }
             }
+        },
+        (err: ResponseError) => {
+            if (err.timeout) sr.warning(self, 'timeout');
+            else sr.error(self, 'no-response');
         }
-        done();
-    });
+    );
 };

--- a/lib/rules/validation/wcag.ts
+++ b/lib/rules/validation/wcag.ts
@@ -8,7 +8,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = (sr, done) => {
+export const check: RuleCheckFunction = sr => {
     sr.info(self, 'tools');
-    return done();
 };

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -58,10 +58,7 @@ export interface RecMetadata {
     rectrack?: string | null;
 }
 
-export type RuleCheckFunction<R = void> = (
-    sr: Specberus,
-    done: (result: R) => void
-) => void | Promise<void>;
+export type RuleCheckFunction<R = void> = (sr: Specberus) => R | Promise<R>;
 
 export interface RuleBase {
     name: string;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -41,7 +41,13 @@ export interface SpecberusConfig {
     validation?: ValidateOptions['validation'];
 }
 
-export type HandlerMessage = Record<string, string | undefined>;
+/** Data types emitted by error, warning, and info events */
+export type HandlerMessage = RuleBase &
+    Partial<RuleMeta> & {
+        detailMessage: string;
+        key: string;
+        extra?: Record<string, any>;
+    };
 
 type IsoDateString = `${number}-${number}-${number}`;
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -11,31 +11,12 @@ import { Octokit } from '@octokit/core';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
 
-import type { HandlerMessage, SpecberusConfig } from './types.js';
+import type { SpecberusConfig } from './types.js';
 import type { ValidateOptions } from './validator.js';
 import pkg from '../package.json' with { type: 'json' };
 
 /** Current specberus version recorded in package.json */
 export const specberusVersion = pkg.version;
-
-/**
- * Builds a JSON result (of validation, metadata extraction, etc).
- */
-
-export const buildJSONresult = function (
-    errors: HandlerMessage[],
-    warnings: HandlerMessage[],
-    info: HandlerMessage[],
-    metadata: Record<string, any>
-) {
-    return {
-        success: !errors.length,
-        errors,
-        warnings,
-        info,
-        metadata,
-    };
-};
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -65,12 +65,14 @@ interface ProcessParamsConstraints {
 /**
  * Build an “options” object based on an HTTP query string or a similar object containing options.
  *
- * An example of <code>constraints</code>:
- * <blockquote><pre>{
- *     "required": ["processDocument"],
- *     "forbidden": ["echidnaReady", "bogusParam"],
+ * An example of `constraints`:
+ * ```json
+ * {
+ *     "required": ["profile"],
+ *     "forbidden": ["source", "bogusParam"],
  *     "allowUnknownParams": true
- * }</pre>/blockquote>
+ * }
+ * ```
  *
  * @param params - an HTTP request query, or a similar object.
  * @param base - (<strong>optional</strong>) a template or “base” object to build from.
@@ -112,9 +114,6 @@ export async function processParams(
         } else if (
             p === 'validation' ||
             p === 'htmlValidator' ||
-            p === 'cssValidator' ||
-            p === 'processDocument' ||
-            p === 'events' ||
             p === 'editorial' ||
             p === 'additionalMetadata'
         ) {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -575,7 +575,6 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
                 const $el = this.$(el);
                 const href = $el.attr('href')!;
                 const text = this.norm($el.text());
-                const found: Record<string, boolean> = {};
 
                 if (REGEX_DELIVERER_TEXT.test(text)) {
                     if (REGEX_DELIVERER_IPR_URL.test(href)) {
@@ -592,10 +591,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
                             href.match(REGEX_DELIVERER_URL);
                         if (delivererUrlMatch) {
                             const id = delivererUrlMatch[1];
-                            if (id && id.length > 1 && !found[id]) {
-                                found[id] = true;
-                                ids.push(parseInt(id, 10));
-                            }
+                            if (id && id.length > 1) ids.push(parseInt(id, 10));
                         } else if (REGEX_TAG_DISCLOSURE.test(href)) {
                             ids.push(TAG.id);
                         }
@@ -650,15 +646,12 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             const $el = this.$(el);
             const href = $el.attr('href')!;
             const text = this.norm($el.text());
-            const found: Record<string, boolean> = {};
             if (REGEX_DELIVERER_TEXT.test(text)) {
                 const delivererUrlMatch = href.match(REGEX_DELIVERER_URL);
                 if (delivererUrlMatch) {
                     const id = delivererUrlMatch[1];
-                    if (id && id.length > 1 && !found[id]) {
-                        found[id] = true;
+                    if (id && id.length > 1)
                         promiseArray.push(parseInt(id, 10));
-                    }
                 } else if (REGEX_TAG_DISCLOSURE.test(href)) {
                     promiseArray.push(TAG.id);
                 } else if (REGEX_DELIVERER_IPR_URL.test(href)) {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -2,8 +2,8 @@
  * @file Main file of the Specberus npm package.
  */
 
+import EventEmitter from 'events';
 import { access, constants, readFile } from 'fs/promises';
-import type EventEmitter from 'events';
 
 import { type Cheerio, load } from 'cheerio';
 import type { Element } from 'domhandler';
@@ -37,7 +37,7 @@ import type {
 setLanguage('en_GB');
 
 interface BaseOptions {
-    events: EventEmitter;
+    events?: EventEmitter;
     file?: string;
     source?: string;
     url?: string;
@@ -118,6 +118,23 @@ export const possibleMonths = [...months, ...abbrMonths].join('|');
 
 const separator = '[ -]{1}';
 
+interface ExceptionsErrorOptions extends ErrorOptions {
+    exceptions: string[];
+}
+
+/**
+ * Error which includes list of exception messages,
+ * thrown in case of unexpected errors during extractMetadata or validate
+ */
+export class ExceptionsError extends Error {
+    exceptions: string[];
+
+    constructor(message?: string, options?: ExceptionsErrorOptions) {
+        super(message, options);
+        this.exceptions = options?.exceptions || [];
+    }
+}
+
 export class Specberus {
     $ = load('');
     config: SpecberusConfig | undefined;
@@ -157,27 +174,18 @@ export class Specberus {
         metadata: Record<string, any>
     ) {
         if (!this.#exceptions.length) {
-            const result = buildJSONresult(errors, warnings, info, metadata);
-            this.#sink?.emit('end-all', result);
-            return result;
+            return buildJSONresult(errors, warnings, info, metadata);
         } else {
-            throw new Error(
+            throw new ExceptionsError(
                 'The following unexpected errors occurred:\n' +
-                    this.#exceptions.join('\n')
+                    this.#exceptions.join('\n'),
+                { exceptions: this.#exceptions }
             );
         }
     }
 
     async extractMetadata(options: ExtractMetadataOptions) {
-        if (!options.events)
-            throw new Error(
-                '[EXCEPTION] The events option is required for reporting.'
-            );
-        const sink = (this.#sink = options.events);
-        if (!this.#sink.listeners('exception').length)
-            throw new Error(
-                '[WARNING] No handler for event `exception` which to report system errors.'
-            );
+        const sink = (this.#sink = options.events || new EventEmitter());
 
         const meta: Record<string, any> = (this.meta = {});
         const errors: HandlerMessage[] = [];
@@ -196,13 +204,13 @@ export class Specberus {
         try {
             this.$ = await this.#load(options);
         } catch (error) {
-            return this.#throw(error.toString());
+            this.#throw(error.toString());
+            throw error;
         }
 
         const profile = options.additionalMetadata
             ? profileAdditionalMetadata
             : profileMetadata;
-        sink.emit('start-all', profile);
         await Promise.all(
             profile.rules.map(async rule => {
                 try {
@@ -221,18 +229,10 @@ export class Specberus {
     }
 
     async validate(options: ValidateOptions) {
-        if (!options.events)
-            throw new Error(
-                '[EXCEPTION] The events option is required for reporting.'
-            );
-        const sink = (this.#sink = options.events);
-        if (sink.listeners('exception').length === 0)
-            throw new Error(
-                '[WARNING] No handler for event `exception` which to report system errors.'
-            );
-
         if (!options.profile)
-            return this.#throw('Without a profile there is nothing to check.');
+            throw new Error('Without a profile there is nothing to check.');
+
+        const sink = (this.#sink = options.events || new EventEmitter());
         const { profile } = options;
         this.config = await processParams(options, profile.config);
         const errors: HandlerMessage[] = [];
@@ -248,13 +248,8 @@ export class Specberus {
             infos.push(Object.assign({}, ...data));
         });
 
-        try {
-            this.$ = await this.#load(options);
-        } catch (error) {
-            return this.#throw(error.toString());
-        }
+        this.$ = await this.#load(options);
 
-        sink.emit('start-all', profile);
         await Promise.all(
             profile.rules.map(async rule => {
                 try {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -245,9 +245,10 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
                     if (result)
                         for (const [key, value] of Object.entries(result))
                             metadata[key] = value;
-                    this.emit('done', rule.name);
                 } catch (error) {
                     this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
                 }
             })
         );
@@ -266,9 +267,10 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             profile.rules.map(async rule => {
                 try {
                     await rule.check(this);
-                    this.emit('done', rule.name);
                 } catch (error) {
                     this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
                 }
             })
         );

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -139,9 +139,6 @@ export class ExceptionsError extends Error {
 export class Specberus {
     $ = load('');
     config: SpecberusConfig | undefined;
-    // TODO(kgf): This is publicly documented, but is unused within the codebase;
-    // it would be better exposed as a Promise return value from extractMetadata
-    meta: Record<string, any> | undefined;
     source: string | undefined;
     url: string | undefined;
     version = specberusVersion;
@@ -185,7 +182,7 @@ export class Specberus {
     async extractMetadata(options: ExtractMetadataOptions) {
         const sink = (this.#sink = options.events || new EventEmitter());
 
-        const metadata: Record<string, any> = (this.meta = {});
+        const metadata: Record<string, any> = {};
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
         const info: HandlerMessage[] = [];

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -2,10 +2,10 @@
  * @file Main file of the Specberus npm package.
  */
 
-import fs from 'fs';
+import { access, constants, readFile } from 'fs/promises';
 import type EventEmitter from 'events';
 
-import { type Cheerio, type CheerioAPI, load } from 'cheerio';
+import { type Cheerio, load } from 'cheerio';
 import type { Element } from 'domhandler';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
@@ -26,7 +26,6 @@ import {
 import type {
     ApiCharter,
     HandlerMessage,
-    RuleModule,
     RuleBase,
     ApiSpecificationVersion,
     RecMetadata,
@@ -125,53 +124,57 @@ export class Specberus {
     // TODO(kgf): This is publicly documented, but is unused within the codebase;
     // it would be better exposed as a Promise return value from extractMetadata
     meta: Record<string, any> | undefined;
-    source!: any | null;
-    url!: string | null;
+    source: string | undefined;
+    url: string | undefined;
     version = specberusVersion;
-    private $docDateEl: Cheerio<Element> | undefined;
-    private $sotdSection: Cheerio<Element> | null | undefined;
+
+    // Private fields
+
+    #$docDateEl: Cheerio<Element> | undefined;
+    #$sotdSection: Cheerio<Element> | null | undefined;
     /** Group objects returned by W3C API charters endpoint */
-    private chartersData: ApiCharter[] | undefined;
+    #chartersData: ApiCharter[] | undefined;
     /** Charter URIs */
-    private charters: string[] | undefined;
-    private delivererIDs: number[] | undefined;
-    private delivererGroups: DelivererGroup[] | undefined;
-    private docDate: Date | null | undefined;
-    private headers: HeaderMap | undefined;
-    private isFirstPublic: any | undefined;
-    private shortname: string | undefined;
-    private sink: EventEmitter | undefined;
+    #charters: string[] | undefined;
+    #delivererIDs: number[] | undefined;
+    #delivererGroups: DelivererGroup[] | undefined;
+    #docDate: Date | undefined;
+    /** Stores messages from any unexpected errors encountered during process */
+    #exceptions: string[] = [];
+    #headers: HeaderMap | undefined;
+    #isFirstPublic: any | undefined;
+    #shortname: string | undefined = undefined;
+    #sink: EventEmitter | undefined;
 
-    constructor() {
-        this.clearCache();
+    /**
+     * Handles common end-state logic for both extractMetadata and validate,
+     * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
+     */
+    #reportResult(
+        errors: HandlerMessage[],
+        warnings: HandlerMessage[],
+        info: HandlerMessage[],
+        metadata: Record<string, any>
+    ) {
+        if (!this.#exceptions.length) {
+            const result = buildJSONresult(errors, warnings, info, metadata);
+            this.#sink?.emit('end-all', result);
+            return result;
+        } else {
+            throw new Error(
+                'The following unexpected errors occurred:\n' +
+                    this.#exceptions.join('\n')
+            );
+        }
     }
 
-    clearCache() {
-        this.$ = load('');
-        this.config = undefined;
-        this.docDate = null;
-        this.$docDateEl = undefined;
-        this.$sotdSection = undefined;
-        this.url = null;
-        this.source = null;
-        this.shortname = undefined;
-        this.delivererIDs = undefined;
-        this.delivererGroups = undefined;
-        this.chartersData = undefined;
-        this.charters = undefined;
-        this.headers = undefined;
-        this.isFirstPublic = undefined;
-    }
-
-    extractMetadata(options: ExtractMetadataOptions) {
-        this.clearCache();
-
+    async extractMetadata(options: ExtractMetadataOptions) {
         if (!options.events)
             throw new Error(
                 '[EXCEPTION] The events option is required for reporting.'
             );
-        const sink = (this.sink = options.events);
-        if (!this.sink.listeners('exception').length)
+        const sink = (this.#sink = options.events);
+        if (!this.#sink.listeners('exception').length)
             throw new Error(
                 '[WARNING] No handler for event `exception` which to report system errors.'
             );
@@ -189,128 +192,81 @@ export class Specberus {
         sink.on('info', data => {
             infos.push(data);
         });
-        /**
-         * @param err
-         * @param {CheerioAPI} $
-         */
-        const doMetadataExtraction = (err: any, $?: CheerioAPI) => {
-            if (err) return this.throw(err);
-            if ($) this.$ = $;
-            const profile = options.additionalMetadata
-                ? profileAdditionalMetadata
-                : profileMetadata;
-            sink.emit('start-all', profile);
-            const total = (profile.rules || []).length;
-            let done = 0;
-            profile.rules.forEach(rule => {
+
+        try {
+            this.$ = await this.#load(options);
+        } catch (error) {
+            return this.#throw(error.toString());
+        }
+
+        const profile = options.additionalMetadata
+            ? profileAdditionalMetadata
+            : profileMetadata;
+        sink.emit('start-all', profile);
+        await Promise.all(
+            profile.rules.map(async rule => {
                 try {
-                    rule.check(this, result => {
-                        if (result) {
-                            for (const i in result) {
-                                meta[i] = result[i];
-                            }
-                        }
-                        done += 1;
-                        sink.emit('done', rule.name);
-                        if (done === total)
-                            sink.emit(
-                                'end-all',
-                                buildJSONresult(errors, warnings, infos, meta)
-                            );
-                    });
-                } catch (e) {
-                    this.throw(e.message);
+                    const result = await rule.check(this);
+                    if (result)
+                        for (const [key, value] of Object.entries(result))
+                            meta[key] = value;
+                    sink.emit('done', rule.name);
+                } catch (error) {
+                    this.#throw(error.message);
                 }
-            });
-        };
-        if (options.url) this.loadURL(options.url, doMetadataExtraction);
-        else if (options.source)
-            this.loadSource(options.source, doMetadataExtraction);
-        else if (options.file)
-            this.loadFile(options.file, doMetadataExtraction);
-        else
-            return this.throw(
-                'At least one of url, source, file, or document must be specified.'
-            );
+            })
+        );
+
+        return this.#reportResult(errors, warnings, infos, meta);
     }
 
-    validate(options: ValidateOptions) {
-        this.clearCache();
-
+    async validate(options: ValidateOptions) {
         if (!options.events)
             throw new Error(
                 '[EXCEPTION] The events option is required for reporting.'
             );
-        const sink = (this.sink = options.events);
+        const sink = (this.#sink = options.events);
         if (sink.listeners('exception').length === 0)
             throw new Error(
                 '[WARNING] No handler for event `exception` which to report system errors.'
             );
 
         if (!options.profile)
-            return this.throw('Without a profile there is nothing to check.');
+            return this.#throw('Without a profile there is nothing to check.');
         const { profile } = options;
-        processParams(options, profile.config)
-            .then(config => {
-                this.config = config;
-                // TODO(kgf): Is this unused? We seem to hard-code it at the top of this file...
-                config.lang = 'en_GB';
-                const errors: HandlerMessage[] = [];
-                const warnings: HandlerMessage[] = [];
-                const infos: HandlerMessage[] = [];
-                sink.on('err', (...data) => {
-                    errors.push(Object.assign({}, ...data));
-                });
-                sink.on('warning', (...data) => {
-                    warnings.push(Object.assign({}, ...data));
-                });
-                sink.on('info', (...data) => {
-                    infos.push(Object.assign({}, ...data));
-                });
-                /**
-                 * @param err
-                 * @param {CheerioAPI} $
-                 */
-                const doValidation = (err: any, $?: CheerioAPI) => {
-                    if (err) return this.throw(err);
-                    if ($) this.$ = $;
-                    sink.emit('start-all', profile.name);
-                    const total = (profile.rules || []).length;
-                    let done = 0;
-                    profile.rules.forEach((rule: RuleModule) => {
-                        // XXX(darobin)
-                        //  I would like to catch all exceptions here, but this derails the testing
-                        //  infrastructure which also uses exceptions that it expects aren't caught
-                        rule.check(
-                            this,
-                            function () {
-                                done += 1;
-                                sink.emit('done', rule.name);
-                                if (done === total)
-                                    sink.emit(
-                                        'end-all',
-                                        buildJSONresult(
-                                            errors,
-                                            warnings,
-                                            infos,
-                                            {}
-                                        )
-                                    );
-                            }.bind(rule)
-                        );
-                    });
-                };
-                if (options.url) this.loadURL(options.url, doValidation);
-                else if (options.source)
-                    this.loadSource(options.source, doValidation);
-                else if (options.file)
-                    this.loadFile(options.file, doValidation);
-                else
-                    return this.throw(
-                        'At least one of url, source, file, or document must be specified.'
-                    );
+        this.config = await processParams(options, profile.config);
+        const errors: HandlerMessage[] = [];
+        const warnings: HandlerMessage[] = [];
+        const infos: HandlerMessage[] = [];
+        sink.on('err', (...data) => {
+            errors.push(Object.assign({}, ...data));
+        });
+        sink.on('warning', (...data) => {
+            warnings.push(Object.assign({}, ...data));
+        });
+        sink.on('info', (...data) => {
+            infos.push(Object.assign({}, ...data));
+        });
+
+        try {
+            this.$ = await this.#load(options);
+        } catch (error) {
+            return this.#throw(error.toString());
+        }
+
+        sink.emit('start-all', profile);
+        await Promise.all(
+            profile.rules.map(async rule => {
+                try {
+                    await rule.check(this);
+                    sink.emit('done', rule.name);
+                } catch (error) {
+                    this.#throw(error.message);
+                }
             })
-            .catch(err => this.throw(err.toString()));
+        );
+
+        return this.#reportResult(errors, warnings, infos, {});
     }
 
     error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
@@ -322,7 +278,7 @@ export class Specberus {
         )
             this.warning(rule, key, extra);
         else
-            this.sink!.emit('err', rule, {
+            this.#sink!.emit('err', rule, {
                 key,
                 extra,
                 detailMessage: assembleData(null, rule, key, extra).message,
@@ -334,7 +290,7 @@ export class Specberus {
         key: string,
         extra?: Record<string, any>
     ) {
-        this.sink!.emit('warning', rule, {
+        this.#sink!.emit('warning', rule, {
             key,
             extra,
             detailMessage: assembleData(null, rule, key, extra).message,
@@ -342,27 +298,42 @@ export class Specberus {
     }
 
     info(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
-        this.sink!.emit('info', rule, {
+        this.#sink!.emit('info', rule, {
             key,
             extra,
             detailMessage: assembleData(null, rule, key, extra).message,
         });
     }
 
-    throw(message: string) {
+    /**
+     * Emits an exception event, intended to signify that the process stopped on a critical error.
+     *
+     * NOTE: This should not be called from rules; they should throw an Error,
+     * which will result in extractMetadata or validate invoking this method.
+     */
+    #throw(message: string) {
         console.error(`[EXCEPTION] ${message}`);
-        this.sink!.emit('exception', { message });
+        this.#sink!.emit('exception', { message });
+        // Track in exceptions array, used to determine whether to resolve or reject process
+        this.#exceptions.push(message);
     }
 
-    checkSelector(sel: string, rule: RuleMeta, done: () => void) {
+    /**
+     * Checks for presence of a selector.
+     * Reports a not-found error for the specified rule if no match is found.
+     */
+    checkSelector(sel: string, rule: RuleMeta) {
         try {
             if (!this.$(sel).length) this.error(rule, 'not-found');
         } catch (e) {
-            this.throw(`Selector '${sel}' caused the validator to blow up.`);
+            throw new Error(`Invalid selector '${sel}': ${e}`);
         }
-        done();
     }
 
+    /**
+     * Normalizes a string by removing leading/trailing whitespace
+     * and condensing multiple consecutive whitespace characters to one.
+     */
     norm(str: string) {
         if (!str) return '';
         return `${str}`
@@ -387,7 +358,7 @@ export class Specberus {
     }
 
     getDocumentDate() {
-        if (this.docDate) return this.docDate;
+        if (this.#docDate) return this.#docDate;
         const rex = new RegExp(
             `${Specberus.dateRegexStrCapturing}(?:, edited in place ${Specberus.dateRegexStrNonCapturing})?$`
         );
@@ -395,22 +366,23 @@ export class Specberus {
 
         const matches = $el.length && this.norm($el.text()).match(rex);
         if (matches) {
-            this.docDate = this.stringToDate(
+            this.#docDate = this.stringToDate(
                 `${matches[1]} ${matches[2]} ${matches[3]}`
             );
-            this.$docDateEl = $el;
+            this.#$docDateEl = $el;
         }
-        return this.docDate;
+        return this.#docDate;
     }
 
     getDocumentStateElement() {
-        if (this.$docDateEl) return this.$docDateEl;
+        if (this.#$docDateEl) return this.#$docDateEl;
         this.getDocumentDate();
-        return this.$docDateEl;
+        return this.#$docDateEl;
     }
 
     getSotDSection() {
-        if (typeof this.$sotdSection !== 'undefined') return this.$sotdSection;
+        if (typeof this.#$sotdSection !== 'undefined')
+            return this.#$sotdSection;
 
         let startH2: Element | undefined;
         let endH2: Element | undefined;
@@ -431,7 +403,7 @@ export class Specberus {
                 startH2 = h2;
             }
         });
-        if (!startH2) this.$sotdSection = null;
+        if (!startH2) this.#$sotdSection = null;
         else {
             let started = false;
             this.$(startH2)
@@ -446,9 +418,9 @@ export class Specberus {
                     if (endH2 === el || $nav[0] === el) return false;
                     $div.append(el.cloneNode(true));
                 });
-            this.$sotdSection = $div.children().length ? $div : null;
+            this.#$sotdSection = $div.children().length ? $div : null;
         }
-        if (!this.$sotdSection)
+        if (!this.#$sotdSection)
             this.error(
                 {
                     name: 'generic.sotd',
@@ -457,7 +429,7 @@ export class Specberus {
                 },
                 'not-found'
             );
-        return this.$sotdSection;
+        return this.#$sotdSection;
     }
 
     /**
@@ -470,7 +442,7 @@ export class Specberus {
         const EDITORS = /^editor(s)?$/;
         const EDITORS_DRAFT = /^(latest )?editor's draft$/i;
 
-        if (!$dl && typeof this.headers !== 'undefined') return this.headers;
+        if (!$dl && typeof this.#headers !== 'undefined') return this.#headers;
 
         $dl = $dl || this.$('body div.head dl');
 
@@ -484,9 +456,7 @@ export class Specberus {
                 let $dd = $dt.next('dd');
                 let key = null;
                 if (!$dd.length)
-                    return this.throw(
-                        `No &lt;dd&gt; element found for ${txt}.`
-                    );
+                    throw new Error(`No &lt;dd&gt; element found for ${txt}.`);
                 if (txt === 'this version') key = 'This';
                 else if (
                     !dts.Latest &&
@@ -512,12 +482,12 @@ export class Specberus {
                 if (key) dts[key] = { pos: idx, $el: $dt, $dd };
             });
         }
-        this.headers = dts;
+        this.#headers = dts;
         return dts;
     }
 
     getShortname() {
-        if (typeof this.shortname !== 'undefined') return this.shortname;
+        if (typeof this.#shortname !== 'undefined') return this.#shortname;
 
         let shortname;
         const dts = this.extractHeaders();
@@ -528,7 +498,7 @@ export class Specberus {
         if (thisVersionMatches && thisVersionMatches.length > 0)
             [, shortname] = thisVersionMatches;
 
-        this.shortname = shortname;
+        this.#shortname = shortname;
         return shortname;
     }
 
@@ -585,8 +555,8 @@ export class Specberus {
      * Retrieves deliverers groupNames and types.
      */
     async getDelivererGroups() {
-        if (typeof this.delivererGroups !== 'undefined')
-            return this.delivererGroups;
+        if (typeof this.#delivererGroups !== 'undefined')
+            return this.#delivererGroups;
         const REGEX_DELIVERER_URL =
             /^https?:\/\/www\.w3\.org\/2004\/01\/pp-impl\/(\d+)\/status(#.*)?$/i;
         const REGEX_DELIVERER_TEXT =
@@ -640,22 +610,18 @@ export class Specberus {
         }
 
         // send request to W3C API if there's id extracted from the doc.
-        for (let i = 0; i < ids.length; i += 1) {
-            const groupApiUrl = `https://api.w3.org/groups/${ids[i]}`;
+        for (const id of ids) {
+            const groupApiUrl = `https://api.w3.org/groups/${id}`;
             promiseArray.push(
-                new Promise(resolve => {
-                    get(groupApiUrl)
-                        .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
-                        .end((_, data) => {
-                            resolve(data);
-                        });
-                })
+                get(groupApiUrl).set(
+                    'User-Agent',
+                    `W3C-Pubrules/${specberusVersion}`
+                )
             );
         }
 
-        await Promise.all(promiseArray).then(res => {
-            for (let i = 0; i < res.length; i += 1) {
-                const data = res[i];
+        await Promise.all(promiseArray).then(responses => {
+            for (const data of responses) {
                 if (data && data.body) {
                     let { type } = data.body;
                     switch (type) {
@@ -677,13 +643,13 @@ export class Specberus {
                 }
             }
         });
-        this.delivererGroups = delivererGroups;
+        this.#delivererGroups = delivererGroups;
         return delivererGroups;
     }
 
     async getDelivererIDs() {
-        if (undefined !== this.delivererIDs) {
-            return this.delivererIDs;
+        if (undefined !== this.#delivererIDs) {
+            return this.#delivererIDs;
         }
         const REGEX_DELIVERER_URL =
             /^https?:\/\/www\.w3\.org\/2004\/01\/pp-impl\/(\d+)\/status(#.*)?$/i;
@@ -740,7 +706,7 @@ export class Specberus {
                 }
             });
         }
-        this.delivererIDs = ids;
+        this.#delivererIDs = ids;
         return ids;
     }
 
@@ -763,7 +729,7 @@ export class Specberus {
 
     /** Finds the current charter(s) of the document. */
     async getChartersData() {
-        if (undefined !== this.chartersData) return this.chartersData;
+        if (undefined !== this.#chartersData) return this.#chartersData;
 
         const deliverers = await this.getDelivererIDs();
         const docDate = this.getDocumentDate()!;
@@ -807,15 +773,15 @@ export class Specberus {
             }
         }
 
-        this.chartersData = chartersData;
+        this.#chartersData = chartersData;
         return chartersData;
     }
 
     async getCharters() {
-        if (typeof this.charters !== 'undefined') return this.charters;
+        if (typeof this.#charters !== 'undefined') return this.#charters;
 
-        this.charters = (await this.getChartersData()).map(({ uri }) => uri);
-        return this.charters;
+        this.#charters = (await this.getChartersData()).map(({ uri }) => uri);
+        return this.#charters;
     }
 
     /**
@@ -823,11 +789,11 @@ export class Specberus {
      * For shortname change document, data-previous-shortname attribute is needed.
      */
     async isFP() {
-        if (typeof this.isFirstPublic !== 'undefined')
-            return this.isFirstPublic;
+        if (typeof this.#isFirstPublic !== 'undefined')
+            return this.#isFirstPublic;
 
-        this.isFirstPublic = !(await this.getPreviousVersion());
-        return this.isFirstPublic;
+        this.#isFirstPublic = !(await this.getPreviousVersion());
+        return this.#isFirstPublic;
     }
 
     /**
@@ -835,7 +801,7 @@ export class Specberus {
      */
     async getPreviousVersion() {
         const dts = this.extractHeaders();
-        const shortname = this.shortname || (await this.getShortname());
+        const shortname = this.#shortname || (await this.getShortname());
 
         if (!shortname) {
             this.error(
@@ -897,41 +863,41 @@ export class Specberus {
         }
     }
 
-    loadURL(url: string, cb: (err: any, $?: CheerioAPI) => void) {
-        if (!cb) return this.throw('Missing callback to loadURL.');
-        get(url)
+    #load(options: ExtractMetadataOptions | ValidateOptions) {
+        if (options.url) return this.#loadURL(options.url);
+        if (options.source) return this.#loadSource(options.source);
+        if (options.file) return this.#loadFile(options.file);
+        throw new Error('url, source, or file must be specified.');
+    }
+
+    #loadURL(url: string) {
+        return get(url)
             .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
-            .end((err, res) => {
-                if (err) return this.throw(err.message);
-                if (!res.text) return this.throw(`Body of ${url} is empty.`);
+            .then(res => {
+                if (!res.text) throw new Error(`Body of ${url} is empty.`);
                 this.url = url;
-                this.loadSource(res.text, cb);
+                return this.#loadSource(res.text);
             });
     }
 
-    loadSource(src: string, cb: (err: Error | null, $?: CheerioAPI) => void) {
-        if (!cb) return this.throw('Missing callback to loadSource.');
+    #loadSource(src: string) {
         this.source = src;
-        let $: CheerioAPI;
         try {
-            $ = load(src);
+            return load(src);
         } catch (e) {
-            return this.throw(
+            throw new Error(
                 `Cheerio failed to parse source: ${JSON.stringify(e)}`
             );
         }
-        cb(null, $);
     }
 
-    loadFile(file: string, cb: (err: any, $?: CheerioAPI) => void) {
-        if (!cb) return this.throw('Missing callback to loadFile.');
-        fs.access(file, fs.constants.F_OK, errors => {
-            if (errors) return cb(`File '${file}' not found.`);
-            fs.readFile(file, { encoding: 'utf8' }, (err, src) => {
-                if (err) return cb(err);
-                this.loadSource(src, cb);
-            });
-        });
+    async #loadFile(file: string) {
+        try {
+            access(file, constants.F_OK);
+        } catch (error) {
+            throw new Error(`File '${file}' not found or inaccessible.`);
+        }
+        return this.#loadSource(await readFile(file, 'utf8'));
     }
 
     transition(options: TransitionOptions) {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -844,7 +844,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
 
     async #loadFile(file: string) {
         try {
-            access(file, constants.F_OK);
+            await access(file, constants.F_OK);
         } catch (error) {
             throw new Error(`File '${file}' not found or inaccessible.`);
         }

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -189,7 +189,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     #shortname: string | undefined = undefined;
 
     /**
-     * Handles common end-state logic for both extractMetadata and validate,
+     * Internal function for handling common end-state logic for extractMetadata and validate,
      * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
      */
     #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
@@ -206,11 +206,12 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         };
     }
 
-    async extractMetadata(options: ExtractMetadataOptions) {
-        const metadata: Record<string, any> = {};
+    /** Internal function containing setup logic common to both extractMetadata and validate. */
+    async #prepare(options: ExtractMetadataOptions | ValidateOptions) {
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
         const info: HandlerMessage[] = [];
+
         this.on('err', (rule, data) => {
             errors.push({ ...rule, ...data });
         });
@@ -228,9 +229,16 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             throw error;
         }
 
+        return { errors, info, warnings };
+    }
+
+    async extractMetadata(options: ExtractMetadataOptions) {
+        const messages = await this.#prepare(options);
+        const metadata: Record<string, any> = {};
         const profile = options.additionalMetadata
             ? profileAdditionalMetadata
             : profileMetadata;
+
         await Promise.all(
             profile.rules.map(async rule => {
                 try {
@@ -244,8 +252,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
                 }
             })
         );
-
-        return this.#reportResult({ errors, warnings, info, metadata });
+        return this.#reportResult({ ...messages, metadata });
     }
 
     async validate(options: ValidateOptions) {
@@ -254,20 +261,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
 
         const { profile } = options;
         this.config = await processParams(options, profile.config);
-        const errors: HandlerMessage[] = [];
-        const warnings: HandlerMessage[] = [];
-        const info: HandlerMessage[] = [];
-        this.on('err', (rule, data) => {
-            errors.push({ ...rule, ...data });
-        });
-        this.on('warning', (rule, data) => {
-            warnings.push({ ...rule, ...data });
-        });
-        this.on('info', (rule, data) => {
-            info.push({ ...rule, ...data });
-        });
-
-        this.$ = await this.#load(options);
+        const messages = await this.#prepare(options);
 
         await Promise.all(
             profile.rules.map(async rule => {
@@ -279,8 +273,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
                 }
             })
         );
-
-        return this.#reportResult({ errors, warnings, info, metadata: {} });
+        return this.#reportResult({ ...messages, metadata: {} });
     }
 
     error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -30,7 +30,6 @@ import type {
 setLanguage('en_GB');
 
 interface BaseOptions {
-    events?: EventEmitter;
     file?: string;
     source?: string;
     url?: string;

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -435,19 +435,14 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         return this.#$sotdSection;
     }
 
-    /**
-     * @param $dl Optional Cheerio-wrapped dl element.
-     *   If not set, extractHeaders() uses the current document to extract headers link and cache them for future use.
-     *   If set, assume data is being extracted from another document; the new element will be used and the result will not be cached.
-     */
-    extractHeaders($dl?: Cheerio<Element>) {
+    extractHeaders() {
         const dts: HeaderMap = {};
         const EDITORS = /^editor(s)?$/;
         const EDITORS_DRAFT = /^(latest )?editor's draft$/i;
 
-        if (!$dl && typeof this.#headers !== 'undefined') return this.#headers;
+        if (typeof this.#headers !== 'undefined') return this.#headers;
 
-        $dl = $dl || this.$('body div.head dl');
+        const $dl = this.$('body div.head dl');
 
         if ($dl && $dl.length) {
             $dl.find('dt').each((idx, dt) => {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -184,7 +184,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     /** Stores messages from any unexpected errors encountered during process */
     #exceptions: string[] = [];
     #headers: HeaderMap | undefined;
-    #isFirstPublic: any | undefined;
+    #isFirstPublic: boolean | undefined;
     #previousVersion: Promise<string | null> | undefined;
     #shortname: string | undefined = undefined;
 
@@ -387,7 +387,8 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     }
 
     getSotDSection() {
-        if (this.#$sotdSection) return this.#$sotdSection;
+        if (typeof this.#$sotdSection !== 'undefined')
+            return this.#$sotdSection;
 
         let startH2: Element | undefined;
         let endH2: Element | undefined;
@@ -734,7 +735,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     }
 
     async getCharters() {
-        if (typeof this.#charters !== 'undefined') return this.#charters;
+        if (this.#charters) return this.#charters;
 
         this.#charters = (await this.getChartersData()).map(({ uri }) => uri);
         return this.#charters;
@@ -756,8 +757,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
      * Gets previous version link from API via shortname.
      */
     async getPreviousVersion() {
-        if (typeof this.#previousVersion !== 'undefined')
-            return this.#previousVersion;
+        if (this.#previousVersion) return this.#previousVersion;
 
         const dts = this.extractHeaders();
         const shortname = this.#shortname || (await this.getShortname());

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -18,13 +18,13 @@ import { get } from './throttled-ua.js';
 import { AB, processParams, REC_TEXT, specberusVersion, TAG } from './util.js';
 import type {
     ApiCharter,
-    HandlerMessage,
-    RuleBase,
     ApiSpecificationVersion,
+    HandlerMessage,
+    ProfileModule,
     RecMetadata,
+    RuleBase,
     RuleMeta,
     SpecberusConfig,
-    ProfileModule,
 } from './types.js';
 
 setLanguage('en_GB');
@@ -136,7 +136,24 @@ export class ExceptionsError extends Error {
     }
 }
 
-export class Specberus {
+type SpecberusMessageEventArgs = [
+    RuleMeta | RuleBase,
+    {
+        detailMessage: string;
+        extra?: Record<string, any>;
+        key: string;
+    },
+];
+
+interface SpecberusEvents {
+    done: [string];
+    err: SpecberusMessageEventArgs;
+    exception: [{ message: string }];
+    info: SpecberusMessageEventArgs;
+    warning: SpecberusMessageEventArgs;
+}
+
+export class Specberus extends EventEmitter<SpecberusEvents> {
     $ = load('');
     config: SpecberusConfig | undefined;
     source: string | undefined;
@@ -159,7 +176,6 @@ export class Specberus {
     #headers: HeaderMap | undefined;
     #isFirstPublic: any | undefined;
     #shortname: string | undefined = undefined;
-    #sink: EventEmitter | undefined;
 
     /**
      * Handles common end-state logic for both extractMetadata and validate,
@@ -180,20 +196,18 @@ export class Specberus {
     }
 
     async extractMetadata(options: ExtractMetadataOptions) {
-        const sink = (this.#sink = options.events || new EventEmitter());
-
         const metadata: Record<string, any> = {};
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
         const info: HandlerMessage[] = [];
-        sink.on('err', data => {
-            errors.push(data);
+        this.on('err', (rule, data) => {
+            errors.push({ ...rule, ...data });
         });
-        sink.on('warning', data => {
-            warnings.push(data);
+        this.on('warning', (rule, data) => {
+            warnings.push({ ...rule, ...data });
         });
-        sink.on('info', data => {
-            info.push(data);
+        this.on('info', (rule, data) => {
+            info.push({ ...rule, ...data });
         });
 
         try {
@@ -213,7 +227,7 @@ export class Specberus {
                     if (result)
                         for (const [key, value] of Object.entries(result))
                             metadata[key] = value;
-                    sink.emit('done', rule.name);
+                    this.emit('done', rule.name);
                 } catch (error) {
                     this.#throw(error.message);
                 }
@@ -227,20 +241,19 @@ export class Specberus {
         if (!options.profile)
             throw new Error('Without a profile there is nothing to check.');
 
-        const sink = (this.#sink = options.events || new EventEmitter());
         const { profile } = options;
         this.config = await processParams(options, profile.config);
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
         const info: HandlerMessage[] = [];
-        sink.on('err', (...data) => {
-            errors.push(Object.assign({}, ...data));
+        this.on('err', (rule, data) => {
+            errors.push({ ...rule, ...data });
         });
-        sink.on('warning', (...data) => {
-            warnings.push(Object.assign({}, ...data));
+        this.on('warning', (rule, data) => {
+            warnings.push({ ...rule, ...data });
         });
-        sink.on('info', (...data) => {
-            info.push(Object.assign({}, ...data));
+        this.on('info', (rule, data) => {
+            info.push({ ...rule, ...data });
         });
 
         this.$ = await this.#load(options);
@@ -249,7 +262,7 @@ export class Specberus {
             profile.rules.map(async rule => {
                 try {
                     await rule.check(this);
-                    sink.emit('done', rule.name);
+                    this.emit('done', rule.name);
                 } catch (error) {
                     this.#throw(error.message);
                 }
@@ -268,9 +281,9 @@ export class Specberus {
         )
             this.warning(rule, key, extra);
         else
-            this.#sink!.emit('err', rule, {
+            this.emit('err', rule, {
                 key,
-                extra,
+                ...(extra && { extra }),
                 detailMessage: assembleData(null, rule, key, extra).message,
             });
     }
@@ -280,17 +293,17 @@ export class Specberus {
         key: string,
         extra?: Record<string, any>
     ) {
-        this.#sink!.emit('warning', rule, {
+        this.emit('warning', rule, {
             key,
-            extra,
+            ...(extra && { extra }),
             detailMessage: assembleData(null, rule, key, extra).message,
         });
     }
 
     info(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
-        this.#sink!.emit('info', rule, {
+        this.emit('info', rule, {
             key,
-            extra,
+            ...(extra && { extra }),
             detailMessage: assembleData(null, rule, key, extra).message,
         });
     }
@@ -303,7 +316,7 @@ export class Specberus {
      */
     #throw(message: string) {
         console.error(`[EXCEPTION] ${message}`);
-        this.#sink!.emit('exception', { message });
+        this.emit('exception', { message });
         // Track in exceptions array, used to determine whether to resolve or reject process
         this.#exceptions.push(message);
     }

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -284,11 +284,10 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     }
 
     error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
-        const name = typeof rule === 'string' ? rule : rule.name;
         const shortname = this.getShortname();
         if (
             typeof shortname !== 'undefined' &&
-            hasExceptions(shortname, name, extra)
+            hasExceptions(shortname, rule.name, extra)
         )
             this.warning(rule, key, extra);
         else

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -109,6 +109,16 @@ const abbrMonths = [
 
 export const possibleMonths = [...months, ...abbrMonths].join('|');
 
+// Regular expressions used by getDelivererIDs and getDelivererGroups
+
+const REGEX_DELIVERER_URL =
+    /^https?:\/\/www\.w3\.org\/2004\/01\/pp-impl\/(\d+)\/status(#.*)?$/i;
+const REGEX_DELIVERER_TEXT =
+    /^(charter|public\s+list\s+of\s+any\s+patent\s+disclosures(\s+\(.+\))?)$/i;
+const REGEX_TAG_DISCLOSURE = /https?:\/\/www.w3.org\/2001\/tag\/disclosures/;
+const REGEX_DELIVERER_IPR_URL =
+    /^https:\/\/www\.w3\.org\/groups\/([^/]+)\/([^/]+)\/ipr\/?(#.*)?$/i;
+
 const separator = '[ -]{1}';
 
 interface ExceptionsErrorOptions extends ErrorOptions {
@@ -165,16 +175,17 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     #$docDateEl: Cheerio<Element> | undefined;
     #$sotdSection: Cheerio<Element> | null | undefined;
     /** Group objects returned by W3C API charters endpoint */
-    #chartersData: ApiCharter[] | undefined;
+    #chartersData: [] | Promise<ApiCharter[]> | undefined;
     /** Charter URIs */
     #charters: string[] | undefined;
-    #delivererIDs: number[] | undefined;
-    #delivererGroups: DelivererGroup[] | undefined;
+    #delivererIDs: number[] | Promise<number[]> | undefined;
+    #delivererGroups: Promise<DelivererGroup[]> | undefined;
     #docDate: Date | undefined;
     /** Stores messages from any unexpected errors encountered during process */
     #exceptions: string[] = [];
     #headers: HeaderMap | undefined;
     #isFirstPublic: any | undefined;
+    #previousVersion: Promise<string | null> | undefined;
     #shortname: string | undefined = undefined;
 
     /**
@@ -384,8 +395,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     }
 
     getSotDSection() {
-        if (typeof this.#$sotdSection !== 'undefined')
-            return this.#$sotdSection;
+        if (this.#$sotdSection) return this.#$sotdSection;
 
         let startH2: Element | undefined;
         let endH2: Element | undefined;
@@ -436,12 +446,11 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     }
 
     extractHeaders() {
+        if (this.#headers) return this.#headers;
+
         const dts: HeaderMap = {};
         const EDITORS = /^editor(s)?$/;
         const EDITORS_DRAFT = /^(latest )?editor's draft$/i;
-
-        if (typeof this.#headers !== 'undefined') return this.#headers;
-
         const $dl = this.$('body div.head dl');
 
         if ($dl && $dl.length) {
@@ -553,25 +562,14 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
      * Retrieves deliverers groupNames and types.
      */
     async getDelivererGroups() {
-        if (typeof this.#delivererGroups !== 'undefined')
-            return this.#delivererGroups;
-        const REGEX_DELIVERER_URL =
-            /^https?:\/\/www\.w3\.org\/2004\/01\/pp-impl\/(\d+)\/status(#.*)?$/i;
-        const REGEX_DELIVERER_TEXT =
-            /^(charter|public\s+list\s+of\s+any\s+patent\s+disclosures(\s+\(.+\))?)$/i;
-        const REGEX_TAG_DISCLOSURE =
-            /https?:\/\/www.w3.org\/2001\/tag\/disclosures/;
-        const REGEX_DELIVERER_IPR_URL =
-            /^https:\/\/www\.w3\.org\/groups\/([^/]+)\/([^/]+)\/ipr\/?(#.*)?$/i;
+        if (this.#delivererGroups) return this.#delivererGroups;
 
         const $sotd = this.getSotDSection();
         const $sotdLinks = $sotd && $sotd.find('a[href]');
-        const promiseArray: Promise<any>[] = [];
-        let ids = [];
         const delivererGroups: DelivererGroup[] = [];
 
         // getDataDelivererIDs first, apply if document is Note/Registry track.
-        ids = this.getDataDelivererIDs() || [];
+        const ids = this.getDataDelivererIDs();
         // For rec-track
         if (ids.length === 0 && $sotdLinks && $sotdLinks.length > 0) {
             $sotdLinks.each((_, el) => {
@@ -607,105 +605,87 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             });
         }
 
-        // send request to W3C API if there's id extracted from the doc.
-        for (const id of ids) {
-            const groupApiUrl = `https://api.w3.org/groups/${id}`;
-            promiseArray.push(
-                get(groupApiUrl).set(
-                    'User-Agent',
-                    `W3C-Pubrules/${specberusVersion}`
-                )
-            );
-        }
+        // Send request to W3C API if there's ids extracted from the doc.
+        // Cache the promise (to avoid duplicate requests)
+        this.#delivererGroups = Promise.all([
+            ...delivererGroups, // Any immediately-resolvable groups from links
+            ...ids.map(id => {
+                const groupApiUrl = `https://api.w3.org/groups/${id}`;
+                return get(groupApiUrl)
+                    .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
+                    .then(
+                        res => {
+                            if (!res.body) return;
+                            const { shortname, type } = res.body;
+                            let groupType = 'other';
+                            if (type === 'working group') groupType = 'wg';
+                            else if (type === 'interest group')
+                                groupType = 'ig';
 
-        await Promise.all(promiseArray).then(responses => {
-            for (const data of responses) {
-                if (data && data.body) {
-                    let { type } = data.body;
-                    switch (type) {
-                        case 'working group':
-                            type = 'wg';
-                            break;
-                        case 'interest group':
-                            type = 'ig';
-                            break;
-                        default:
-                            type = 'other';
-                            break;
-                    }
-
-                    delivererGroups.push({
-                        groupShortname: data.body.shortname,
-                        groupType: type,
-                    });
-                }
-            }
-        });
-        this.#delivererGroups = delivererGroups;
-        return delivererGroups;
+                            return {
+                                groupShortname: shortname,
+                                groupType,
+                            };
+                        },
+                        () => {}
+                    );
+            }),
+        ]).then(groups => groups.filter(group => !!group));
+        return this.#delivererGroups;
     }
 
     async getDelivererIDs() {
-        if (undefined !== this.#delivererIDs) {
-            return this.#delivererIDs;
-        }
-        const REGEX_DELIVERER_URL =
-            /^https?:\/\/www\.w3\.org\/2004\/01\/pp-impl\/(\d+)\/status(#.*)?$/i;
-        const REGEX_DELIVERER_TEXT =
-            /^(charter|public\s+list\s+of\s+any\s+patent\s+disclosures(\s+\(.+\))?)$/i;
-        const REGEX_TAG_DISCLOSURE =
-            /https?:\/\/www.w3.org\/2001\/tag\/disclosures/;
-        const REGEX_DELIVERER_IPR_URL =
-            /^https:\/\/www\.w3\.org\/groups\/([^/]+)\/([^/]+)\/ipr\/?(#.*)?$/i;
+        if (this.#delivererIDs) return this.#delivererIDs;
+
         const ids: number[] = this.getDataDelivererIDs() || [];
         const $sotd = this.getSotDSection();
         const $sotdLinks = $sotd && $sotd.find('a[href]');
-        const promiseArray: Promise<any>[] = [];
 
-        if (ids.length === 0 && $sotdLinks && $sotdLinks.length > 0) {
-            $sotdLinks.each((_, el) => {
-                const $el = this.$(el);
-                const href = $el.attr('href')!;
-                const text = this.norm($el.text());
-                const found: Record<string, boolean> = {};
-                if (REGEX_DELIVERER_TEXT.test(text)) {
-                    const delivererUrlMatch = href.match(REGEX_DELIVERER_URL);
-                    if (delivererUrlMatch) {
-                        const id = delivererUrlMatch[1];
-                        if (id && id.length > 1 && !found[id]) {
-                            found[id] = true;
-                            ids.push(parseInt(id, 10));
-                        }
-                    } else if (REGEX_TAG_DISCLOSURE.test(href)) {
-                        ids.push(TAG.id);
-                    } else if (REGEX_DELIVERER_IPR_URL.test(href)) {
-                        const [, type, shortname] =
-                            REGEX_DELIVERER_IPR_URL.exec(href)!;
-                        const groupApiUrl = `https://api.w3.org/groups/${type}/${shortname}`;
-                        promiseArray.push(
-                            new Promise(resolve => {
-                                get(groupApiUrl)
-                                    .set(
-                                        'User-Agent',
-                                        `W3C-Pubrules/${specberusVersion}`
-                                    )
-                                    .end((_: any, data) => {
-                                        resolve(data);
-                                    });
-                            })
-                        );
-                    }
-                }
-            });
-
-            await Promise.all(promiseArray).then(res => {
-                for (const data of res) {
-                    if (data?.body?.id) ids.push(data.body.id);
-                }
-            });
+        if (ids.length > 0 || !$sotdLinks?.length) {
+            this.#delivererIDs = ids;
+            return ids;
         }
-        this.#delivererIDs = ids;
-        return ids;
+
+        const promiseArray: (number | Promise<number>)[] = [];
+        $sotdLinks.each((_, el) => {
+            const $el = this.$(el);
+            const href = $el.attr('href')!;
+            const text = this.norm($el.text());
+            const found: Record<string, boolean> = {};
+            if (REGEX_DELIVERER_TEXT.test(text)) {
+                const delivererUrlMatch = href.match(REGEX_DELIVERER_URL);
+                if (delivererUrlMatch) {
+                    const id = delivererUrlMatch[1];
+                    if (id && id.length > 1 && !found[id]) {
+                        found[id] = true;
+                        promiseArray.push(parseInt(id, 10));
+                    }
+                } else if (REGEX_TAG_DISCLOSURE.test(href)) {
+                    promiseArray.push(TAG.id);
+                } else if (REGEX_DELIVERER_IPR_URL.test(href)) {
+                    const [, type, shortname] =
+                        REGEX_DELIVERER_IPR_URL.exec(href)!;
+                    const groupApiUrl = `https://api.w3.org/groups/${type}/${shortname}`;
+                    promiseArray.push(
+                        get(groupApiUrl)
+                            .set(
+                                'User-Agent',
+                                `W3C-Pubrules/${specberusVersion}`
+                            )
+                            .then(
+                                res => res.body?.id,
+                                () => {}
+                            )
+                    );
+                }
+            }
+        });
+
+        // Cache the promise (to avoid duplicate requests)
+        this.#delivererIDs = Promise.all(promiseArray).then(ids =>
+            ids.filter(id => typeof id !== 'undefined')
+        );
+        return this.#delivererIDs;
     }
 
     getDataDelivererIDs() {
@@ -727,52 +707,45 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
 
     /** Finds the current charter(s) of the document. */
     async getChartersData() {
-        if (undefined !== this.#chartersData) return this.#chartersData;
+        if (this.#chartersData) return this.#chartersData;
 
         const deliverers = await this.getDelivererIDs();
-        const docDate = this.getDocumentDate()!;
-        const chartersData: ApiCharter[] = [];
-        if (deliverers.length) {
-            const delivererPromises: Promise<ApiCharter[]>[] = [];
-            const AbID = AB.id;
-            // Get charter data from W3C API
-            // deliverers.forEach is for joint publication.
-            deliverers.forEach(deliverer => {
-                // Skip finding charter for the TAG which doesn't have any charter
-                if (deliverer === TAG.id || deliverer === AbID) return;
-
-                delivererPromises.push(
-                    new Promise(resolve => {
-                        w3cApi
-                            .group(deliverer)
-                            .charters()
-                            .fetch(
-                                { embed: true },
-                                (_: any, charters: ApiCharter[]) => {
-                                    resolve(charters);
-                                }
-                            );
-                    })
-                );
-            });
-
-            // groups -> group is for joint publication.
-            for (const groupCharters of await Promise.all(delivererPromises)) {
-                if (groupCharters) {
-                    for (const groupCharter of groupCharters) {
-                        if (
-                            docDate >= new Date(groupCharter.start) &&
-                            docDate <= new Date(groupCharter.end)
-                        ) {
-                            chartersData.push(groupCharter);
-                        }
-                    }
-                }
-            }
+        if (!deliverers.length) {
+            this.#chartersData = [];
+            return this.#chartersData;
         }
 
-        this.#chartersData = chartersData;
-        return chartersData;
+        const docDate = this.getDocumentDate()!;
+        const delivererPromises: Promise<ApiCharter[]>[] = [];
+        // Get charter data from W3C API
+        // deliverers.forEach is for joint publication.
+        deliverers.forEach(deliverer => {
+            // Skip finding charter for the TAG which doesn't have any charter
+            if (deliverer === TAG.id || deliverer === AB.id) return;
+
+            delivererPromises.push(
+                w3cApi
+                    .group(deliverer)
+                    .charters()
+                    .fetch({ embed: true })
+                    .then(
+                        (groupCharters: ApiCharter[]) => {
+                            if (!groupCharters) return;
+                            return groupCharters.filter(
+                                groupCharter =>
+                                    docDate >= new Date(groupCharter.start) &&
+                                    docDate <= new Date(groupCharter.end)
+                            );
+                        },
+                        () => {}
+                    )
+            );
+        });
+
+        this.#chartersData = Promise.all(delivererPromises).then(lists =>
+            lists.flat().filter(charter => !!charter)
+        );
+        return this.#chartersData;
     }
 
     async getCharters() {
@@ -798,6 +771,9 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
      * Gets previous version link from API via shortname.
      */
     async getPreviousVersion() {
+        if (typeof this.#previousVersion !== 'undefined')
+            return this.#previousVersion;
+
         const dts = this.extractHeaders();
         const shortname = this.#shortname || (await this.getShortname());
 
@@ -813,52 +789,44 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             return;
         }
 
-        const shortnameHistory = await new Promise<
-            ApiSpecificationVersion[] | null
-        >(resolve => {
+        const shortnameHistory: Promise<ApiSpecificationVersion[] | undefined> =
             w3cApi
                 .specification(shortname)
                 .versions()
-                .fetch(
-                    { embed: true, items: 1000 },
-                    (err: any, data: ApiSpecificationVersion[]) => {
-                        if (err && err.status === 404) {
-                            // check if it's not a shortname change
-                            const shortnameChange = dts.History
-                                ? dts.History.$dd
-                                      .find('a')
-                                      .attr('data-previous-shortname')
-                                : null;
-                            if (shortnameChange) {
-                                w3cApi
-                                    .specification(shortnameChange)
-                                    .versions()
-                                    .fetch(
-                                        { embed: true, items: 1000 },
-                                        (
-                                            _: any,
-                                            data: ApiSpecificationVersion[]
-                                        ) => {
-                                            resolve(data);
-                                        }
-                                    );
-                            } else {
-                                resolve(null);
-                            }
-                        } else {
-                            resolve(data);
+                .fetch({ embed: true, items: 1000 })
+                .catch((err: any) => {
+                    if (err.status === 404) {
+                        // check if it's not a shortname change
+                        const shortnameChange = dts.History
+                            ? dts.History.$dd
+                                  .find('a')
+                                  .attr('data-previous-shortname')
+                            : null;
+                        if (shortnameChange) {
+                            return w3cApi
+                                .specification(shortnameChange)
+                                .versions()
+                                .fetch({ embed: true, items: 1000 })
+                                .catch(() => {});
                         }
                     }
-                );
-        });
-        const versions = shortnameHistory || [];
-        const linkThis = dts.This ? dts.This.$dd.find('a').attr('href') : '';
+                });
 
-        if (versions.length && linkThis) {
-            const versionUris = versions.map(({ uri }) => uri);
-            const index = versionUris.indexOf(linkThis);
-            return index === -1 ? versionUris[0] : versionUris[index + 1];
-        }
+        // Cache the promise (to avoid duplicate requests)
+        this.#previousVersion = shortnameHistory.then(history => {
+            const versions = history || [];
+            const linkThis = dts.This
+                ? dts.This.$dd.find('a').attr('href')
+                : '';
+
+            if (versions.length && linkThis) {
+                const versionUris = versions.map(({ uri }) => uri);
+                const index = versionUris.indexOf(linkThis);
+                return index === -1 ? versionUris[0] : versionUris[index + 1];
+            }
+            return null;
+        });
+        return this.#previousVersion;
     }
 
     #load(options: ExtractMetadataOptions | ValidateOptions) {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -15,14 +15,7 @@ import { assembleData, setLanguage } from './l10n.js';
 import * as profileMetadata from './profiles/metadata.js';
 import * as profileAdditionalMetadata from './profiles/additionalMetadata.js';
 import { get } from './throttled-ua.js';
-import {
-    AB,
-    buildJSONresult,
-    processParams,
-    REC_TEXT,
-    specberusVersion,
-    TAG,
-} from './util.js';
+import { AB, processParams, REC_TEXT, specberusVersion, TAG } from './util.js';
 import type {
     ApiCharter,
     HandlerMessage,
@@ -122,6 +115,14 @@ interface ExceptionsErrorOptions extends ErrorOptions {
     exceptions: string[];
 }
 
+export interface SpecberusResult {
+    errors: HandlerMessage[];
+    info: HandlerMessage[];
+    metadata: Record<string, any>;
+    success: boolean;
+    warnings: HandlerMessage[];
+}
+
 /**
  * Error which includes list of exception messages,
  * thrown in case of unexpected errors during extractMetadata or validate
@@ -167,30 +168,27 @@ export class Specberus {
      * Handles common end-state logic for both extractMetadata and validate,
      * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
      */
-    #reportResult(
-        errors: HandlerMessage[],
-        warnings: HandlerMessage[],
-        info: HandlerMessage[],
-        metadata: Record<string, any>
-    ) {
-        if (!this.#exceptions.length) {
-            return buildJSONresult(errors, warnings, info, metadata);
-        } else {
+    #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
+        if (this.#exceptions.length) {
             throw new ExceptionsError(
                 'The following unexpected errors occurred:\n' +
                     this.#exceptions.join('\n'),
                 { exceptions: this.#exceptions }
             );
         }
+        return {
+            ...result,
+            success: !result.errors.length,
+        };
     }
 
     async extractMetadata(options: ExtractMetadataOptions) {
         const sink = (this.#sink = options.events || new EventEmitter());
 
-        const meta: Record<string, any> = (this.meta = {});
+        const metadata: Record<string, any> = (this.meta = {});
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
-        const infos: HandlerMessage[] = [];
+        const info: HandlerMessage[] = [];
         sink.on('err', data => {
             errors.push(data);
         });
@@ -198,7 +196,7 @@ export class Specberus {
             warnings.push(data);
         });
         sink.on('info', data => {
-            infos.push(data);
+            info.push(data);
         });
 
         try {
@@ -217,7 +215,7 @@ export class Specberus {
                     const result = await rule.check(this);
                     if (result)
                         for (const [key, value] of Object.entries(result))
-                            meta[key] = value;
+                            metadata[key] = value;
                     sink.emit('done', rule.name);
                 } catch (error) {
                     this.#throw(error.message);
@@ -225,7 +223,7 @@ export class Specberus {
             })
         );
 
-        return this.#reportResult(errors, warnings, infos, meta);
+        return this.#reportResult({ errors, warnings, info, metadata });
     }
 
     async validate(options: ValidateOptions) {
@@ -237,7 +235,7 @@ export class Specberus {
         this.config = await processParams(options, profile.config);
         const errors: HandlerMessage[] = [];
         const warnings: HandlerMessage[] = [];
-        const infos: HandlerMessage[] = [];
+        const info: HandlerMessage[] = [];
         sink.on('err', (...data) => {
             errors.push(Object.assign({}, ...data));
         });
@@ -245,7 +243,7 @@ export class Specberus {
             warnings.push(Object.assign({}, ...data));
         });
         sink.on('info', (...data) => {
-            infos.push(Object.assign({}, ...data));
+            info.push(Object.assign({}, ...data));
         });
 
         this.$ = await this.#load(options);
@@ -261,7 +259,7 @@ export class Specberus {
             })
         );
 
-        return this.#reportResult(errors, warnings, infos, {});
+        return this.#reportResult({ errors, warnings, info, metadata: {} });
     }
 
     error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "cheerio": "^1.1.2",
         "compression": "1.8.1",
         "cors": "2.8.6",
-        "doasync": "2.0.1",
         "express": "5.2.1",
         "express-fileupload": "1.5.2",
         "express-handlebars": "9.0.1",
@@ -2952,15 +2951,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/doasync": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/doasync/-/doasync-2.0.1.tgz",
-      "integrity": "sha512-5u7qAb+ACe2dvxHXrhjWNAfWuj42yB45Z9ght+U9QkB09nNGYMw5S4q6sXcpVnxjcKGl0jUYcxrGpR6kBTGJHw==",
-      "engines": {
-        "node": ">= 8.2.1",
-        "npm": ">= 5.3.0"
       }
     },
     "node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cheerio": "^1.1.2",
     "compression": "1.8.1",
     "cors": "2.8.6",
-    "doasync": "2.0.1",
     "express": "5.2.1",
     "express-fileupload": "1.5.2",
     "express-handlebars": "9.0.1",

--- a/test/api.ts
+++ b/test/api.ts
@@ -149,6 +149,26 @@ describe('API', () => {
                 }
             ));
 
+        it('Should 400 with error on POST if "file" is provided but "profile" is not', () =>
+            assert.rejects(
+                createPostRequest('validate').attach(
+                    'file',
+                    join(testDocsPath, 'wd-good.html')
+                ),
+                (error: any) => {
+                    const { success, errors } = JSON.parse(
+                        getErrorResponseText(error)
+                    );
+                    assert.strictEqual(success, false);
+                    assert.deepStrictEqual(errors, [
+                        {
+                            error: 'Error: Parameter “profile” is required in this context',
+                        },
+                    ]);
+                    return true;
+                }
+            ));
+
         it('Should accept "file" via POST, and succeed when the document is valid', () =>
             createPostRequest('validate')
                 .field('profile', 'WD')

--- a/test/api.ts
+++ b/test/api.ts
@@ -159,10 +159,9 @@ describe('API', () => {
                     getErrorResponseText(error)
                 );
                 assert.strictEqual(success, false);
-                assert.strictEqual(
-                    errors[0],
-                    'Error: Illegal parameter “document”'
-                );
+                assert.deepStrictEqual(errors[0], {
+                    error: 'Error: Illegal parameter “document”',
+                });
                 return true;
             }));
 
@@ -172,10 +171,9 @@ describe('API', () => {
                     getErrorResponseText(error)
                 );
                 assert.strictEqual(success, false);
-                assert.strictEqual(
-                    errors[0],
-                    'Error: Parameter “source” is not allowed in this context'
-                );
+                assert.deepStrictEqual(errors[0], {
+                    error: 'Error: Parameter “source” is not allowed in this context',
+                });
                 return true;
             }));
     });

--- a/test/api.ts
+++ b/test/api.ts
@@ -49,6 +49,14 @@ function setup() {
 const handleResponse = (response: Response) => response.text || response.body;
 const handleJsonResponse = (response: Response) =>
     JSON.parse(handleResponse(response));
+function assertResponseStatus(response: Response | undefined, status: number) {
+    const actualStatus = response?.status;
+    assert.strictEqual(
+        status,
+        actualStatus,
+        `Expected ${status} response status but received ${actualStatus}`
+    );
+}
 function getErrorResponseText(error: ResponseError) {
     const text = error.response?.text;
     assert(text, 'Response data not available on error');
@@ -112,6 +120,7 @@ describe('API', () => {
                     join(testDocsPath, 'wd-fail-date.html')
                 ),
                 (error: any) => {
+                    assertResponseStatus(error.response, 500);
                     const { errors } = JSON.parse(getErrorResponseText(error));
                     assert.strictEqual(
                         errors.length,
@@ -130,6 +139,7 @@ describe('API', () => {
                     .field('profile', 'REC')
                     .attach('file', join(testDocsPath, 'ttml-imsc1.html')),
                 (error: any) => {
+                    assertResponseStatus(error.response, 400);
                     const { success, errors } = JSON.parse(
                         getErrorResponseText(error)
                     );
@@ -156,6 +166,7 @@ describe('API', () => {
                     join(testDocsPath, 'wd-good.html')
                 ),
                 (error: any) => {
+                    assertResponseStatus(error.response, 400);
                     const { success, errors } = JSON.parse(
                         getErrorResponseText(error)
                     );
@@ -194,6 +205,7 @@ describe('API', () => {
                     .field('profile', 'auto')
                     .attach('file', join(testDocsPath, 'wd-fail-auto.html')),
                 (error: any) => {
+                    assertResponseStatus(error.response, 500);
                     const { errors } = JSON.parse(getErrorResponseText(error));
                     assert.strictEqual(errors.length, 1);
                     assert.match(
@@ -208,6 +220,7 @@ describe('API', () => {
     describe('Parameter restrictions', () => {
         it('Should reject the parameter "document" as unknown', () =>
             assert.rejects(get('metadata?document=foo'), (error: any) => {
+                assertResponseStatus(error.response, 400);
                 const { success, errors } = JSON.parse(
                     getErrorResponseText(error)
                 );
@@ -220,6 +233,7 @@ describe('API', () => {
 
         it('Should reject the parameter "source" as forbidden', () =>
             assert.rejects(get('metadata?source=foo'), (error: any) => {
+                assertResponseStatus(error.response, 400);
                 const { success, errors } = JSON.parse(
                     getErrorResponseText(error)
                 );

--- a/test/api.ts
+++ b/test/api.ts
@@ -104,6 +104,23 @@ describe('API', () => {
                     assert.strictEqual(metadata.profile, 'REC');
                     assert.strictEqual(metadata.docDate, '2016-3-8');
                 }));
+
+        it('Should accept "file" via POST, and report exceptions', () =>
+            assert.rejects(
+                createPostRequest('metadata').attach(
+                    'file',
+                    join(testDocsPath, 'wd-fail-date.html')
+                ),
+                (error: any) => {
+                    const { errors } = JSON.parse(getErrorResponseText(error));
+                    assert.strictEqual(
+                        errors.length,
+                        2,
+                        'Expected multiple errors to be reported'
+                    );
+                    return true;
+                }
+            ));
     });
 
     describe('Method “validate”', () => {
@@ -150,6 +167,22 @@ describe('API', () => {
                     assert.strictEqual(success, true);
                     assert.strictEqual(metadata.profile, 'WD');
                 }));
+
+        it('Special profile “auto”: should report exception if profile cannot be determined', () =>
+            assert.rejects(
+                createPostRequest('validate')
+                    .field('profile', 'auto')
+                    .attach('file', join(testDocsPath, 'wd-fail-auto.html')),
+                (error: any) => {
+                    const { errors } = JSON.parse(getErrorResponseText(error));
+                    assert.strictEqual(errors.length, 1);
+                    assert.match(
+                        errors[0].exception,
+                        /Pubrules is having a hard time identifying the profile of the document/
+                    );
+                    return true;
+                }
+            ));
     });
 
     describe('Parameter restrictions', () => {

--- a/test/data/goodDocuments.ts
+++ b/test/data/goodDocuments.ts
@@ -16,6 +16,10 @@ export const goodDocuments = {
     STMT: {
         url: 'doc-views/TR/Note/STMT?type=good',
     },
+    'STMT-exception': {
+        profile: 'STMT',
+        url: 'doc-views/TR/Note/STMT?type=goodException',
+    },
 
     // Recommendation track
     CR: {

--- a/test/doc-views/TR/Note/STMT.ts
+++ b/test/doc-views/TR/Note/STMT.ts
@@ -16,10 +16,30 @@ const customData = {
 
 // Used in http://localhost:8001/doc-views/TR/Note/STMT?type=good
 const good = { ...data, ...customData };
+
+// Test hasException by failing a rule, accompanied by
+// metadata that downgrades the failure from error to warning
+const goodException = {
+    ...good,
+    dl: {
+        ...good.dl,
+        editor2: {
+            show: true,
+            id: '3440',
+        },
+        history: {
+            ...data.dl.history,
+            shortName: 'privacy-principles',
+        },
+        shortName: 'privacy-principles',
+        seriesShortName: 'privacy-principles',
+    },
+};
 const common = buildCommonViewData(good);
 
 export default {
     good,
+    goodException,
     ...common,
     stability: {
         ...common.stability,

--- a/test/docs/api/wd-fail-auto.html
+++ b/test/docs/api/wd-fail-auto.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+Like wd-good, but with w3c-state content mangled to fail profile auto-detection
+-->
+<head>
+    <meta charset="utf-8">
+    <style>
+        .handlebars-data {
+            background: rgba(255, 0, 0, 0.15)
+        }
+    </style>
+        <meta name="viewport" content="width&#x3D;device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="canonical" href="https://www.w3.org/TR/hr-time/">
+        <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD.css">
+        <title>WD-Echidna: test document - Specberus</title> <!-- matches div.head h1 -->
+</head>
+<body class="h-entry" data-cite="WebIDL html dom webidl ecma-262">
+    <div class="head">
+            <a class="logo" href="https://www.w3.org/">
+                <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C">
+            </a>
+            <h1 id="title" class="title p-name"><span class="handlebars-data">WD-Echidna: test document - Specberus</span></h1>
+
+        <p id='w3c-state'>
+            <a href='https://www.w3.org/standards/types/#WD'>W3C <span class="handlebars-data">Working Thing</span></a>
+            <time class="dt-published" datetime="2021-11-04">
+                        <span class="handlebars-data">7 April 2026</span>
+            </time>
+        </p>
+        <details open>
+                <summary>More details about this document</summary>
+                <dl>
+
+                        <dt>This Version</dt>
+                        <dd>
+                            <a class="u-url" href="https://www.w3.org/TR/2026/WD-hr-time-20260407/">
+                                https://www.w3.org/TR/<span class="handlebars-data">2026</span>/<span class="handlebars-data">WD</span>-<span class="handlebars-data">hr-time</span>-<span class="handlebars-data">20260407</span>/
+                            </a>
+                        </dd>
+
+                        <dt>Latest published version: (@@note that version is not required in the latest version)</dt>
+                        <dd> <a href="https://www.w3.org/TR/hr-time/">https://www.w3.org/TR/<span class="handlebars-data">hr-time</span>/</a>
+                        </dd>
+
+                        <dt>Latest editor's draft:</dt>
+                        <dd> <a href="https://w3c.github.io/hr-time/">https://w3c.github.io/<span class="handlebars-data">hr-time</span>/</a>
+                        </dd>
+
+                        <dt><span class="handlebars-data">History</span>:</dt>
+                        <dd> <a href="https://www.w3.org/standards/history/hr-time">https://www.w3.org/standards/history/<span class="handlebars-data">hr-time</span></a>
+                        </dd>
+
+
+                        <dt><span class="handlebars-data">Editor</span>:</dt>
+                        <dd class="p-author h-card vcard" data-editor-id="3439">George Herald (WebFoo)
+                        </dd>
+
+
+
+
+                        <dt>Feedback:</dt>
+                        <dd><a href="https://github.com/w3c/hr-time/issues"><span class="handlebars-data">https://github.com/w3c/</span><span class="handlebars-data">hr-time</span>/issues</a></dd>
+                        <dd><a href="mailto:public-foo@w3.org?subject=%5Bhr-time%5D%20YOUR%20TOPIC%20HERE">public-foo@w3.org</a> with subject line “<kbd>[<span class="handlebars-data">hr-time</span>] <var>… message topic …</var></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-foo/" rel="discussion">archives</a>)</dd>
+                </dl>
+        </details>
+
+
+            <p class="copyright">
+                    <a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026 <a href="https://www.w3.org/"> World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/">permissive document license</a> rules apply.
+            </p>
+
+            <hr title="Separator for header">
+    </div>
+
+    <section id="abstract" class="introductory">
+        <h2><span class="handlebars-data">Abstract</span></h2>
+        <p>This specification defines an API that provides the time origin, and current time in sub-millisecond resolution, such that it is not subject to system clock skew or adjustments.</p>
+
+    </section>
+
+    <section id="sotd" data-link-for="Performance" class="introductory">
+        <h2><span class="handlebars-data">Status of This Document</span></h2>
+
+        <p><span class="handlebars-data"><em>This section describes the status of this document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> standards and drafts index</a>.</em></span></p>
+
+
+        <p>
+            This document <span class="handlebars-data"></span>was published by the <a href="https://www.w3.org/groups/wg/i18n-core/"><span class="handlebars-data">Internationalization Working Group</span></a> as a <span class="handlebars-data">Working Draft </span> using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'><span class="handlebars-data">Recommendation</span> track</a>.
+        </p>
+
+
+        <p>
+            <span class="handlebars-data">
+
+
+
+                        Publication as a <span class="handlebars-data">Working Draft</span> <span class="handlebars-data">does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.</span>
+
+
+
+
+
+                        <span class="handlebars-data">This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. It is inappropriate to cite this document as other than a work in progress.</span>
+
+
+
+            </span>
+        </p>
+
+
+
+
+            <p>
+                This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/"><span class="handlebars-data"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</span></a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/i18n-core/ipr"><span class="handlebars-data">public list of any patent disclosures</span></a> made in connection with the deliverables of <span class="handlebars-data">the group; that page also includes</span> instructions for disclosing a patent. <span class="handlebars-data">An individual who has</span> actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/#def-essential"><span class="handlebars-data">Essential Claim(s)</span></a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure"><span class="handlebars-data">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</span></a>.
+            </p>
+
+        <p>
+            This document <span class="handlebars-data">is governed by the</span> <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/"><span class="handlebars-data">18 August 2025 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</span></a>.
+        </p>
+
+    </section>
+        <nav id="toc">
+                <h2 class="introductory" id="table-of-contents">Table of Contents</h2>
+            <ol class="toc">
+                <li class="tocline"><a class="tocxref" href="#introduction"><bdi class="">1. </bdi>Introduction</a>
+                    <ol class="toc"> <li class="tocline"><a class="tocxref" href="#examples"><bdi class="">1.1 </bdi>Examples</a> </li>
+                    </ol>
+                </li>
+
+                <li class="tocline"><a class="tocxref" href="#time-origin"><bdi class="">2. </bdi>Time Origin</a>
+                </li>
+            </ol>
+        </nav>
+    <section id="introduction" class="informative">
+        <h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction<a class="self-link" aria-label="§" href="#introduction"></a></h2>
+        <p id="examples"><em>This section is non-normative.</em></p>
+    </section>
+    <section id="time-origin" class="informative">
+        <h2 id="x1-time-origin"><bdi class="secno">1. </bdi>Time Origin<a class="self-link" aria-label="§" href="#sec-time-origin"></a></h2>
+        <p><em>This section is non-normative.</em></p>
+    </section>
+
+        <p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p>
+
+        <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+</body>
+</html>

--- a/test/docs/api/wd-fail-date.html
+++ b/test/docs/api/wd-fail-date.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+Like wd-good, but with malformed publish date to cause multiple exceptions
+-->
+<head>
+    <meta charset="utf-8">
+    <style>
+        .handlebars-data {
+            background: rgba(255, 0, 0, 0.15)
+        }
+    </style>
+        <meta name="viewport" content="width&#x3D;device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="canonical" href="https://www.w3.org/TR/hr-time/">
+        <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD.css">
+        <title>WD-Echidna: test document - Specberus</title> <!-- matches div.head h1 -->
+</head>
+<body class="h-entry" data-cite="WebIDL html dom webidl ecma-262">
+    <div class="head">
+            <a class="logo" href="https://www.w3.org/">
+                <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C">
+            </a>
+            <h1 id="title" class="title p-name"><span class="handlebars-data">WD-Echidna: test document - Specberus</span></h1>
+
+        <p id='w3c-state'>
+            <a href='https://www.w3.org/standards/types/#WD'>W3C <span class="handlebars-data">Working Draft</span></a>
+            <time class="dt-published" datetime="2021-11-04">
+                        <span class="handlebars-data">7 04 2026</span>
+            </time>
+        </p>
+        <details open>
+                <summary>More details about this document</summary>
+                <dl>
+
+                        <dt>This Version</dt>
+                        <dd>
+                            <a class="u-url" href="https://www.w3.org/TR/2026/WD-hr-time-20260407/">
+                                https://www.w3.org/TR/<span class="handlebars-data">2026</span>/<span class="handlebars-data">WD</span>-<span class="handlebars-data">hr-time</span>-<span class="handlebars-data">20260407</span>/
+                            </a>
+                        </dd>
+
+                        <dt>Latest published version: (@@note that version is not required in the latest version)</dt>
+                        <dd> <a href="https://www.w3.org/TR/hr-time/">https://www.w3.org/TR/<span class="handlebars-data">hr-time</span>/</a>
+                        </dd>
+
+                        <dt>Latest editor's draft:</dt>
+                        <dd> <a href="https://w3c.github.io/hr-time/">https://w3c.github.io/<span class="handlebars-data">hr-time</span>/</a>
+                        </dd>
+
+                        <dt><span class="handlebars-data">History</span>:</dt>
+                        <dd> <a href="https://www.w3.org/standards/history/hr-time">https://www.w3.org/standards/history/<span class="handlebars-data">hr-time</span></a>
+                        </dd>
+
+
+                        <dt><span class="handlebars-data">Editor</span>:</dt>
+                        <dd class="p-author h-card vcard" data-editor-id="3439">George Herald (WebFoo)
+                        </dd>
+
+
+
+
+                        <dt>Feedback:</dt>
+                        <dd><a href="https://github.com/w3c/hr-time/issues"><span class="handlebars-data">https://github.com/w3c/</span><span class="handlebars-data">hr-time</span>/issues</a></dd>
+                        <dd><a href="mailto:public-foo@w3.org?subject=%5Bhr-time%5D%20YOUR%20TOPIC%20HERE">public-foo@w3.org</a> with subject line “<kbd>[<span class="handlebars-data">hr-time</span>] <var>… message topic …</var></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-foo/" rel="discussion">archives</a>)</dd>
+                </dl>
+        </details>
+
+
+            <p class="copyright">
+                    <a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026 <a href="https://www.w3.org/"> World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/">permissive document license</a> rules apply.
+            </p>
+
+            <hr title="Separator for header">
+    </div>
+
+    <section id="abstract" class="introductory">
+        <h2><span class="handlebars-data">Abstract</span></h2>
+        <p>This specification defines an API that provides the time origin, and current time in sub-millisecond resolution, such that it is not subject to system clock skew or adjustments.</p>
+
+    </section>
+
+    <section id="sotd" data-link-for="Performance" class="introductory">
+        <h2><span class="handlebars-data">Status of This Document</span></h2>
+
+        <p><span class="handlebars-data"><em>This section describes the status of this document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> standards and drafts index</a>.</em></span></p>
+
+
+        <p>
+            This document <span class="handlebars-data"></span>was published by the <a href="https://www.w3.org/groups/wg/i18n-core/"><span class="handlebars-data">Internationalization Working Group</span></a> as a <span class="handlebars-data">Working Draft </span> using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'><span class="handlebars-data">Recommendation</span> track</a>.
+        </p>
+
+
+        <p>
+            <span class="handlebars-data">
+
+
+
+                        Publication as a <span class="handlebars-data">Working Draft</span> <span class="handlebars-data">does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.</span>
+
+
+
+
+
+                        <span class="handlebars-data">This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. It is inappropriate to cite this document as other than a work in progress.</span>
+
+
+
+            </span>
+        </p>
+
+
+
+
+            <p>
+                This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/"><span class="handlebars-data"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</span></a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/i18n-core/ipr"><span class="handlebars-data">public list of any patent disclosures</span></a> made in connection with the deliverables of <span class="handlebars-data">the group; that page also includes</span> instructions for disclosing a patent. <span class="handlebars-data">An individual who has</span> actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/#def-essential"><span class="handlebars-data">Essential Claim(s)</span></a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure"><span class="handlebars-data">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</span></a>.
+            </p>
+
+        <p>
+            This document <span class="handlebars-data">is governed by the</span> <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/"><span class="handlebars-data">18 August 2025 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</span></a>.
+        </p>
+
+    </section>
+        <nav id="toc">
+                <h2 class="introductory" id="table-of-contents">Table of Contents</h2>
+            <ol class="toc">
+                <li class="tocline"><a class="tocxref" href="#introduction"><bdi class="">1. </bdi>Introduction</a>
+                    <ol class="toc"> <li class="tocline"><a class="tocxref" href="#examples"><bdi class="">1.1 </bdi>Examples</a> </li>
+                    </ol>
+                </li>
+
+                <li class="tocline"><a class="tocxref" href="#time-origin"><bdi class="">2. </bdi>Time Origin</a>
+                </li>
+            </ol>
+        </nav>
+    <section id="introduction" class="informative">
+        <h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction<a class="self-link" aria-label="§" href="#introduction"></a></h2>
+        <p id="examples"><em>This section is non-normative.</em></p>
+    </section>
+    <section id="time-origin" class="informative">
+        <h2 id="x1-time-origin"><bdi class="secno">1. </bdi>Time Origin<a class="self-link" aria-label="§" href="#sec-time-origin"></a></h2>
+        <p><em>This section is non-normative.</em></p>
+    </section>
+
+        <p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p>
+
+        <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+</body>
+</html>

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -3,6 +3,7 @@ import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
+import { rules as metadataRules } from '../lib/profiles/metadata.js';
 import { removeRules } from '../lib/profiles/profileUtil.js';
 import type { HandlerMessage } from '../lib/types.js';
 import { allProfiles } from '../lib/util.js';
@@ -110,8 +111,12 @@ describe('Basics', () => {
                 await readFile('test/docs/2021-wd.html', 'utf8')
             ).replace(/04 November/, '04 11');
 
+            let observedDone = 0;
             const observedExceptions: string[] = [];
             const sr = new Specberus();
+            sr.on('done', () => {
+                observedDone++;
+            });
             sr.on('exception', ({ message }) => {
                 observedExceptions.push(message);
             });
@@ -132,6 +137,11 @@ describe('Basics', () => {
                         observedExceptions,
                         error.exceptions,
                         'Exceptions in rejection error should match emitted exception events'
+                    );
+                    assert.strictEqual(
+                        observedDone,
+                        metadataRules.length,
+                        'done event should fire for all rules regardless of exceptions'
                     );
                     return true;
                 }

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -40,20 +40,6 @@ interface CompareMetadataObject {
 }
 
 /**
- * Returns an EventEmitter and Promise, both reflecting progress/completion of a Specberus call.
- */
-function createSpecberusPromiseHandler() {
-    const handler = new EventEmitter();
-    const promise = new Promise<ReturnType<typeof buildJSONresult>>(
-        (resolve, reject) => {
-            handler.on('end-all', resolve);
-            handler.on('exception', reject);
-        }
-    );
-    return { handler, promise };
-}
-
-/**
  * Assert that metadata detected in a spec is equal to the expected values.
  *
  * @param file - name of local file containing a spec (without path and without ".html" suffix).
@@ -64,9 +50,7 @@ function compareMetadata(file: string, expectedObject: CompareMetadataObject) {
 
     it(`Should detect metadata for ${testFile}`, async () => {
         const specberus = new Specberus();
-        const { handler, promise } = createSpecberusPromiseHandler();
-        specberus.extractMetadata({ events: handler, file: testFile });
-        const result = await promise;
+        const result = await specberus.extractMetadata({ file: testFile });
 
         assert.strictEqual(result.success, !('errors' in expectedObject));
         if ('errors' in expectedObject) {
@@ -148,8 +132,8 @@ interface ValidationTestConfig {
     warnings?: any[];
 }
 
-function buildValidationTestHandler(test: ValidationTestConfig) {
-    const { handler, promise } = createSpecberusPromiseHandler();
+function buildValidationTestHandler() {
+    const handler = new EventEmitter();
 
     if (DEBUG) {
         handler.on('err', (type, data) => {
@@ -168,39 +152,38 @@ function buildValidationTestHandler(test: ValidationTestConfig) {
         );
     });
 
-    return {
-        handler,
-        promise: promise.then(({ errors, warnings }) => {
-            if (test.errors) {
-                assert.strictEqual(errors.length, test.errors.length);
-                errors.forEach(({ key, name }, i) => {
-                    assert.strictEqual(`${name}.${key}`, test.errors![i]);
+    return handler;
+}
+
+const verifySpecberusResult = (
+    promise: Promise<ReturnType<typeof buildJSONresult>>,
+    test: ValidationTestConfig
+) =>
+    promise.then(({ errors, warnings }) => {
+        if (test.errors) {
+            assert.strictEqual(errors.length, test.errors.length);
+            errors.forEach(({ key, name }, i) => {
+                assert.strictEqual(`${name}.${key}`, test.errors![i]);
+            });
+        } else {
+            assert.strictEqual(errors.length, 0, 'Expected errors to be empty');
+        }
+
+        if (!test.ignoreWarnings) {
+            if (test.warnings) {
+                assert.strictEqual(warnings.length, test.warnings.length);
+                warnings.forEach(({ key, name }, i) => {
+                    assert.strictEqual(`${name}.${key}`, test.warnings![i]);
                 });
             } else {
                 assert.strictEqual(
-                    errors.length,
+                    warnings.length,
                     0,
-                    'Expected errors to be empty'
+                    'Expected warnings to be empty'
                 );
             }
-
-            if (!test.ignoreWarnings) {
-                if (test.warnings) {
-                    assert.strictEqual(warnings.length, test.warnings.length);
-                    warnings.forEach(({ key, name }, i) => {
-                        assert.strictEqual(`${name}.${key}`, test.warnings![i]);
-                    });
-                } else {
-                    assert.strictEqual(
-                        warnings.length,
-                        0,
-                        'Expected warnings to be empty'
-                    );
-                }
-            }
-        }),
-    };
-}
+        }
+    });
 
 const testsGoodDoc = goodDocuments;
 
@@ -243,20 +226,18 @@ describe('Making sure good documents pass Specberus...', () => {
                 'links.linkchecker', // too slow. will check separately.
             ]);
 
-            const { handler, promise } = buildValidationTestHandler({
-                ignoreWarnings: true,
-            });
             const options = {
                 profile: {
                     ...extendedProfile,
                     rules, // do not change profile.rules
                 },
-                events: handler,
+                events: buildValidationTestHandler(),
                 url,
             };
 
-            new Specberus().validate(options);
-            return promise;
+            await verifySpecberusResult(new Specberus().validate(options), {
+                ignoreWarnings: true,
+            });
         });
     }
 });
@@ -292,7 +273,6 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
             const ruleModule = await import(
                 `../lib/rules/${category}/${rule}.js`
             );
-            const { handler, promise } = buildValidationTestHandler(test);
 
             const options = {
                 url,
@@ -304,10 +284,12 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
                         ...test.config,
                     },
                 },
-                events: handler,
+                events: buildValidationTestHandler(),
             };
-            new Specberus().validate(options);
-            return promise;
+            await verifySpecberusResult(
+                new Specberus().validate(options),
+                test
+            );
         });
     });
 }

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -1,11 +1,16 @@
 import assert from 'assert';
+import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { removeRules } from '../lib/profiles/profileUtil.js';
 import type { HandlerMessage } from '../lib/types.js';
 import { allProfiles } from '../lib/util.js';
-import { Specberus, type SpecberusResult } from '../lib/validator.js';
+import {
+    ExceptionsError,
+    Specberus,
+    type SpecberusResult,
+} from '../lib/validator.js';
 // A list of good documents to be tested, using all rules configured in the profiles.
 // Shouldn't cause any error.
 import { goodDocuments } from './data/goodDocuments.js';
@@ -99,6 +104,39 @@ describe('Basics', () => {
         samples.forEach(sample => {
             compareMetadata(sample.file, sample);
         });
+
+        it('Should report multiple exceptions when failing to parse date', async () => {
+            const badHtml = (
+                await readFile('test/docs/2021-wd.html', 'utf8')
+            ).replace(/04 November/, '04 11');
+
+            const observedExceptions: string[] = [];
+            const sr = new Specberus();
+            sr.on('exception', ({ message }) => {
+                observedExceptions.push(message);
+            });
+
+            return assert.rejects(
+                sr.extractMetadata({ source: badHtml }),
+                (error: ExceptionsError) => {
+                    assert.strictEqual(error.exceptions.length, 2);
+                    assert.match(
+                        error.exceptions[0],
+                        /^Cannot find the .* element for profile and date/
+                    );
+                    assert.strictEqual(
+                        error.exceptions[1],
+                        'The document date could not be parsed.'
+                    );
+                    assert.deepStrictEqual(
+                        observedExceptions,
+                        error.exceptions,
+                        'Exceptions in rejection error should match emitted exception events'
+                    );
+                    return true;
+                }
+            );
+        });
     });
 
     describe('Method "validate"', () => {
@@ -156,7 +194,8 @@ const verifySpecberusResult = (
     promise: Promise<SpecberusResult>,
     test: ValidationTestConfig
 ) =>
-    promise.then(({ errors, warnings }) => {
+    promise.then(result => {
+        const { errors, warnings } = result;
         if (test.errors) {
             assert.strictEqual(errors.length, test.errors.length);
             errors.forEach(({ key, name }, i) => {
@@ -180,6 +219,9 @@ const verifySpecberusResult = (
                 );
             }
         }
+
+        // Pass through result to allow further verifications
+        return result;
     });
 
 const testsGoodDoc = goodDocuments;
@@ -285,7 +327,31 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
                     },
                 },
             };
-            await verifySpecberusResult(sr.validate(options), test);
+
+            const counts = { errors: 0, info: 0, warnings: 0 };
+            sr.on('err', () => counts.errors++);
+            sr.on('info', () => counts.info++);
+            sr.on('warning', () => counts.warnings++);
+
+            const result = await verifySpecberusResult(
+                sr.validate(options),
+                test
+            );
+            assert.strictEqual(
+                result.errors.length,
+                counts.errors,
+                'Number of err events emitted should match number in resolved promise'
+            );
+            assert.strictEqual(
+                result.info.length,
+                counts.info,
+                'Number of info events emitted should match number in resolved promise'
+            );
+            assert.strictEqual(
+                result.warnings.length,
+                counts.warnings,
+                'Number of warning events emitted should match number in resolved promise'
+            );
         });
     });
 }

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -1,9 +1,9 @@
 import assert from 'assert';
-import { EventEmitter } from 'events';
 import type { Server } from 'http';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { removeRules } from '../lib/profiles/profileUtil.js';
+import type { HandlerMessage } from '../lib/types.js';
 import { allProfiles } from '../lib/util.js';
 import { Specberus, type SpecberusResult } from '../lib/validator.js';
 // A list of good documents to be tested, using all rules configured in the profiles.
@@ -35,7 +35,7 @@ const testType = process.env.TYPE;
 const testProfile = process.env.PROFILE;
 
 interface CompareMetadataObject {
-    errors?: Record<string, any>[];
+    errors?: Partial<HandlerMessage>[];
     [index: string]: any;
 }
 
@@ -61,7 +61,9 @@ function compareMetadata(file: string, expectedObject: CompareMetadataObject) {
             assert(
                 expectedObject.errors.every((expected, i) =>
                     Object.entries(expected).every(
-                        ([key, value]) => result.errors[i][key] === value
+                        ([key, value]) =>
+                            result.errors[i][key as keyof HandlerMessage] ===
+                            value
                     )
                 ),
                 `Errors should contain expected properties:\n${JSON.stringify(
@@ -131,27 +133,23 @@ interface ValidationTestConfig {
     warnings?: any[];
 }
 
-function buildValidationTestHandler() {
-    const handler = new EventEmitter();
-
+function addValidationEventListeners(sr: Specberus) {
     if (DEBUG) {
-        handler.on('err', (type, data) => {
+        sr.on('err', (type, data) => {
             console.log('error:\n', type, data);
         });
-        handler.on('warning', (type, data) => {
+        sr.on('warning', (type, data) => {
             console.log('warning:\n', type, data);
         });
-        handler.on('done', name => {
+        sr.on('done', name => {
             console.log(`----> ${name} check done`);
         });
     }
-    handler.on('exception', data => {
+    sr.on('exception', data => {
         console.error(
             `[EXCEPTION] Validator had a massive failure: ${data.message}`
         );
     });
-
-    return handler;
 }
 
 const verifySpecberusResult = (
@@ -225,16 +223,17 @@ describe('Making sure good documents pass Specberus...', () => {
                 'links.linkchecker', // too slow. will check separately.
             ]);
 
+            const sr = new Specberus();
+            addValidationEventListeners(sr);
             const options = {
                 profile: {
                     ...extendedProfile,
                     rules, // do not change profile.rules
                 },
-                events: buildValidationTestHandler(),
                 url,
             };
 
-            await verifySpecberusResult(new Specberus().validate(options), {
+            await verifySpecberusResult(sr.validate(options), {
                 ignoreWarnings: true,
             });
         });
@@ -273,6 +272,8 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
                 `../lib/rules/${category}/${rule}.js`
             );
 
+            const sr = new Specberus();
+            addValidationEventListeners(sr);
             const options = {
                 url,
                 profile: {
@@ -283,12 +284,8 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
                         ...test.config,
                     },
                 },
-                events: buildValidationTestHandler(),
             };
-            await verifySpecberusResult(
-                new Specberus().validate(options),
-                test
-            );
+            await verifySpecberusResult(sr.validate(options), test);
         });
     });
 }

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -4,8 +4,8 @@ import type { Server } from 'http';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { removeRules } from '../lib/profiles/profileUtil.js';
-import { allProfiles, buildJSONresult } from '../lib/util.js';
-import { Specberus } from '../lib/validator.js';
+import { allProfiles } from '../lib/util.js';
+import { Specberus, type SpecberusResult } from '../lib/validator.js';
 // A list of good documents to be tested, using all rules configured in the profiles.
 // Shouldn't cause any error.
 import { goodDocuments } from './data/goodDocuments.js';
@@ -156,7 +156,7 @@ function buildValidationTestHandler() {
 }
 
 const verifySpecberusResult = (
-    promise: Promise<ReturnType<typeof buildJSONresult>>,
+    promise: Promise<SpecberusResult>,
     test: ValidationTestConfig
 ) =>
     promise.then(({ errors, warnings }) => {

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -72,14 +72,13 @@ function compareMetadata(file: string, expectedObject: CompareMetadataObject) {
             );
         }
 
-        assert(specberus.meta, 'Expected specberus.meta to be defined');
         for (const [key, value] of Object.entries(expectedObject)) {
             if (key === 'errors' || key === 'file') continue;
             assert(
-                key in specberus.meta,
-                `Expected specberus.meta.${key} to be defined`
+                key in result.metadata,
+                `Expected ${key} to be defined in metadata`
             );
-            assert.deepStrictEqual(specberus.meta[key], value);
+            assert.deepStrictEqual(result.metadata[key], value);
         }
     });
 }


### PR DESCRIPTION
**This PR contains a significant amount of API changes, some of them breaking,** but the result should be easier to use and avoids hanging due to unexpected errors.

- Converts `extractMetadata`, `validate`, and all rule check functions to return promises
  - This involves re-flowing code in a few rules to return existing promises they already produced
  - Rules no longer use `sr.throw`; they throw errors directly, and this is wrapped with `this.#throw` on the `validator.ts` end (the `throw` method is now private)
    - Any `#throw` invocations are collected into a list of exceptions, which will be included within the rejected promise's error in an `exceptions` property
  - Rules which checked for superagent timeouts now compare correctly (as alerted by superagent typings)
- Re-flows asynchronous `validator.ts` APIs that cache values to cache the pending promise, to avoid duplicated near-simultaneous requests
- Any `validator.ts` APIs that were not intended to be directly used are now private
- Removes `meta` instance property (use the resolved value of `extractMetata` instead)
- Removes `clearCache` method which was never used (all usage only calls `extractMetadata` or `validate` once)
- Removes unused optional parameter from `extractHeaders` method
- Removes `start-all` and `end-all` events (use promises instead for `end-all`; `start-all` already seemed unused)
- `extractMetadata` and `validate` now emit error/info/warning events consistently with each other (previously, `extractMetadata` did not include `key`, `extra`, or `detailMessage`)
- Removes `events` property from `extractMetadata` and `validate` options; use `sr.on(...)` (which exposes specific typings for supported events) instead of passing an entire `EventEmitter`
- `exception` handler is no longer required in Specberus options; exceptions will reject the promise, which should be handled instead
  - `exception` is still a listenable event for instances where granular feedback is desired
- When exceptions are reported via errors in API output, they are now objects with 'exception' key, to be more consistent with all other reported errors being objects (not strings)
- Removes `doasync` dependency (used by shortname rule) which was not doing anything necessary (`superagent` methods already return promise-likes)
- Converts all `fs` usage in `validator.ts` to use `fs/promises`
- Reduces duplicated code within `validator.ts` with new private functions such as `#load`, `#prepare`, and `#reportResult`
- Adds a few test cases (some long overdue)
- Restores and fixes `type=good2` test cases which were not actually being run (instead they were re-running `type=good` cases)
