### PR TITLE
Split main Specberus and rule check APIs into separate classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Specberus is a [Node.js](https://nodejs.org/en/) application, [distributed throu
 Alternatively, you can clone [the repository](https://github.com/w3c/specberus) and run:
 
 ```bash
-$ npm install -d
+$ npm install
 ```
 
 In order to get all the dependencies installed. Naturally, this requires that you have a reasonably
@@ -30,8 +30,7 @@ recent version of Node.js installed.
 
 ## 2. Running
 
-Currently there is no shell to run Specberus. Later we will add both Web and CLI interfaces based
-on the same core library.
+Specberus runs as a web server, providing both HTML form UI and API endpoints.
 
 ### Syntax and command-line parameters
 
@@ -147,12 +146,12 @@ $ RULE=copyright TYPE=noCopyright npm run test
 
 ## 4. JS API
 
-The interface you get when you `import { Specberus } from "specberus"` is that from `lib/validator`.
+The interface you get when you `import { Specberus } from "specberus"` is that from `lib/specberus`.
 `Specberus` is a class configured for operation in the Node.js environment.
 
 (See also [the REST API](#5-rest-api).)
 
-## Creating a Validator instance
+## Creating a Specberus instance
 
 ```js
 import { Specberus } from 'specberus';

--- a/README.md
+++ b/README.md
@@ -435,22 +435,27 @@ Events listed below are expressed with parameters to reflect what is passed to t
 
 ## 8. Writing rules
 
-Rules are simple modules that just expose a `check(sr)` method. They receive a Specberus object,
+Rules are simple modules that expose a `check(context)` method. They receive a context object,
 which they use to examine the document and fire validation events. They return a promise which
 resolves on completion (regardless of pass or fail) or rejects on unexpected system error
 (exception). Usually, they are written as `async` functions to automatically handle the
 resolve vs. reject distinction.
 
-The Specberus object exposes the following APIs useful for validation:
+The context object includes the following APIs useful for validation:
+
+### Properties
 
 - `source`. The HTML source of the document being processed
 - `url`. The URL of the document being processed, only applicable if `options.url` was specified
+- `version`. The Specberus version.
+
+### Methods
+
 - `error`, `warn`, `info`. Methods for firing respective levels of events on the instance.
   All three methods accept the same arguments:
     - `rule` object: at minimum, an object with a `name` string. May also contain `rule` and `section` strings.
     - `key` string: specifies the precise occurrence within the particular `rule`
     - `extra` object (optional): any additional fields to include within the event
-- `version`. The Specberus version.
 - `checkSelector(selector, ruleName)`. Some rules need to do nothing other than to check that a
   selector returns some content. This handles checking the selector, reporting an error if it is
   not found, or throwing an error if the selector is invalid.

--- a/app.ts
+++ b/app.ts
@@ -19,7 +19,7 @@ import * as api from './lib/api.js';
 import badterms from './lib/badterms.js';
 import * as l10n from './lib/l10n.js';
 import { allProfiles, specberusVersion } from './lib/util.js';
-import { ExceptionsError, Specberus } from './lib/validator.js';
+import { ExceptionsError, Specberus } from './lib/specberus.js';
 import * as views from './lib/views.js';
 import type { ProfileModule } from './lib/types.js';
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,7 +12,7 @@ import {
     Specberus,
     type SpecberusResult,
     type ValidateOptions,
-} from './validator.js';
+} from './specberus.js';
 
 /** Data types emitted by error events */
 type ErrorHandlerMessage =

--- a/lib/rule-context.ts
+++ b/lib/rule-context.ts
@@ -9,6 +9,7 @@ import w3cApi from 'node-w3capi';
 
 import { hasExceptions } from './exceptions.js';
 import { assembleData } from './l10n.js';
+// Reminder: specberus.js imports this module; only types may be imported in the other direction
 import type { Specberus } from './specberus.js';
 import { get } from './throttled-ua.js';
 import { AB, REC_TEXT, specberusVersion, TAG } from './util.js';

--- a/lib/rule-context.ts
+++ b/lib/rule-context.ts
@@ -2,241 +2,24 @@
  * @file Main file of the Specberus npm package.
  */
 
-import EventEmitter from 'events';
-import { access, constants, readFile } from 'fs/promises';
-
 import { type Cheerio, type CheerioAPI, load } from 'cheerio';
 import type { Element } from 'domhandler';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
 
 import { hasExceptions } from './exceptions.js';
-import { assembleData, setLanguage } from './l10n.js';
-import * as profileMetadata from './profiles/metadata.js';
-import * as profileAdditionalMetadata from './profiles/additionalMetadata.js';
+import { assembleData } from './l10n.js';
+import type { Specberus } from './specberus.js';
 import { get } from './throttled-ua.js';
-import { AB, processParams, REC_TEXT, specberusVersion, TAG } from './util.js';
+import { AB, REC_TEXT, specberusVersion, TAG } from './util.js';
 import type {
     ApiCharter,
     ApiSpecificationVersion,
-    HandlerMessage,
-    ProfileModule,
     RecMetadata,
     RuleBase,
     RuleMeta,
     SpecberusConfig,
 } from './types.js';
-
-setLanguage('en_GB');
-
-interface BaseOptions {
-    file?: string;
-    source?: string;
-    url?: string;
-}
-
-interface ExtractMetadataOptions extends BaseOptions {
-    additionalMetadata?: boolean;
-}
-
-export interface ValidateOptions extends BaseOptions {
-    profile: ProfileModule;
-    validation?: 'no-validation' | 'recursive';
-}
-
-interface ExceptionsErrorOptions extends ErrorOptions {
-    exceptions: string[];
-}
-
-export interface SpecberusResult {
-    errors: HandlerMessage[];
-    info: HandlerMessage[];
-    metadata: Record<string, any>;
-    success: boolean;
-    warnings: HandlerMessage[];
-}
-
-/**
- * Error which includes list of exception messages,
- * thrown in case of unexpected errors during extractMetadata or validate
- */
-export class ExceptionsError extends Error {
-    exceptions: string[];
-
-    constructor(message?: string, options?: ExceptionsErrorOptions) {
-        super(message, options);
-        this.exceptions = options?.exceptions || [];
-    }
-}
-
-type SpecberusMessageEventArgs = [
-    RuleMeta | RuleBase,
-    {
-        detailMessage: string;
-        extra?: Record<string, any>;
-        key: string;
-    },
-];
-
-interface SpecberusEvents {
-    done: [string];
-    err: SpecberusMessageEventArgs;
-    exception: [{ message: string }];
-    info: SpecberusMessageEventArgs;
-    warning: SpecberusMessageEventArgs;
-}
-
-export class Specberus extends EventEmitter<SpecberusEvents> {
-    source: string | undefined;
-    url: string | undefined;
-    version = specberusVersion;
-
-    /** Stores messages from any unexpected errors encountered during process */
-    #exceptions: string[] = [];
-
-    /**
-     * Internal function for handling common end-state logic for extractMetadata and validate,
-     * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
-     */
-    #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
-        if (this.#exceptions.length) {
-            throw new ExceptionsError(
-                'The following unexpected errors occurred:\n' +
-                    this.#exceptions.join('\n'),
-                { exceptions: this.#exceptions }
-            );
-        }
-        return {
-            ...result,
-            success: !result.errors.length,
-        };
-    }
-
-    /** Internal function containing setup logic common to both extractMetadata and validate. */
-    async #prepare(options: ExtractMetadataOptions | ValidateOptions) {
-        const errors: HandlerMessage[] = [];
-        const warnings: HandlerMessage[] = [];
-        const info: HandlerMessage[] = [];
-
-        this.on('err', (rule, data) => {
-            errors.push({ ...rule, ...data });
-        });
-        this.on('warning', (rule, data) => {
-            warnings.push({ ...rule, ...data });
-        });
-        this.on('info', (rule, data) => {
-            info.push({ ...rule, ...data });
-        });
-
-        try {
-            const $ = await this.#load(options);
-            return { $, errors, info, warnings };
-        } catch (error) {
-            this.#throw(error.toString());
-            throw error;
-        }
-    }
-
-    async extractMetadata(options: ExtractMetadataOptions) {
-        const { $, ...messages } = await this.#prepare(options);
-        const metadata: Record<string, any> = {};
-        const profile = options.additionalMetadata
-            ? profileAdditionalMetadata
-            : profileMetadata;
-        const ruleContext = new RuleContext(this, $);
-
-        await Promise.all(
-            profile.rules.map(async rule => {
-                try {
-                    const result = await rule.check(ruleContext);
-                    if (result)
-                        for (const [key, value] of Object.entries(result))
-                            metadata[key] = value;
-                } catch (error) {
-                    this.#throw(error.message);
-                } finally {
-                    this.emit('done', rule.name);
-                }
-            })
-        );
-        return this.#reportResult({ ...messages, metadata });
-    }
-
-    async validate(options: ValidateOptions) {
-        if (!options.profile)
-            throw new Error('Without a profile there is nothing to check.');
-
-        const { profile } = options;
-        const config = await processParams(options, profile.config);
-        const { $, ...messages } = await this.#prepare(options);
-        const ruleContext = new RuleContext(this, $, config);
-
-        await Promise.all(
-            profile.rules.map(async rule => {
-                try {
-                    await rule.check(ruleContext);
-                } catch (error) {
-                    this.#throw(error.message);
-                } finally {
-                    this.emit('done', rule.name);
-                }
-            })
-        );
-        return this.#reportResult({ ...messages, metadata: {} });
-    }
-
-    /**
-     * Emits an exception event, intended to signify that the process stopped on a critical error.
-     *
-     * NOTE: This should not be called from rules; they should throw an Error,
-     * which will result in extractMetadata or validate invoking this method.
-     */
-    #throw(message: string) {
-        console.error(`[EXCEPTION] ${message}`);
-        this.emit('exception', { message });
-        // Track in exceptions array, used to determine whether to resolve or reject process
-        this.#exceptions.push(message);
-    }
-
-    #load(options: ExtractMetadataOptions | ValidateOptions) {
-        if (options.url) return this.#loadURL(options.url);
-        if (options.source) return this.#loadSource(options.source);
-        if (options.file) return this.#loadFile(options.file);
-        throw new Error('url, source, or file must be specified.');
-    }
-
-    #loadURL(url: string) {
-        return get(url)
-            .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
-            .then(res => {
-                if (!res.text) throw new Error(`Body of ${url} is empty.`);
-                this.url = url;
-                return this.#loadSource(res.text);
-            });
-    }
-
-    #loadSource(src: string) {
-        this.source = src;
-        try {
-            return load(src);
-        } catch (e) {
-            throw new Error(
-                `Cheerio failed to parse source: ${JSON.stringify(e)}`
-            );
-        }
-    }
-
-    async #loadFile(file: string) {
-        try {
-            await access(file, constants.F_OK);
-        } catch (error) {
-            throw new Error(`File '${file}' not found or inaccessible.`);
-        }
-        return this.#loadSource(await readFile(file, 'utf8'));
-    }
-}
-
-// End of Specberus-related code; start of RuleContext-related code
 
 type HeaderMap = Record<
     string,
@@ -320,7 +103,7 @@ const REGEX_DELIVERER_IPR_URL =
  * Encapsulates all methods of interest to rule check functions,
  * separate from the APIs responsible for core Specberus requests.
  */
-class RuleContext {
+export class RuleContext {
     $: CheerioAPI;
     /**
      * Configuration that Specberus parsed from params.
@@ -909,6 +692,3 @@ class RuleContext {
         return meta;
     }
 }
-
-// Expose typings for types.d.ts to use, separate from the unexposed implementation
-export type { RuleContext };

--- a/lib/rules/echidna/deliverer-change.ts
+++ b/lib/rules/echidna/deliverer-change.ts
@@ -27,13 +27,9 @@ async function getPreviousDelivererIDs(
     return data.map(({ id }) => id);
 }
 
-/**
- * @param sr
- * @param done
- */
-export const check: RuleCheckFunction = async sr => {
-    const previousVersion = await sr.getPreviousVersion();
-    const shortname = await sr.getShortname();
+export const check: RuleCheckFunction = async context => {
+    const previousVersion = await context.getPreviousVersion();
+    const shortname = await context.getShortname();
 
     if (!previousVersion || !shortname) return;
 
@@ -41,14 +37,14 @@ export const check: RuleCheckFunction = async sr => {
         shortname,
         previousVersion
     );
-    const delivererIDs = await sr.getDelivererIDs();
+    const delivererIDs = await context.getDelivererIDs();
 
     const delivererChanged =
         delivererIDs.sort().toString() !==
         previousDelivererIDs.sort().toString();
 
     if (delivererChanged) {
-        sr.error(self, 'deliverer-changed', {
+        context.error(self, 'deliverer-changed', {
             this: delivererIDs.sort().toString(),
             previous: previousDelivererIDs.sort().toString(),
         });

--- a/lib/rules/echidna/todays-date.ts
+++ b/lib/rules/echidna/todays-date.ts
@@ -9,7 +9,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     /**
      * Get the timestamp of a day, regardless the time of the day.
      * This function creates a new `Date` to avoid modifying the original one.
@@ -21,10 +21,10 @@ export const check: RuleCheckFunction = sr => {
         return new Date(date.getTime()).setHours(0, 0, 0, 0);
     }
 
-    const documentDate = sr.getDocumentDate();
+    const documentDate = context.getDocumentDate();
     if (!(documentDate instanceof Date)) {
-        sr.error(self, 'date-not-detected');
+        context.error(self, 'date-not-detected');
     } else if (getDateTime(documentDate) !== getDateTime(new Date())) {
-        sr.error(self, 'wrong-date');
+        context.error(self, 'wrong-date');
     }
 };

--- a/lib/rules/headers/copyright.ts
+++ b/lib/rules/headers/copyright.ts
@@ -11,7 +11,7 @@ import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
 import { AB, TAG } from '../../util.js';
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 
 import copyrightExceptions from '../../copyright-exceptions.js';
 import type { ApiCharter, RuleCheckFunction, RuleMeta } from '../../types.js';

--- a/lib/rules/headers/copyright.ts
+++ b/lib/rules/headers/copyright.ts
@@ -11,7 +11,7 @@ import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
 import { AB, TAG } from '../../util.js';
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 
 import copyrightExceptions from '../../copyright-exceptions.js';
 import type { ApiCharter, RuleCheckFunction, RuleMeta } from '../../types.js';
@@ -52,7 +52,7 @@ const latestBaseLinks = {
 
 export const { name } = self;
 
-async function isOnlyPublishedByTagOrAb(sr: Specberus) {
+async function isOnlyPublishedByTagOrAb(sr: RuleContext) {
     const delivererIDs = await sr.getDelivererIDs();
     return delivererIDs.every(id => id === TAG.id || id === AB.id);
 }
@@ -66,7 +66,7 @@ function getCommonLicenseUri(data: ApiCharter[]) {
 }
 
 // The date can be 19xx-2023, or 2023.
-function getLatestCopyrightMatchRegex(sr: Specberus, licenseTexts: string[]) {
+function getLatestCopyrightMatchRegex(sr: RuleContext, licenseTexts: string[]) {
     const licenseRex = licenseTexts.join('|');
     const year = (sr.getDocumentDate() || new Date()).getFullYear();
 
@@ -81,7 +81,7 @@ function getLatestCopyrightMatchRegex(sr: Specberus, licenseTexts: string[]) {
 
 // Some documents like epub-33 uses special copyrights listed in copyright-exception.json
 function checkSpecialCopyright(
-    sr: Specberus,
+    sr: RuleContext,
     $copyright: Cheerio<Element>,
     specialCopyright: (typeof copyrightExceptions)[number],
     shortname: string | undefined
@@ -102,7 +102,7 @@ function checkSpecialCopyright(
 }
 
 function checkLatestCopyright(
-    sr: Specberus,
+    sr: RuleContext,
     $copyright: Cheerio<Element>,
     licenseTexts: string[]
 ) {

--- a/lib/rules/headers/copyright.ts
+++ b/lib/rules/headers/copyright.ts
@@ -52,8 +52,8 @@ const latestBaseLinks = {
 
 export const { name } = self;
 
-async function isOnlyPublishedByTagOrAb(sr: RuleContext) {
-    const delivererIDs = await sr.getDelivererIDs();
+async function isOnlyPublishedByTagOrAb(context: RuleContext) {
+    const delivererIDs = await context.getDelivererIDs();
     return delivererIDs.every(id => id === TAG.id || id === AB.id);
 }
 
@@ -66,9 +66,12 @@ function getCommonLicenseUri(data: ApiCharter[]) {
 }
 
 // The date can be 19xx-2023, or 2023.
-function getLatestCopyrightMatchRegex(sr: RuleContext, licenseTexts: string[]) {
+function getLatestCopyrightMatchRegex(
+    context: RuleContext,
+    licenseTexts: string[]
+) {
     const licenseRex = licenseTexts.join('|');
-    const year = (sr.getDocumentDate() || new Date()).getFullYear();
+    const year = (context.getDocumentDate() || new Date()).getFullYear();
 
     const startRex =
         '^Copyright [©|&copy;] (?:(?:199\\d|20\\d\\d)-)?@YEAR *World Wide Web Consortium'.replace(
@@ -81,19 +84,19 @@ function getLatestCopyrightMatchRegex(sr: RuleContext, licenseTexts: string[]) {
 
 // Some documents like epub-33 uses special copyrights listed in copyright-exception.json
 function checkSpecialCopyright(
-    sr: RuleContext,
+    context: RuleContext,
     $copyright: Cheerio<Element>,
     specialCopyright: (typeof copyrightExceptions)[number],
     shortname: string | undefined
 ) {
-    const year = (sr.getDocumentDate() || new Date()).getFullYear();
+    const year = (context.getDocumentDate() || new Date()).getFullYear();
 
-    const domHtml = sr.norm($copyright.html()!);
-    const specHtml = sr.norm(
+    const domHtml = context.norm($copyright.html()!);
+    const specHtml = context.norm(
         specialCopyright.copyright.replace(/@YEAR/g, '' + year)
     );
     if (domHtml !== specHtml) {
-        sr.error(self, 'exception-no-html', {
+        context.error(self, 'exception-no-html', {
             copyright: domHtml,
             expected: specHtml,
             shortname,
@@ -102,14 +105,14 @@ function checkSpecialCopyright(
 }
 
 function checkLatestCopyright(
-    sr: RuleContext,
+    context: RuleContext,
     $copyright: Cheerio<Element>,
     licenseTexts: string[]
 ) {
-    const matchRegex = getLatestCopyrightMatchRegex(sr, licenseTexts);
-    const regResult = sr.norm($copyright.text()).match(matchRegex);
+    const matchRegex = getLatestCopyrightMatchRegex(context, licenseTexts);
+    const regResult = context.norm($copyright.text()).match(matchRegex);
     if (!regResult) {
-        sr.error(self, 'no-match', { rex: matchRegex });
+        context.error(self, 'no-match', { rex: matchRegex });
         return;
     }
 
@@ -124,11 +127,11 @@ function checkLatestCopyright(
     const links = $copyright.find('a').toArray();
     Object.keys(linksToCheck).forEach(linkText => {
         const link = links.find(link =>
-            sr.norm(sr.$(link).text()).includes(linkText)
+            context.norm(context.$(link).text()).includes(linkText)
         );
 
         if (!link) {
-            return sr.error(self, 'no-link', { text: linkText });
+            return context.error(self, 'no-link', { text: linkText });
         }
 
         const linkHref = link.attribs.href;
@@ -139,7 +142,7 @@ function checkLatestCopyright(
             : expected === linkHref;
 
         if (!linkFound) {
-            sr.error(self, 'href-not-match', {
+            context.error(self, 'href-not-match', {
                 expected: isExpectedArray ? expected.join("' or '") : expected,
                 hrefInDoc: linkHref,
                 text: linkText,
@@ -148,30 +151,30 @@ function checkLatestCopyright(
     });
 }
 
-export const check: RuleCheckFunction = async sr => {
-    const $copyright = sr.$('body div.head p.copyright').first();
+export const check: RuleCheckFunction = async context => {
+    const $copyright = context.$('body div.head p.copyright').first();
 
     if (!$copyright.length) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
         return;
     }
-    if (await isOnlyPublishedByTagOrAb(sr)) {
+    if (await isOnlyPublishedByTagOrAb(context)) {
         return;
     }
 
-    const chartersData = await sr.getChartersData();
+    const chartersData = await context.getChartersData();
     if (!chartersData || !chartersData.length) {
-        sr.error(self, 'no-data-from-API');
+        context.error(self, 'no-data-from-API');
         return;
     }
 
     const allowedLicenses = getCommonLicenseUri(chartersData);
     if (!allowedLicenses.length && chartersData.length > 1) {
-        sr.error(self, 'no-license-found-joint');
+        context.error(self, 'no-license-found-joint');
         return;
     }
     if (!allowedLicenses.length) {
-        sr.error(self, 'no-license-found');
+        context.error(self, 'no-license-found');
         return;
     }
 
@@ -181,14 +184,14 @@ export const check: RuleCheckFunction = async sr => {
         .map(v => LICENSE_URL_TEXT_MAP[v]);
 
     // get exception rule for certain shortnames
-    const shortname = await sr.getShortname();
+    const shortname = await context.getShortname();
     const specialCopyright = copyrightExceptions.find(
         ({ specShortnames }) => shortname && specShortnames.includes(shortname)
     );
 
     if (specialCopyright) {
-        checkSpecialCopyright(sr, $copyright, specialCopyright, shortname);
+        checkSpecialCopyright(context, $copyright, specialCopyright, shortname);
     } else {
-        checkLatestCopyright(sr, $copyright, licenseTexts);
+        checkLatestCopyright(context, $copyright, licenseTexts);
     }
 };

--- a/lib/rules/headers/details-summary.ts
+++ b/lib/rules/headers/details-summary.ts
@@ -10,30 +10,30 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $details = sr.$('.head details').first();
+export const check: RuleCheckFunction = context => {
+    const $details = context.$('.head details').first();
     if (!$details.length) {
-        sr.error(self, 'no-details');
+        context.error(self, 'no-details');
         return;
     }
 
     if (!$details.attr('open')) {
-        sr.error(self, 'no-details-open');
+        context.error(self, 'no-details-open');
     }
 
-    if (!sr.$('.head details dl').length) {
-        sr.error(self, 'no-details-dl');
+    if (!context.$('.head details dl').length) {
+        context.error(self, 'no-details-dl');
         return;
     }
 
-    const $summary = sr.$('.head details summary').first();
+    const $summary = context.$('.head details summary').first();
     if (!$summary.length) {
-        sr.error(self, 'no-details-summary');
+        context.error(self, 'no-details-summary');
         return;
     }
 
-    const summaryText = sr.norm($summary.text());
+    const summaryText = context.norm($summary.text());
     if (summaryText !== 'More details about this document') {
-        sr.error(self, 'wrong-summary-text');
+        context.error(self, 'wrong-summary-text');
     }
 };

--- a/lib/rules/headers/div-head.ts
+++ b/lib/rules/headers/div-head.ts
@@ -10,6 +10,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    sr.checkSelector('body div.head', self);
+export const check: RuleCheckFunction = context => {
+    context.checkSelector('body div.head', self);
 };

--- a/lib/rules/headers/dl.ts
+++ b/lib/rules/headers/dl.ts
@@ -10,7 +10,7 @@ import type { Element } from 'domhandler';
 
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 import { resolveGithubUsernameToId } from '../../util.js';
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 
 const self: RuleMeta = {
     name: 'headers.dl',

--- a/lib/rules/headers/dl.ts
+++ b/lib/rules/headers/dl.ts
@@ -44,7 +44,7 @@ interface CheckLinkOptions {
     linkName: string;
     mustHave?: boolean;
     rule?: RuleMeta;
-    sr: RuleContext;
+    context: RuleContext;
 }
 
 /**
@@ -52,7 +52,7 @@ interface CheckLinkOptions {
  * @returns boolean whether element exists and can continue
  */
 function checkLink({
-    sr,
+    context,
     rule = self,
     $element,
     linkName,
@@ -60,40 +60,41 @@ function checkLink({
 }: CheckLinkOptions) {
     if (!$element?.length || !$element.attr('href')) {
         if (mustHave)
-            sr.error(rule, 'not-found', { linkName, message: linkName });
+            context.error(rule, 'not-found', { linkName, message: linkName });
         return false;
     }
-    const text = sr.norm($element.text()).trim();
+    const text = context.norm($element.text()).trim();
     const href = ($element.attr('href') || '').trim();
-    if (href !== text) sr.error(rule, 'link-diff', { text, href, linkName });
+    if (href !== text)
+        context.error(rule, 'link-diff', { text, href, linkName });
     return true;
 }
 
-export const check: RuleCheckFunction = async sr => {
-    const { rescinds, status, submissionType } = sr.config!;
+export const check: RuleCheckFunction = async context => {
+    const { rescinds, status, submissionType } = context.config!;
     let topLevel = 'TR';
 
     if (submissionType === 'member') topLevel = 'submissions';
 
-    const dts = sr.extractHeaders();
-    if (!dts.This) sr.error(self, 'this-version');
-    if (!dts.Latest) sr.error(self, 'latest-version');
-    if (!dts.History) sr.error(self, 'no-history');
-    if (rescinds && !dts.Rescinds) sr.error(self, 'rescinds');
-    if (!rescinds && dts.Rescinds) sr.warning(self, 'rescinds-not-needed');
+    const dts = context.extractHeaders();
+    if (!dts.This) context.error(self, 'this-version');
+    if (!dts.Latest) context.error(self, 'latest-version');
+    if (!dts.History) context.error(self, 'no-history');
+    if (rescinds && !dts.Rescinds) context.error(self, 'rescinds');
+    if (!rescinds && dts.Rescinds) context.warning(self, 'rescinds-not-needed');
 
     if (dts.This && dts.Latest && dts.This.pos > dts.Latest.pos)
-        sr.error(self, 'this-latest-order');
+        context.error(self, 'this-latest-order');
     // TODO: What's the order for History?
     if (dts.Latest && dts.Rescinds && dts.Latest.pos > dts.Rescinds.pos)
-        sr.error(self, 'latest-rescinds-order');
+        context.error(self, 'latest-rescinds-order');
 
     let matches;
 
     if (dts.This) {
         const $linkThis = dts.This.$dd.find('a').first();
         const exist = checkLink({
-            sr,
+            context,
             rule: self,
             $element: $linkThis,
             linkName: 'This version',
@@ -106,7 +107,7 @@ export const check: RuleCheckFunction = async sr => {
             matches = ($linkThis.attr('href') || '')
                 .trim()
                 .match(new RegExp(vThisRex));
-            const docDate = sr.getDocumentDate();
+            const docDate = context.getDocumentDate();
             if (matches) {
                 const year = +matches[1];
                 const year2 = +matches[3];
@@ -119,16 +120,16 @@ export const check: RuleCheckFunction = async sr => {
                         month - 1 !== docDate.getMonth() ||
                         day !== docDate.getDate()
                     )
-                        sr.error(self, 'this-date');
-                } else sr.warning(self, 'no-date');
-            } else sr.error(thisError, 'this-syntax');
+                        context.error(self, 'this-date');
+                } else context.warning(self, 'no-date');
+            } else context.error(thisError, 'this-syntax');
         }
     }
 
     if (dts.Latest) {
         const $linkLate = dts.Latest.$dd.find('a').first();
         const exist = checkLink({
-            sr,
+            context,
             rule: self,
             $element: $linkLate,
             linkName: 'Latest published version',
@@ -141,7 +142,7 @@ export const check: RuleCheckFunction = async sr => {
                 .match(new RegExp(lateRex));
 
             if (!matches) {
-                sr.error(latestError, 'latest-syntax');
+                context.error(latestError, 'latest-syntax');
             }
         }
     }
@@ -149,7 +150,7 @@ export const check: RuleCheckFunction = async sr => {
     if (dts.History) {
         const $linkHistory = dts.History.$dd.find('a').first();
         checkLink({
-            sr,
+            context,
             rule: historyError,
             $element: $linkHistory,
             linkName: 'History',
@@ -159,7 +160,7 @@ export const check: RuleCheckFunction = async sr => {
     if (dts.Rescinds) {
         const $linkRescinds = dts.Rescinds.$dd.find('a').first();
         const exist = checkLink({
-            sr,
+            context,
             rule: self,
             $element: $linkRescinds,
             linkName: 'Rescinds this Recommendation',
@@ -173,7 +174,7 @@ export const check: RuleCheckFunction = async sr => {
                 );
 
             if (!matches) {
-                sr.error(self, 'rescinds-syntax');
+                context.error(self, 'rescinds-syntax');
             }
         }
     }
@@ -181,15 +182,15 @@ export const check: RuleCheckFunction = async sr => {
     // check "Implementation report" link. Unless in Sotd saying there's none.
     const needImplementation =
         ['CR', 'CRD', 'PR', 'REC'].indexOf(status) !== -1;
-    const $sotd = sr.getSotDSection();
+    const $sotd = context.getSotDSection();
     const noImplementation =
-        sr
+        context
             .norm(($sotd && $sotd.text()) || '')
             .indexOf('There is no preliminary implementation report.') > -1;
     const $linkImplementation =
         dts.Implementation && dts.Implementation.$dd.find('a').first();
     const implementationExist = checkLink({
-        sr,
+        context,
         rule: self,
         $element: $linkImplementation,
         linkName: 'Implementation report',
@@ -202,19 +203,19 @@ export const check: RuleCheckFunction = async sr => {
             .toLowerCase()
             .startsWith('https://')
     ) {
-        sr.error(self, 'implelink-should-be-https', {
+        context.error(self, 'implelink-should-be-https', {
             link: $linkImplementation.attr('href') || '',
         });
     }
     if (noImplementation && needImplementation) {
-        sr.warning(self, 'implelink-confirm-no');
+        context.warning(self, 'implelink-confirm-no');
     }
 
     // check "Editor's draft" link
     if (dts.EditorDraft) {
         const $editorsDraftElement = dts.EditorDraft.$dd.find('a').first();
         const exist = checkLink({
-            sr,
+            context,
             rule: self,
             $element: $editorsDraftElement,
             linkName: 'Implementation report',
@@ -222,7 +223,7 @@ export const check: RuleCheckFunction = async sr => {
         if (exist) {
             const editorsDraft = $editorsDraftElement.attr('href') || '';
             if (!editorsDraft.trim().toLowerCase().startsWith('https://'))
-                sr.error(self, 'editors-draft-should-be-https', {
+                context.error(self, 'editors-draft-should-be-https', {
                     link: editorsDraft,
                 });
         }
@@ -233,15 +234,15 @@ export const check: RuleCheckFunction = async sr => {
             editor =>
                 !editor.attribs['data-editor-id'] &&
                 !editor.attribs['data-editor-github'] &&
-                !sr
+                !context
                     .$(editor)
                     .text()
                     .match(/(working|interest) group/i)
         );
         if (missingElements.length) {
-            sr.error(editorError, 'editor-missing-id', {
+            context.error(editorError, 'editor-missing-id', {
                 names: missingElements
-                    .map(editor => sr.$(editor).text())
+                    .map(editor => context.$(editor).text())
                     .join(', '),
             });
         }
@@ -257,18 +258,18 @@ export const check: RuleCheckFunction = async sr => {
                 if (!(await resolveGithubUsernameToId(username)))
                     unresolvedUsernames.push(username);
             } catch (error) {
-                sr.error(editorError, 'editor-github-failed', {
+                context.error(editorError, 'editor-github-failed', {
                     name: error.cause,
                 });
             }
         }
         if (unresolvedUsernames.length) {
-            sr.error(editorError, 'editor-github-unresolvable', {
+            context.error(editorError, 'editor-github-unresolvable', {
                 names: unresolvedUsernames.join(', '),
             });
         }
     } else {
         // should at least have 1 editor
-        sr.error(editorError, 'editor-not-found');
+        context.error(editorError, 'editor-not-found');
     }
 };

--- a/lib/rules/headers/dl.ts
+++ b/lib/rules/headers/dl.ts
@@ -10,7 +10,7 @@ import type { Element } from 'domhandler';
 
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 import { resolveGithubUsernameToId } from '../../util.js';
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 
 const self: RuleMeta = {
     name: 'headers.dl',
@@ -44,7 +44,7 @@ interface CheckLinkOptions {
     linkName: string;
     mustHave?: boolean;
     rule?: RuleMeta;
-    sr: Specberus;
+    sr: RuleContext;
 }
 
 /**

--- a/lib/rules/headers/editor-participation.ts
+++ b/lib/rules/headers/editor-participation.ts
@@ -10,15 +10,15 @@ const self: RuleMeta = {
 };
 export const name = self.name;
 
-export const check: RuleCheckFunction = async sr => {
-    const groups = await sr.getDelivererIDs();
-    const editors = sr.extractHeaders()?.Editor;
+export const check: RuleCheckFunction = async context => {
+    const groups = await context.getDelivererIDs();
+    const editors = context.extractHeaders()?.Editor;
     const editorsToCheck = [];
     if (editors) {
         // only check editors elements that don't have a span with class "former"
         for (const dd of editors.$dd.toArray()) {
-            const $former = sr.$(dd).find('span.former').first();
-            if (!$former.length || !sr.norm($former.text())) {
+            const $former = context.$(dd).find('span.former').first();
+            if (!$former.length || !context.norm($former.text())) {
                 if (dd.attribs['data-editor-id'])
                     editorsToCheck.push(
                         parseInt(dd.attribs['data-editor-id'], 10)
@@ -49,7 +49,7 @@ export const check: RuleCheckFunction = async sr => {
 
     editorsToCheck.forEach(id => {
         if (!userIds.includes(id)) {
-            sr.error(self, 'not-participating', { id });
+            context.error(self, 'not-participating', { id });
         }
     });
 };

--- a/lib/rules/headers/errata.ts
+++ b/lib/rules/headers/errata.ts
@@ -1,7 +1,7 @@
 // errata, right after dl
 
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 
 const self: RuleMeta = {
     name: 'headers.errata',

--- a/lib/rules/headers/errata.ts
+++ b/lib/rules/headers/errata.ts
@@ -12,18 +12,18 @@ const self: RuleMeta = {
 export const { name } = self;
 
 // Check if document is Recommendation, and uses inline changes(REC with Candidate/Proposed changes)
-function isRECWithChanges(sr: RuleContext) {
-    if (sr.config!.status !== 'REC') return false;
+function isRECWithChanges(context: RuleContext) {
+    if (context.config!.status !== 'REC') return false;
 
-    const recMeta = sr.getRecMetadata();
+    const recMeta = context.getRecMetadata();
     return Object.values(recMeta).length !== 0;
 }
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     // for REC with Candidate/Proposed changes, no need to check errata link
-    if (isRECWithChanges(sr)) return;
+    if (isRECWithChanges(context)) return;
 
-    const dts = sr.extractHeaders();
+    const dts = context.extractHeaders();
     // Check 'Errata:' exist, don't check any further.
-    if (!dts.Errata) sr.error(self, 'no-errata');
+    if (!dts.Errata) context.error(self, 'no-errata');
 };

--- a/lib/rules/headers/errata.ts
+++ b/lib/rules/headers/errata.ts
@@ -1,7 +1,7 @@
 // errata, right after dl
 
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 
 const self: RuleMeta = {
     name: 'headers.errata',
@@ -12,7 +12,7 @@ const self: RuleMeta = {
 export const { name } = self;
 
 // Check if document is Recommendation, and uses inline changes(REC with Candidate/Proposed changes)
-function isRECWithChanges(sr: Specberus) {
+function isRECWithChanges(sr: RuleContext) {
     if (sr.config!.status !== 'REC') return false;
 
     const recMeta = sr.getRecMetadata();

--- a/lib/rules/headers/github-repo.ts
+++ b/lib/rules/headers/github-repo.ts
@@ -12,16 +12,16 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const dts = sr.extractHeaders();
+export const check: RuleCheckFunction = context => {
+    const dts = context.extractHeaders();
     if (!dts.Feedback) {
-        sr.error(self, 'no-feedback');
+        context.error(self, 'no-feedback');
         return;
     }
 
     // Check 'github repo' exist in 'Feedback:'
     const foundRepo = dts.Feedback.$dd.toArray().some(feedbackEl => {
-        const links = sr
+        const links = context
             .$(feedbackEl)
             .find('a[href]')
             .toArray()
@@ -37,5 +37,5 @@ export const check: RuleCheckFunction = sr => {
         //     href
         // );
     });
-    if (!foundRepo) sr.error(self, 'no-repo');
+    if (!foundRepo) context.error(self, 'no-repo');
 };

--- a/lib/rules/headers/h1-title.ts
+++ b/lib/rules/headers/h1-title.ts
@@ -10,16 +10,16 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $title = sr.$('head > title').first();
-    const $h1 = sr.$('body div.head h1').first();
+export const check: RuleCheckFunction = context => {
+    const $title = context.$('head > title').first();
+    const $h1 = context.$('body div.head h1').first();
     if (!$title.length || !$h1.length) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
     } else {
-        const titleText = sr.norm($title.text());
+        const titleText = context.norm($title.text());
         $h1.html($h1.html()!.replace(/:<br>/g, ': ').replace(/<br>/g, ' - '));
-        const h1Text = sr.norm($h1.text());
+        const h1Text = context.norm($h1.text());
         if (titleText !== h1Text)
-            sr.error(self, 'not-match', { titleText, h1Text });
+            context.error(self, 'not-match', { titleText, h1Text });
     }
 };

--- a/lib/rules/headers/h2-toc.ts
+++ b/lib/rules/headers/h2-toc.ts
@@ -14,26 +14,27 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const EXPECTED_HEADING = /^table\s+of\s+contents$/i;
-    const $tocNav = sr.$('nav#toc > h2');
-    const $tocDiv = sr.$('div#toc > h2');
+    const $tocNav = context.$('nav#toc > h2');
+    const $tocDiv = context.$('div#toc > h2');
     let $toc;
 
     if ($tocDiv.length > 0) {
-        if ($tocNav.length > 0) sr.error(self, 'mixed');
+        if ($tocNav.length > 0) context.error(self, 'mixed');
         else {
-            sr.warning(self, 'not-html5');
+            context.warning(self, 'not-html5');
             $toc = $tocDiv;
         }
     } else if ($tocNav.length > 0) $toc = $tocNav;
-    else sr.error(self, 'not-found');
+    else context.error(self, 'not-found');
     if ($toc && $toc.length > 0) {
         let matches = 0;
         $toc.each((_, el) => {
-            if (EXPECTED_HEADING.test(sr.norm(sr.$(el).text()))) matches += 1;
+            if (EXPECTED_HEADING.test(context.norm(context.$(el).text())))
+                matches += 1;
         });
-        if (matches > 1) sr.error(self, 'too-many');
-        else if (matches === 0) sr.error(self, 'not-found');
+        if (matches > 1) context.error(self, 'too-many');
+        else if (matches === 0) context.error(self, 'not-found');
     }
 };

--- a/lib/rules/headers/hr.ts
+++ b/lib/rules/headers/hr.ts
@@ -8,12 +8,13 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const hasHrLastChild = sr.$('body div.head > hr:last-child').length === 1;
-    const hasHrNextSibling = sr.$('body div.head + hr').length === 1;
+export const check: RuleCheckFunction = context => {
+    const hasHrLastChild =
+        context.$('body div.head > hr:last-child').length === 1;
+    const hasHrNextSibling = context.$('body div.head + hr').length === 1;
     if (hasHrLastChild && hasHrNextSibling) {
-        sr.error(self, 'duplicate');
+        context.error(self, 'duplicate');
     } else if (!hasHrLastChild && !hasHrNextSibling) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
     }
 };

--- a/lib/rules/headers/logo.ts
+++ b/lib/rules/headers/logo.ts
@@ -8,8 +8,10 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $logo = sr.$("body div.head a[href] > img[src][alt='W3C']").first();
+export const check: RuleCheckFunction = context => {
+    const $logo = context
+        .$("body div.head a[href] > img[src][alt='W3C']")
+        .first();
     if (
         !$logo.length ||
         !/^(https:)?\/\/www\.w3\.org\/StyleSheets\/TR\/2021\/logos\/W3C?$/.test(
@@ -19,6 +21,6 @@ export const check: RuleCheckFunction = sr => {
             $logo.parent().attr('href') || ''
         )
     ) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
     }
 };

--- a/lib/rules/headers/memsub-copyright.ts
+++ b/lib/rules/headers/memsub-copyright.ts
@@ -6,8 +6,8 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $copyright = sr.$('body div.head p.copyright').first();
+export const check: RuleCheckFunction = context => {
+    const $copyright = context.$('body div.head p.copyright').first();
     if ($copyright.length) {
         // ,   "https://www.w3.org/copyright/document-license/":           "document use"
         const seen = $copyright
@@ -19,6 +19,6 @@ export const check: RuleCheckFunction = sr => {
                         'https://www.w3.org/copyright/document-license/'
                     ) === 0
             );
-        if (!seen) sr.error(self, 'not-found');
-    } else sr.error(self, 'not-found');
+        if (!seen) context.error(self, 'not-found');
+    } else context.error(self, 'not-found');
 };

--- a/lib/rules/headers/ol-toc.ts
+++ b/lib/rules/headers/ol-toc.ts
@@ -13,8 +13,8 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $toc = sr.$('nav#toc ol.toc, div#toc ol.toc');
+export const check: RuleCheckFunction = context => {
+    const $toc = context.$('nav#toc ol.toc, div#toc ol.toc');
 
-    if (!$toc.length) sr.warning(self, 'not-found');
+    if (!$toc.length) context.warning(self, 'not-found');
 };

--- a/lib/rules/headers/secno.ts
+++ b/lib/rules/headers/secno.ts
@@ -10,12 +10,12 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     // TODO: once supported, use: ":is(h2, h3, h4, h5, h6) :is(bdi.secno,span.secno)"
-    const $secnos = sr.$(
+    const $secnos = context.$(
         'h1 span.secno, h2 span.secno, h3 span.secno, h4 span.secno, h5 span.secno, h6 span.secno, #toc span.secno,' +
             'h1 bdi.secno, h2 bdi.secno, h3 bdi.secno, h4 bdi.secno, h5 bdi.secno, h6 bdi.secno, #toc bdi.secno'
     );
 
-    if (!$secnos.length) sr.warning(self, 'not-found');
+    if (!$secnos.length) context.warning(self, 'not-found');
 };

--- a/lib/rules/headers/shortname.ts
+++ b/lib/rules/headers/shortname.ts
@@ -22,12 +22,12 @@ const historyError: RuleMeta = {
 };
 export const name = self.name;
 
-export const check: RuleCheckFunction = async sr => {
+export const check: RuleCheckFunction = async context => {
     let topLevel = 'TR';
 
-    if (sr.config!.submissionType === 'member') topLevel = 'submissions';
+    if (context.config!.submissionType === 'member') topLevel = 'submissions';
 
-    const dts = sr.extractHeaders();
+    const dts = context.extractHeaders();
 
     let shortname = '';
     let seriesShortname = '';
@@ -37,7 +37,7 @@ export const check: RuleCheckFunction = async sr => {
 
         if ($linkThis.attr('href')) {
             const vThisRex = `^https:\\/\\/www\\.w3\\.org\\/${topLevel}\\/(\\d{4})\\/${
-                sr.config!.status || '[A-Z]+'
+                context.config!.status || '[A-Z]+'
             }-(.+)-(\\d{4})(\\d\\d)(\\d\\d)\\/?$`;
             const matches = ($linkThis.attr('href') || '')
                 .trim()
@@ -57,9 +57,11 @@ export const check: RuleCheckFunction = async sr => {
                         .find('a')
                         .first()
                         .attr('data-previous-shortname');
-                const needLowercase = shortnameChange || (await sr.isFP());
+                const needLowercase = shortnameChange || (await context.isFP());
                 if (needLowercase && shortname.toLowerCase() !== shortname)
-                    sr.error(thisError, 'shortname-lowercase', { shortname });
+                    context.error(thisError, 'shortname-lowercase', {
+                        shortname,
+                    });
             }
         }
     }
@@ -77,7 +79,7 @@ export const check: RuleCheckFunction = async sr => {
                 sn = matches[1];
                 // latest version link mention either shortlink or the series shortlink
                 if (sn !== shortname && sn !== seriesShortname)
-                    sr.error(self, 'this-latest-shortname', {
+                    context.error(self, 'this-latest-shortname', {
                         thisShortname: shortname,
                         latestShortname: sn,
                     });
@@ -97,7 +99,9 @@ export const check: RuleCheckFunction = async sr => {
             if (matches) {
                 const [, historyShortname] = matches;
                 if (historyShortname !== shortname) {
-                    sr.error(historyError, 'history-syntax', { shortname });
+                    context.error(historyError, 'history-syntax', {
+                        shortname,
+                    });
                 } else {
                     // Check if the history link exist
                     let historyStatusCode;
@@ -107,7 +111,7 @@ export const check: RuleCheckFunction = async sr => {
                     } catch (err) {
                         historyStatusCode = err.status;
                     }
-                    var hasPreviousVersion = !(await sr.isFP());
+                    var hasPreviousVersion = !(await context.isFP());
                     if (hasPreviousVersion && historyStatusCode === 404) {
                         // it's a none FP spec, but the history page doesn't exist. There should be a 'valid' previous-shortname.
                         const previousShortname = $linkHistory.attr(
@@ -115,7 +119,7 @@ export const check: RuleCheckFunction = async sr => {
                         );
                         if (previousShortname) {
                             // prettier-ignore
-                            sr.warning(historyError, 'this-previous-shortname',
+                            context.warning(historyError, 'this-previous-shortname',
                                 {
                                     previousShortname,
                                     thisShortname: shortname,
@@ -134,10 +138,14 @@ export const check: RuleCheckFunction = async sr => {
                             }
 
                             if (previousHistoryStatusCode === 404) {
-                                sr.error(historyError, 'history-bad-previous', {
-                                    previousShortname,
-                                    url: previousHistoryHref,
-                                });
+                                context.error(
+                                    historyError,
+                                    'history-bad-previous',
+                                    {
+                                        previousShortname,
+                                        url: previousHistoryHref,
+                                    }
+                                );
                             }
                         }
                     }
@@ -159,7 +167,7 @@ export const check: RuleCheckFunction = async sr => {
             if (matches) {
                 sn = matches[1];
                 if (sn !== shortname)
-                    sr.error(self, 'this-rescinds-shortname', {
+                    context.error(self, 'this-rescinds-shortname', {
                         rescindsShortname: sn,
                         thisShortname: shortname,
                     });
@@ -168,26 +176,26 @@ export const check: RuleCheckFunction = async sr => {
     }
 
     // check shortname is valid.
-    const isFP = await sr.isFP();
+    const isFP = await context.isFP();
     // FP documents cannot use existing shortname
     if (
-        sr.config!.longStatus === 'First Public Working Draft' &&
+        context.config!.longStatus === 'First Public Working Draft' &&
         !isFP &&
         shortname
     ) {
-        sr.error(self, 'shortname-existed');
+        context.error(self, 'shortname-existed');
     }
 
     // non-initial state documents should use existing shortname
     // TODO: Registry and Note track?
     if (
-        sr.config!.track === 'Recommendation' &&
-        sr.config!.longStatus !== 'First Public Working Draft' &&
+        context.config!.track === 'Recommendation' &&
+        context.config!.longStatus !== 'First Public Working Draft' &&
         isFP &&
         shortname
     ) {
-        sr.error(self, 'shortname-not-existed', {
-            status: sr.config!.longStatus,
+        context.error(self, 'shortname-not-existed', {
+            status: context.config!.longStatus,
         });
     }
 };

--- a/lib/rules/headers/subm-logo.ts
+++ b/lib/rules/headers/subm-logo.ts
@@ -6,11 +6,11 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $logo = sr
+export const check: RuleCheckFunction = context => {
+    const $logo = context
         .$("body div.head a[href] > img[src][height='48'][width='211'][alt]")
         .first();
-    const type = sr.config!.submissionType || 'member';
+    const type = context.config!.submissionType || 'member';
     const checks = {
         member: {
             alt: 'W3C Member Submission',
@@ -24,7 +24,7 @@ export const check: RuleCheckFunction = sr => {
         !checks[type].src.test($logo.attr('src') || '') ||
         !checks[type].href.test($logo.parent().attr('href') || '')
     ) {
-        sr.error(self, 'not-found', {
+        context.error(self, 'not-found', {
             type: type.charAt(0).toUpperCase() + type.slice(1),
         });
     }

--- a/lib/rules/headers/translation.ts
+++ b/lib/rules/headers/translation.ts
@@ -8,27 +8,31 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const translationLink = sr
+export const check: RuleCheckFunction = context => {
+    const translationLink = context
         .$('body div.head a')
         .toArray()
         .find(link => {
-            return sr.$(link).text().toLowerCase().includes('translations');
+            return context
+                .$(link)
+                .text()
+                .toLowerCase()
+                .includes('translations');
         });
 
     if (!translationLink) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
         return;
     }
 
     const href = translationLink.attribs.href;
-    sr.info(self, 'found', { link: href });
+    context.info(self, 'found', { link: href });
     if (
-        !sr
+        !context
             .norm(href)
             .toLowerCase()
             .startsWith('https://www.w3.org/translations/')
     ) {
-        sr.warning(self, 'not-recommended-link');
+        context.warning(self, 'not-recommended-link');
     }
 };

--- a/lib/rules/headers/w3c-state.ts
+++ b/lib/rules/headers/w3c-state.ts
@@ -9,24 +9,24 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const config = sr.config!;
+export const check: RuleCheckFunction = context => {
+    const config = context.config!;
     let profileFound = false;
 
     if (config.longStatus) return;
-    const $stateEl = sr.getDocumentStateElement();
+    const $stateEl = context.getDocumentStateElement();
     if (!$stateEl) {
-        sr.error(self, 'no-w3c-state');
+        context.error(self, 'no-w3c-state');
         return;
     }
-    const txt = sr.norm($stateEl.text());
+    const txt = context.norm($stateEl.text());
     // crType/cryType: Add 'Draft', 'Snapshot' suffix to title.
     const docTitle =
         config.longStatus +
         (config.crType ? ` ${config.crType}` : '') +
         (config.cryType ? ` ${config.cryType}` : '');
     if (!txt.startsWith(`W3C ${docTitle}`)) {
-        sr.error(self, 'bad-w3c-state');
+        context.error(self, 'bad-w3c-state');
     }
 
     for (const { profiles } of Object.values(rules))
@@ -39,7 +39,7 @@ export const check: RuleCheckFunction = sr => {
                 }
             }
 
-    if (!profileFound) sr.error(self, 'bad-w3c-state');
+    if (!profileFound) context.error(self, 'bad-w3c-state');
     else {
         // check the profile link
         const $standardLink = $stateEl.find('a').first();
@@ -52,12 +52,12 @@ export const check: RuleCheckFunction = sr => {
             `https://www.w3.org/standards/types/?#${hash}`
         );
         if (!$standardLink.length) {
-            sr.error(self, 'no-w3c-state-link');
+            context.error(self, 'no-w3c-state-link');
         } else if (!expectedLink.test($standardLink.attr('href') || '')) {
-            sr.error(self, 'wrong-w3c-state-link', {
+            context.error(self, 'wrong-w3c-state-link', {
                 hash,
                 linkFound: $standardLink.attr('href'),
-                text: sr.norm($standardLink.text()),
+                text: context.norm($standardLink.text()),
             });
         }
     }

--- a/lib/rules/heuristic/date-format.ts
+++ b/lib/rules/heuristic/date-format.ts
@@ -1,5 +1,5 @@
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import { possibleMonths } from '../../validator.js';
+import { possibleMonths } from '../../rule-context.js';
 
 const self: RuleMeta = {
     name: 'heuristic.date-format',

--- a/lib/rules/heuristic/date-format.ts
+++ b/lib/rules/heuristic/date-format.ts
@@ -9,7 +9,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     // Pseudo-constants:
     const POSSIBLE_DATE = new RegExp(
         `\\b([0123]?\\d|${possibleMonths})[\\ \\-\\/–—]([0123]?\\d|${possibleMonths})[\\ \\-\\/–—]([\\'‘’]?\\d{2})(\\d\\d)?\\b`,
@@ -20,7 +20,10 @@ export const check: RuleCheckFunction = sr => {
         'i'
     );
 
-    const boilerplateSections = [sr.$('div.head').first(), sr.getSotDSection()];
+    const boilerplateSections = [
+        context.$('div.head').first(),
+        context.getSotDSection(),
+    ];
     const candidateDates: string[] = [];
 
     for (const $section of boilerplateSections) {
@@ -35,7 +38,7 @@ export const check: RuleCheckFunction = sr => {
 
     for (const date of candidateDates) {
         if (!date.match(EXPECTED_DATE_FORMAT)) {
-            sr.error(self, 'wrong', { text: date });
+            context.error(self, 'wrong', { text: date });
         }
     }
 };

--- a/lib/rules/links/compound.ts
+++ b/lib/rules/links/compound.ts
@@ -9,19 +9,19 @@ const TIMEOUT = 10000;
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const { validation } = sr.config!;
-    const url = sr.url!;
+export const check: RuleCheckFunction = context => {
+    const { validation } = context.config!;
+    const url = context.url!;
 
     if (validation !== 'recursive') {
-        sr.warning(self, 'skipped');
+        context.warning(self, 'skipped');
         return;
     }
 
     let links: string[] = [];
 
     if (url) {
-        sr.$('a[href]').each((_, el) => {
+        context.$('a[href]').each((_, el) => {
             const u = new URL(el.attribs.href, url);
             const l = u.origin + u.pathname;
             if (l.startsWith(url) && l !== url) links.push(l);
@@ -35,12 +35,12 @@ export const check: RuleCheckFunction = sr => {
     const markupService = 'https://validator.w3.org/nu/';
     return Promise.all(
         links.map(l => {
-            const ua = `W3C-Pubrules/${sr.version}`;
+            const ua = `W3C-Pubrules/${context.version}`;
             const req = get(markupService)
                 .set('User-Agent', ua)
                 .query({ doc: l, out: 'json' })
                 .on('error', err => {
-                    sr.error(self, 'error', {
+                    context.error(self, 'error', {
                         file: l.split('/').pop(),
                         link: l,
                         errMsg: err,
@@ -60,13 +60,13 @@ export const check: RuleCheckFunction = sr => {
                             (msg: { type: string }) => msg.type === 'error'
                         ) || [];
                     if (errors.length === 0) {
-                        sr.info(self, 'link', {
+                        context.info(self, 'link', {
                             file: l.split('/').pop(),
                             link: l,
                             markup: '\u2714',
                         });
                     } else {
-                        sr.error(self, 'link', {
+                        context.error(self, 'link', {
                             file: l.split('/').pop(),
                             link: l,
                             markup: '\u2718',
@@ -74,7 +74,7 @@ export const check: RuleCheckFunction = sr => {
                     }
                 },
                 (err: ResponseError) => {
-                    if (err.timeout) sr.warning(self, 'html-timeout');
+                    if (err.timeout) context.warning(self, 'html-timeout');
                     else
                         throw new Error(`HTML validator error: ${err.message}`);
                 }

--- a/lib/rules/links/internal.ts
+++ b/lib/rules/links/internal.ts
@@ -8,13 +8,13 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    sr.$("a[href^='#']").each((_, el) => {
+export const check: RuleCheckFunction = context => {
+    context.$("a[href^='#']").each((_, el) => {
         const id = el.attribs.href.replace('#', '');
         const escId = id.replace(/([.()#:[\]+*])/g, '\\$1');
         if (id === '') return;
-        if (!sr.$(`#${escId}, a[name='${id}']`).length) {
-            sr.error(self, 'anchor', { id });
+        if (!context.$(`#${escId}, a[name='${id}']`).length) {
+            context.error(self, 'anchor', { id });
         }
     });
 };

--- a/lib/rules/links/linkchecker.ts
+++ b/lib/rules/links/linkchecker.ts
@@ -53,13 +53,13 @@ function includedByReg(url: string, regArray = allowList) {
     );
 }
 
-export const check: RuleCheckFunction = async sr => {
+export const check: RuleCheckFunction = async context => {
     // send out warning for /nu W3C link checker.
-    sr.warning(self, 'display', { link: sr.url });
+    context.warning(self, 'display', { link: context.url });
 
-    if (!sr.url) return;
+    if (!context.url) return;
 
-    // sr.url is used as base url. Every other resource should use in same folder as base. e.g.
+    // context.url is used as base url. Every other resource should use in same folder as base. e.g.
     // - spec doc: https://www.w3.org/TR/2021/WD-pubrules-20210401/
     // - image (pass): https://www.w3.org/TR/2021/WD-pubrules-20210401/images/sample.png
     // - image (pass): https://www.w3.org/TR/2021/WD-pubrules-20210401/sample.png
@@ -69,8 +69,10 @@ export const check: RuleCheckFunction = async sr => {
         args: ['--disable-gpu'],
     });
     const page = await browser.newPage();
-    const docPath = sr.url.replace(/\/[^/]+$/, '/').replace(/^https?:/, '');
-    const origin = new URL(sr.url).origin;
+    const docPath = context.url
+        .replace(/\/[^/]+$/, '/')
+        .replace(/^https?:/, '');
+    const origin = new URL(context.url).origin;
 
     page.on('response', response => {
         const url = simplifyURL(response.url());
@@ -81,9 +83,12 @@ export const check: RuleCheckFunction = async sr => {
             if (
                 !url.replace(/^https?:/, '').startsWith(docPath) &&
                 !(includedByReg(url) || includedByReg(referer)) &&
-                url !== sr.url
+                url !== context.url
             ) {
-                sr.error(compound, 'not-same-folder', { base: docPath, url });
+                context.error(compound, 'not-same-folder', {
+                    base: docPath,
+                    url,
+                });
             }
 
             // check if every resource's status code is ok, ignore 3xx
@@ -91,7 +96,7 @@ export const check: RuleCheckFunction = async sr => {
                 const chain = response.request().redirectChain();
                 // If an url is redirected from another, chain shall exist
                 if (chain.length) {
-                    sr.error(compound, 'response-error-with-redirect', {
+                    context.error(compound, 'response-error-with-redirect', {
                         url,
                         originUrl: chain[0].url(),
                         status: response.status(),
@@ -99,7 +104,7 @@ export const check: RuleCheckFunction = async sr => {
                         referer,
                     });
                 } else {
-                    sr.error(compound, 'response-error', {
+                    context.error(compound, 'response-error', {
                         url,
                         status: response.status(),
                         text: response.statusText(),
@@ -110,7 +115,7 @@ export const check: RuleCheckFunction = async sr => {
         }
     });
 
-    await page.goto(sr.url, { waitUntil: 'load', timeout: 60000 });
+    await page.goto(context.url, { waitUntil: 'load', timeout: 60000 });
 
     await browser.close();
 };

--- a/lib/rules/links/reliability.ts
+++ b/lib/rules/links/reliability.ts
@@ -20,15 +20,15 @@ const unreliableServices = [
     // { domain: 'w3.org', path: /track(er)?\/(actions|issues|resolutions)/}
 ];
 
-export const check: RuleCheckFunction = sr => {
-    sr.$('a').each((_, el) => {
-        const $el = sr.$(el);
+export const check: RuleCheckFunction = context => {
+    context.$('a').each((_, el) => {
+        const $el = context.$(el);
         const href = $el.attr('href');
         if (!href) return;
 
         let url;
         try {
-            url = new URL(href, sr.url || 'https://www.w3.org');
+            url = new URL(href, context.url || 'https://www.w3.org');
         } catch (e) {
             // when failed to parse URL, move on to next one.
             return;
@@ -44,9 +44,9 @@ export const check: RuleCheckFunction = sr => {
                     (unreliableService.path &&
                         unreliableService.path.test(path)))
             ) {
-                sr.warning(self, 'unreliable-link', {
+                context.warning(self, 'unreliable-link', {
                     link: href,
-                    text: sr.norm($el.text()),
+                    text: context.norm($el.text()),
                 });
                 // when finding this URL unreliable, quit 'unreliableServices.some'
                 return true;

--- a/lib/rules/metadata/abstract.ts
+++ b/lib/rules/metadata/abstract.ts
@@ -7,16 +7,20 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'metadata.abstract';
 
-export const check: RuleCheckFunction<{ abstract: string }> = sr => {
-    const abstractHeadingEl = sr
+export const check: RuleCheckFunction<{ abstract: string }> = context => {
+    const abstractHeadingEl = context
         .$('h2')
         .toArray()
-        .find(el => sr.norm(sr.$(el).text()).toLowerCase() === 'abstract');
+        .find(
+            el =>
+                context.norm(context.$(el).text()).toLowerCase() === 'abstract'
+        );
 
     if (!abstractHeadingEl) return { abstract: 'Not found' };
 
     const $div = load('<div></div>', null, false)('div');
-    sr.$(abstractHeadingEl)
+    context
+        .$(abstractHeadingEl)
         .parent()
         .children()
         .each((_, child) => {
@@ -25,5 +29,5 @@ export const check: RuleCheckFunction<{ abstract: string }> = sr => {
                     $div.append(child.cloneNode(true));
             }
         });
-    return { abstract: sr.norm($div.html()!) };
+    return { abstract: context.norm($div.html()!) };
 };

--- a/lib/rules/metadata/charters.ts
+++ b/lib/rules/metadata/charters.ts
@@ -10,4 +10,4 @@ export const name = 'metadata.charters';
 
 export const check: RuleCheckFunction<{
     charters: string[];
-}> = async sr => ({ charters: await sr.getCharters() });
+}> = async context => ({ charters: await context.getCharters() });

--- a/lib/rules/metadata/deliverers.ts
+++ b/lib/rules/metadata/deliverers.ts
@@ -7,10 +7,6 @@ import type { RuleCheckFunction } from '../../types.js';
 // 'self.name' would be 'metadata.deliverers'
 export const name = 'metadata.deliverers';
 
-/**
- * @param sr
- * @param done
- */
 export const check: RuleCheckFunction<{
     delivererIDs: number[];
-}> = async sr => ({ delivererIDs: await sr.getDelivererIDs() });
+}> = async context => ({ delivererIDs: await context.getDelivererIDs() });

--- a/lib/rules/metadata/dl.ts
+++ b/lib/rules/metadata/dl.ts
@@ -23,8 +23,8 @@ interface DlMetadata {
     updated?: boolean;
 }
 
-export const check: RuleCheckFunction<DlMetadata> = async sr => {
-    const dts = sr.extractHeaders();
+export const check: RuleCheckFunction<DlMetadata> = async context => {
+    const dts = context.extractHeaders();
     const result: DlMetadata = {};
     let shortname;
     let previousShortname;
@@ -34,7 +34,7 @@ export const check: RuleCheckFunction<DlMetadata> = async sr => {
     const thisHref = $linkThis?.attr('href')?.trim();
     if (thisHref) {
         result.thisVersion = thisHref;
-        shortname = await sr.getShortname();
+        shortname = await context.getShortname();
     }
 
     const $linkLate = dts.Latest ? dts.Latest.$dd.find('a').first() : null;
@@ -48,7 +48,7 @@ export const check: RuleCheckFunction<DlMetadata> = async sr => {
             if (latestShortname !== shortname) {
                 result.latestVersion = `https://www.w3.org/TR/${shortname}/`;
             }
-        } else sr.error(latestRule, 'latest-not-found');
+        } else context.error(latestRule, 'latest-not-found');
     }
 
     const $linkHistory = dts.History ? dts.History.$dd.find('a').first() : null;
@@ -56,7 +56,7 @@ export const check: RuleCheckFunction<DlMetadata> = async sr => {
 
     if ($linkHistory && historyHref) {
         result.history = historyHref;
-        result.previousVersion = await sr.getPreviousVersion();
+        result.previousVersion = await context.getPreviousVersion();
         previousShortname = $linkHistory.attr('data-previous-shortname');
     }
 
@@ -70,8 +70,8 @@ export const check: RuleCheckFunction<DlMetadata> = async sr => {
     }
 
     // check same day publications
-    const ua = `W3C-Pubrules/${sr.version}`;
-    const docDate = sr.getDocumentDate();
+    const ua = `W3C-Pubrules/${context.version}`;
+    const docDate = context.getDocumentDate();
     if (docDate) {
         const year = docDate.getFullYear();
         const month = (docDate.getMonth() + 1).toString();

--- a/lib/rules/metadata/docDate.ts
+++ b/lib/rules/metadata/docDate.ts
@@ -11,8 +11,8 @@ interface DocDateMetadata {
     docDate: `${number}-${number}-${number}`;
 }
 
-export const check: RuleCheckFunction<DocDateMetadata | void> = sr => {
-    const docDate = sr.getDocumentDate();
+export const check: RuleCheckFunction<DocDateMetadata | void> = context => {
+    const docDate = context.getDocumentDate();
     if (docDate)
         return {
             docDate: `${docDate.getFullYear()}-${docDate.getMonth() + 1}-${docDate.getDate()}`,

--- a/lib/rules/metadata/editor-ids.ts
+++ b/lib/rules/metadata/editor-ids.ts
@@ -18,8 +18,8 @@ interface EditorIDsMetadata {
     editorIDs: number[];
 }
 
-export const check: RuleCheckFunction<EditorIDsMetadata> = async sr => {
-    const dts = sr.extractHeaders();
+export const check: RuleCheckFunction<EditorIDsMetadata> = async context => {
+    const dts = context.extractHeaders();
     const editorIds: number[] = [];
     const unresolvedUsernames = [];
     if (dts.Editor) {
@@ -36,7 +36,7 @@ export const check: RuleCheckFunction<EditorIDsMetadata> = async sr => {
                         if (id) editorIds.push(id);
                         else unresolvedUsernames.push(editorGithub);
                     } catch (error) {
-                        sr.error(self, 'editor-github-failed', {
+                        context.error(self, 'editor-github-failed', {
                             name: error.cause,
                         });
                     }
@@ -44,7 +44,7 @@ export const check: RuleCheckFunction<EditorIDsMetadata> = async sr => {
             }
         }
         if (unresolvedUsernames.length) {
-            sr.error(self, 'editor-github-unresolvable', {
+            context.error(self, 'editor-github-unresolvable', {
                 names: unresolvedUsernames,
             });
         }

--- a/lib/rules/metadata/editor-names.ts
+++ b/lib/rules/metadata/editor-names.ts
@@ -11,12 +11,12 @@ interface EditorNamesMetadata {
     editorNames: string[];
 }
 
-export const check: RuleCheckFunction<EditorNamesMetadata> = sr => {
-    const dts = sr.extractHeaders();
+export const check: RuleCheckFunction<EditorNamesMetadata> = context => {
+    const dts = context.extractHeaders();
     const editorNames: string[] = [];
     if (dts.Editor) {
         dts.Editor.$dd.each((_, el) => {
-            const editor = sr
+            const editor = context
                 .$(el)
                 .text()
                 .trim()

--- a/lib/rules/metadata/errata.ts
+++ b/lib/rules/metadata/errata.ts
@@ -12,12 +12,12 @@ interface ErrataMetadata {
     errata: string;
 }
 
-export const check: RuleCheckFunction<ErrataMetadata | void> = sr => {
+export const check: RuleCheckFunction<ErrataMetadata | void> = context => {
     const errataRegex = /errata/i;
-    const $links = sr.$('body div.head details + p > a');
+    const $links = context.$('body div.head details + p > a');
     const errata = $links
         .toArray()
-        .filter(el => errataRegex.test(sr.$(el).text()));
+        .filter(el => errataRegex.test(context.$(el).text()));
     if (errata.length && errata[0].attribs.href)
         return { errata: errata[0].attribs.href };
 };

--- a/lib/rules/metadata/informative.ts
+++ b/lib/rules/metadata/informative.ts
@@ -11,13 +11,13 @@ interface InformativeMetadata {
     informative: boolean;
 }
 
-export const check: RuleCheckFunction<InformativeMetadata | void> = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction<InformativeMetadata | void> = context => {
+    const $sotd = context.getSotDSection();
     const expected = /This\s+document\s+is\s+informative\s+only\./;
     if (!$sotd) return;
 
-    const $stateEl = sr.getDocumentStateElement();
-    const candidate = $stateEl && sr.norm($stateEl.text()).toLowerCase();
+    const $stateEl = context.getDocumentStateElement();
+    const candidate = $stateEl && context.norm($stateEl.text()).toLowerCase();
     const isInformative = !!candidate && candidate.indexOf('group note') !== -1;
 
     return {

--- a/lib/rules/metadata/process.ts
+++ b/lib/rules/metadata/process.ts
@@ -16,8 +16,8 @@ interface ProcessMetadata {
     process: string;
 }
 
-export const check: RuleCheckFunction<ProcessMetadata | void> = sr => {
-    const $processDocument = sr.$('a#w3c_process_revision').first();
+export const check: RuleCheckFunction<ProcessMetadata | void> = context => {
+    const $processDocument = context.$('a#w3c_process_revision').first();
     const processDocumentHref =
         $processDocument.length && $processDocument.attr('href');
 

--- a/lib/rules/metadata/profile.ts
+++ b/lib/rules/metadata/profile.ts
@@ -15,7 +15,7 @@ import rules from '../../rules-track.js';
 // 'self.name' would be 'metadata.profile'
 export const name = 'metadata.profile';
 
-export const check: RuleCheckFunction<RecMetadata> = async sr => {
+export const check: RuleCheckFunction<RecMetadata> = async context => {
     let matchedLength = 0;
     let id;
     let $profileEl: Cheerio<Element> | undefined;
@@ -25,13 +25,13 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
         CRY: 'cryFeedbackDue',
     } as const;
 
-    const $stateEl = sr.getDocumentStateElement();
+    const $stateEl = context.getDocumentStateElement();
     if (!$stateEl) {
         throw new Error(
             'Cannot find the <code>&lt;p id="w3c-state"&gt;</code> element for profile and date.<br><br>Please make sure the <code>&lt;p id="w3c-state"&gt;<a href="https://www.w3.org/standards/types#@@Profile">W3C @@Profile</a>, DD Month Year&lt;/p&gt;</code> element can be selected by <code>document.getElementById(\'w3c-state\')</code>; <br>If you are using bikeshed, please update to the latest version.'
         );
     }
-    const candidate = $stateEl && sr.norm($stateEl.text()).toLowerCase();
+    const candidate = $stateEl && context.norm($stateEl.text()).toLowerCase();
     if (candidate) {
         for (const { profiles } of Object.values(rules)) {
             for (const [p, profile] of Object.entries(profiles)) {
@@ -51,7 +51,7 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
     function assembleMeta(id: string) {
         let meta: RecMetadata = { profile: id };
         if (id in reviewStatus) {
-            const dueDate = sr.getFeedbackDueDate();
+            const dueDate = context.getFeedbackDueDate();
             const dates = dueDate && dueDate.valid;
             let res = dates[0];
             if (dates.length === 0 || !res) return { profile: id };
@@ -63,7 +63,7 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
         }
         // implementation report
         if (['CR', 'CRD', 'PR', 'REC'].includes(id)) {
-            const dts = sr.extractHeaders();
+            const dts = context.extractHeaders();
             if (dts.Implementation?.$dd?.find('a').length) {
                 meta.implementationReport = dts.Implementation.$dd
                     .find('a')
@@ -72,7 +72,7 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
             }
         }
         if (id === 'REC') {
-            meta = sr.getRecMetadata(meta);
+            meta = context.getRecMetadata(meta);
         }
 
         // Get 'track/rectrack' of the document based on id
@@ -95,9 +95,11 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
     function checkRecType() {
         if (
             $profileEl &&
-            sr.norm($profileEl.text()).indexOf('Candidate Recommendation') > 0
+            context
+                .norm($profileEl.text())
+                .indexOf('Candidate Recommendation') > 0
         ) {
-            return sr.norm($profileEl.text()).indexOf('Draft') > 0
+            return context.norm($profileEl.text()).indexOf('Draft') > 0
                 ? 'CRD'
                 : 'CR';
         }
@@ -114,19 +116,19 @@ export const check: RuleCheckFunction<RecMetadata> = async sr => {
         if (id === 'CRY') {
             // distinguish CRY CRYD
             id =
-                sr.norm($profileEl?.text() || '').indexOf('Draft') > 0
+                context.norm($profileEl?.text() || '').indexOf('Draft') > 0
                     ? 'CRYD'
                     : 'CRY';
         }
         return assembleMeta(id);
     } else {
-        const docTitle = (await getTitle(sr))?.title;
+        const docTitle = (await getTitle(context))?.title;
         if (candidate && candidate.indexOf("editor's draft") > -1) {
             throw new Error(
                 `The document "${docTitle}" seems to be an Editor's Draft, which is not supported.`
             );
         } else if (
-            sr.$('link[href^="https://www.w3.org/StyleSheets/TR/"]').length
+            context.$('link[href^="https://www.w3.org/StyleSheets/TR/"]').length
         ) {
             let profileList = '';
             sortedProfiles.forEach(category => {

--- a/lib/rules/metadata/sotd.ts
+++ b/lib/rules/metadata/sotd.ts
@@ -10,7 +10,7 @@ interface SotdMetadata {
     sotd: string;
 }
 
-export const check: RuleCheckFunction<SotdMetadata> = sr => {
-    const $sotd = sr.getSotDSection();
-    return { sotd: $sotd ? sr.norm($sotd.html()!) : 'Not found' };
+export const check: RuleCheckFunction<SotdMetadata> = context => {
+    const $sotd = context.getSotDSection();
+    return { sotd: $sotd ? context.norm($sotd.html()!) : 'Not found' };
 };

--- a/lib/rules/metadata/title.ts
+++ b/lib/rules/metadata/title.ts
@@ -8,12 +8,12 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'metadata.title';
 
-export const check: RuleCheckFunction<{ title: string } | void> = sr => {
-    const $title = sr.$('body div.head h1').first();
+export const check: RuleCheckFunction<{ title: string } | void> = context => {
+    const $title = context.$('body div.head h1').first();
     if (!$title.length) return;
 
     $title.html($title.html()!.replace(/:<br>/g, ': ').replace(/<br>/g, ' - '));
     return {
-        title: sr.norm($title.text()),
+        title: context.norm($title.text()),
     };
 };

--- a/lib/rules/sotd/candidate-review-end.ts
+++ b/lib/rules/sotd/candidate-review-end.ts
@@ -8,28 +8,32 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const isEditorial =
-        (sr.config!.editorial && /^true$/i.test(sr.config!.editorial)) || false;
+        (context.config!.editorial &&
+            /^true$/i.test(context.config!.editorial)) ||
+        false;
     if (isEditorial) {
-        sr.warning(self, 'editorial');
+        context.warning(self, 'editorial');
     } else {
-        const dates = sr.getFeedbackDueDate();
-        if (dates.list.length === 0) sr.error(self, 'not-found');
+        const dates = context.getFeedbackDueDate();
+        if (dates.list.length === 0) context.error(self, 'not-found');
         else {
             let res;
 
             if (dates.valid.length === 1) {
                 [res] = dates.valid;
-                sr.info(self, 'date-found', { date: res.toDateString() });
+                context.info(self, 'date-found', { date: res.toDateString() });
             } else if (dates.valid.length > 1) {
-                sr.warning(self, 'multiple-found');
+                context.warning(self, 'multiple-found');
                 res = dates.valid.map(item => new Date(item).toDateString());
-                sr.info(self, 'date-found', { date: res.join(', ') });
+                context.info(self, 'date-found', { date: res.join(', ') });
             } else {
                 // dates found but not valid
                 res = dates.list.map(item => new Date(item).toDateString());
-                sr.error(self, 'found-not-valid', { date: res.join(', ') });
+                context.error(self, 'found-not-valid', {
+                    date: res.join(', '),
+                });
             }
         }
     }

--- a/lib/rules/sotd/charter.ts
+++ b/lib/rules/sotd/charter.ts
@@ -13,13 +13,13 @@ export const { name } = self;
 const charterText =
     /The disclosure obligations of the Participants of this group are described in the charter\./;
 
-export const check: RuleCheckFunction = async sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = async context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
-        const deliverIds = await sr.getDelivererIDs();
+        const deliverIds = await context.getDelivererIDs();
 
         if (!deliverIds.length) {
-            sr.error(self, 'no-group');
+            context.error(self, 'no-group');
             return;
         }
 
@@ -32,18 +32,18 @@ export const check: RuleCheckFunction = async sr => {
         );
         if (!groupIds.length) return;
 
-        const charters = await sr.getCharters();
+        const charters = await context.getCharters();
         if (!charters.length) {
-            sr.error(self, 'no-charter');
+            context.error(self, 'no-charter');
             return;
         }
 
-        if (sr.config!.longStatus === 'Interest Group Note') {
+        if (context.config!.longStatus === 'Interest Group Note') {
             const expectedHref = charters && `${charters[0]}#patentpolicy`;
             // check text exists
-            const txt = sr.norm($sotd && $sotd.text());
+            const txt = context.norm($sotd && $sotd.text());
             if (!charterText.test(txt)) {
-                sr.error(self, 'text-not-found');
+                context.error(self, 'text-not-found');
                 return;
             }
 
@@ -51,10 +51,10 @@ export const check: RuleCheckFunction = async sr => {
             let charterLinkFound = false;
             let charterHrefInDocument;
             $sotd.find('a[href]').each((_, a) => {
-                const $a = sr.$(a);
+                const $a = context.$(a);
                 const charterHref = $a.attr('href');
-                const text = sr.norm($a.text());
-                const pText = sr.norm($a.parent().text());
+                const text = context.norm($a.text());
+                const pText = context.norm($a.parent().text());
                 // Find the right paragraph and right link.
                 if (charterText.test(pText) && text === 'charter') {
                     charterLinkFound = true;
@@ -62,9 +62,9 @@ export const check: RuleCheckFunction = async sr => {
                 }
             });
             if (!charterLinkFound) {
-                sr.error(self, 'link-not-found');
+                context.error(self, 'link-not-found');
             } else if (expectedHref !== charterHrefInDocument) {
-                sr.error(self, 'wrong-link', {
+                context.error(self, 'wrong-link', {
                     expectedHref,
                 });
             }

--- a/lib/rules/sotd/deliverer-note.ts
+++ b/lib/rules/sotd/deliverer-note.ts
@@ -8,7 +8,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const deliverers = sr.getDataDelivererIDs();
-    if (deliverers.length === 0) sr.error(self, 'not-found');
+export const check: RuleCheckFunction = context => {
+    const deliverers = context.getDataDelivererIDs();
+    if (deliverers.length === 0) context.error(self, 'not-found');
 };

--- a/lib/rules/sotd/deployment.ts
+++ b/lib/rules/sotd/deployment.ts
@@ -10,8 +10,8 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
 
     if ($sotd) {
         // Find the sentence of 'W3C recommends the wide deployment of this specification as a standard for the Web.'
@@ -20,7 +20,7 @@ export const check: RuleCheckFunction = sr => {
         const paragraph = $sotd
             .find('p')
             .toArray()
-            .find(p => sr.norm(sr.$(p).text()) === depText);
-        if (!paragraph) sr.error(self, 'not-found');
+            .find(p => context.norm(context.$(p).text()) === depText);
+        if (!paragraph) context.error(self, 'not-found');
     }
 };

--- a/lib/rules/sotd/diff.ts
+++ b/lib/rules/sotd/diff.ts
@@ -8,6 +8,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    sr.info(self, 'note');
+export const check: RuleCheckFunction = context => {
+    context.info(self, 'note');
 };

--- a/lib/rules/sotd/draft-stability.ts
+++ b/lib/rules/sotd/draft-stability.ts
@@ -10,9 +10,9 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
-    const { crType, cryType } = sr.config!;
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
+    const { crType, cryType } = context.config!;
     const STABILITY_REX =
         /This is a draft document and may be updated, replaced,? or obsoleted by other documents at any time\. It is inappropriate to cite this document as other than a work in progress\./;
 
@@ -20,21 +20,21 @@ export const check: RuleCheckFunction = sr => {
         'This document is maintained and updated at any time. Some parts of this document are work in progress.';
 
     if ($sotd) {
-        const txt = sr.norm($sotd.text());
+        const txt = context.norm($sotd.text());
         // CRD and CRYD allows both sentence.
         if (
             (crType && crType === 'Draft') ||
             (cryType && cryType === 'Draft')
         ) {
             if (!txt.match(STABILITY_REX) && !txt.includes(STABILITY_2))
-                sr.error(self, 'not-found-either', {
+                context.error(self, 'not-found-either', {
                     expected1: STABILITY_REX,
                     expected2: STABILITY_2,
                 });
         }
         // while other profiles allows only 'STABILITY' sentence
         else if (!txt.match(STABILITY_REX))
-            sr.error(self, 'not-found', {
+            context.error(self, 'not-found', {
                 expected: STABILITY_REX,
             });
     }

--- a/lib/rules/sotd/new-features.ts
+++ b/lib/rules/sotd/new-features.ts
@@ -8,9 +8,9 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
-    const docType = `${sr.config!.status !== 'REC' ? 'upcoming ' : ''}Recommendation`;
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
+    const docType = `${context.config!.status !== 'REC' ? 'upcoming ' : ''}Recommendation`;
     const warning = new RegExp(
         `Future updates to this ${docType} may incorporate new features.`
     );
@@ -18,19 +18,19 @@ export const check: RuleCheckFunction = sr => {
     const linkHref =
         'https://www.w3.org/policies/process/20250818/#allow-new-features';
 
-    if ($sotd && sr.norm($sotd.text()).match(warning)) {
+    if ($sotd && context.norm($sotd.text()).match(warning)) {
         const foundLink = $sotd
             .find('a')
             .toArray()
             .some(
                 a =>
-                    sr.norm(sr.$(a).text()) === linkTxt &&
+                    context.norm(context.$(a).text()) === linkTxt &&
                     a.attribs.href === linkHref
             );
         if (!foundLink) {
-            sr.error(self, 'no-link');
+            context.error(self, 'no-link');
         }
     } else {
-        sr.warning(self, 'no-warning');
+        context.warning(self, 'no-warning');
     }
 };

--- a/lib/rules/sotd/obsl-rescind.ts
+++ b/lib/rules/sotd/obsl-rescind.ts
@@ -6,7 +6,7 @@
 // Obsoleting and Rescinding W3C Specifications</a>.</p>
 
 import type { Cheerio } from 'cheerio';
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 import type { Element } from 'domhandler';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 

--- a/lib/rules/sotd/obsl-rescind.ts
+++ b/lib/rules/sotd/obsl-rescind.ts
@@ -6,11 +6,11 @@
 // Obsoleting and Rescinding W3C Specifications</a>.</p>
 
 import type { Cheerio } from 'cheerio';
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 import type { Element } from 'domhandler';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
-function findRscndRationale($candidates: Cheerio<Element>, sr: Specberus) {
+function findRscndRationale($candidates: Cheerio<Element>, sr: RuleContext) {
     const v = sr.config!.rescinds === true ? 'rescind' : '';
 
     for (const p of $candidates.toArray()) {

--- a/lib/rules/sotd/obsl-rescind.ts
+++ b/lib/rules/sotd/obsl-rescind.ts
@@ -10,12 +10,15 @@ import type { RuleContext } from '../../validator.js';
 import type { Element } from 'domhandler';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
-function findRscndRationale($candidates: Cheerio<Element>, sr: RuleContext) {
-    const v = sr.config!.rescinds === true ? 'rescind' : '';
+function findRscndRationale(
+    $candidates: Cheerio<Element>,
+    context: RuleContext
+) {
+    const v = context.config!.rescinds === true ? 'rescind' : '';
 
     for (const p of $candidates.toArray()) {
-        const $p = sr.$(p);
-        const text = sr.norm($p.text());
+        const $p = context.$(p);
+        const text = context.norm($p.text());
         const wanted1 = new RegExp(
             `W3C has chosen to ${v} the .*? Recommendation for the following reasons:`,
             'i'
@@ -37,24 +40,24 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
         const $rationale =
-            findRscndRationale($sotd.filter('p'), sr) ||
-            findRscndRationale($sotd.find('p'), sr);
+            findRscndRationale($sotd.filter('p'), context) ||
+            findRscndRationale($sotd.find('p'), context);
         if (!$rationale?.length) {
-            sr.error(self, 'no-rationale');
+            context.error(self, 'no-rationale');
         } else {
             const $a = $rationale.find('a:last-child').first();
             const href = $a.attr('href');
-            const text = sr.norm($a.text());
+            const text = context.norm($a.text());
             if (
                 href !== 'https://www.w3.org/2016/11/obsoleting-rescinding/' ||
                 text !==
                     'explanation of Obsoleting, Rescinding or Superseding W3C Specifications'
             ) {
-                sr.error(self, 'no-explanation-link');
+                context.error(self, 'no-explanation-link');
             }
         }
     }

--- a/lib/rules/sotd/pp.ts
+++ b/lib/rules/sotd/pp.ts
@@ -1,7 +1,7 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 const self: RuleMeta = {
@@ -14,7 +14,7 @@ const ppLink = 'https://www.w3.org/policies/patent-policy/';
 const ppLink2020 = 'https://www.w3.org/policies/patent-policy/20200915/';
 const ppLink2025 = 'https://www.w3.org/policies/patent-policy/20250515/';
 
-function buildWanted(groups: string[], sr: Specberus) {
+function buildWanted(groups: string[], sr: RuleContext) {
     const config = sr.config!;
     let wanted;
     const isRecTrack = config.track === 'Recommendation';
@@ -60,7 +60,7 @@ function buildWanted(groups: string[], sr: Specberus) {
     };
 }
 
-function findPP($candidates: Cheerio<Element>, sr: Specberus) {
+function findPP($candidates: Cheerio<Element>, sr: RuleContext) {
     const delivererGroups = sr.getDelivererNames();
     if (delivererGroups.length > 1) sr.warning(self, 'joint-publication');
 

--- a/lib/rules/sotd/pp.ts
+++ b/lib/rules/sotd/pp.ts
@@ -1,7 +1,7 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 const self: RuleMeta = {

--- a/lib/rules/sotd/pp.ts
+++ b/lib/rules/sotd/pp.ts
@@ -14,8 +14,8 @@ const ppLink = 'https://www.w3.org/policies/patent-policy/';
 const ppLink2020 = 'https://www.w3.org/policies/patent-policy/20200915/';
 const ppLink2025 = 'https://www.w3.org/policies/patent-policy/20250515/';
 
-function buildWanted(groups: string[], sr: RuleContext) {
-    const config = sr.config!;
+function buildWanted(groups: string[], context: RuleContext) {
+    const config = context.config!;
     let wanted;
     const isRecTrack = config.track === 'Recommendation';
     const ppText = '( 15 September 2020| 15 May 2025)?';
@@ -60,15 +60,15 @@ function buildWanted(groups: string[], sr: RuleContext) {
     };
 }
 
-function findPP($candidates: Cheerio<Element>, sr: RuleContext) {
-    const delivererGroups = sr.getDelivererNames();
-    if (delivererGroups.length > 1) sr.warning(self, 'joint-publication');
+function findPP($candidates: Cheerio<Element>, context: RuleContext) {
+    const delivererGroups = context.getDelivererNames();
+    if (delivererGroups.length > 1) context.warning(self, 'joint-publication');
 
-    const wanted = buildWanted(delivererGroups, sr);
+    const wanted = buildWanted(delivererGroups, context);
     const expected = wanted.text;
     for (const p of $candidates.toArray()) {
-        const $p = sr.$(p);
-        const text = sr.norm($p.text());
+        const $p = context.$(p);
+        const text = context.norm($p.text());
         if (wanted.regex.test(text)) return { $pp: $p, expected };
     }
     return { $pp: null, expected };
@@ -76,18 +76,18 @@ function findPP($candidates: Cheerio<Element>, sr: RuleContext) {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
-    const track = sr.config!.track;
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
+    const track = context.config!.track;
     const isRecTrack = track === 'Recommendation';
 
     if ($sotd) {
         const { $pp, expected } = findPP(
             $sotd.filter('p').add($sotd.find('p')),
-            sr
+            context
         );
         if (!$pp) {
-            sr.error(self, 'no-pp', { expected });
+            context.error(self, 'no-pp', { expected });
             return;
         }
 
@@ -96,9 +96,9 @@ export const check: RuleCheckFunction = sr => {
         let foundEssentials = false;
         let foundSection6 = false;
         $pp.find('a[href]').each((_, a) => {
-            const $a = sr.$(a);
+            const $a = context.$(a);
             const href = $a.attr('href')!;
-            const text = sr.norm($a.text());
+            const text = context.norm($a.text());
             const possiblePPLinks = [ppLink, ppLink2020, ppLink2025];
             if (
                 possiblePPLinks.includes(href) &&
@@ -136,14 +136,15 @@ export const check: RuleCheckFunction = sr => {
             }
         });
 
-        if (!foundLink) sr.error(self, 'no-link');
-        if (!foundPublicList && isRecTrack) sr.error(self, 'no-disclosures');
+        if (!foundLink) context.error(self, 'no-link');
+        if (!foundPublicList && isRecTrack)
+            context.error(self, 'no-disclosures');
         if (
             (track === 'Recommendation' || track === 'Note') &&
             isRecTrack &&
             !foundEssentials
         )
-            sr.error(self, 'no-claims', {
+            context.error(self, 'no-claims', {
                 link: `${ppLink}#def-essential`,
             });
         if (
@@ -151,7 +152,7 @@ export const check: RuleCheckFunction = sr => {
             isRecTrack &&
             !foundSection6
         )
-            sr.error(self, 'no-section6', {
+            context.error(self, 'no-section6', {
                 link: `${ppLink}#sec-Disclosure`,
             });
     }

--- a/lib/rules/sotd/process-document.ts
+++ b/lib/rules/sotd/process-document.ts
@@ -8,8 +8,8 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     const BOILERPLATE_PREFIX = 'This document is governed by the ';
     const BOILERPLATE_SUFFIX = ' W3C Process Document.';
     const newProc = '18 August 2025';
@@ -23,7 +23,7 @@ export const check: RuleCheckFunction = sr => {
         BOILERPLATE_PREFIX + previousProc + BOILERPLATE_SUFFIX;
 
     // 1 month transition period
-    sr.transition({
+    context.transition({
         from: new Date('2023-11-02'),
         to: new Date('2023-12-03'),
         doBefore() {},
@@ -38,36 +38,36 @@ export const check: RuleCheckFunction = sr => {
     if ($sotd) {
         let found = false;
         $sotd.find('p').each((_, p) => {
-            const $p = sr.$(p);
+            const $p = context.$(p);
             const pText = $p.text();
             const $a = $p.find('a').first();
             if (
-                sr.norm(pText) === boilerplate &&
+                context.norm(pText) === boilerplate &&
                 $a.length &&
                 $a.attr('href') === newProcUri
             ) {
                 if (found)
-                    sr.error(self, 'multiple-times', { process: newProc });
+                    context.error(self, 'multiple-times', { process: newProc });
                 else {
                     found = true;
                 }
             } else if (
-                sr.norm(pText) === previousBoilerplate &&
+                context.norm(pText) === previousBoilerplate &&
                 $a.length &&
                 $a.attr('href') === previousProcUri
             ) {
                 if (previousAllowed) {
-                    sr.warning(self, 'previous-allowed', {
+                    context.warning(self, 'previous-allowed', {
                         process: previousProc,
                     });
                     found = true;
                 } else {
-                    sr.error(self, 'previous-not-allowed', {
+                    context.error(self, 'previous-not-allowed', {
                         process: previousProc,
                     });
                 }
             }
         });
-        if (!found) sr.error(self, 'not-found', { process: newProc });
+        if (!found) context.error(self, 'not-found', { process: newProc });
     }
 };

--- a/lib/rules/sotd/publish.ts
+++ b/lib/rules/sotd/publish.ts
@@ -8,9 +8,9 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async sr => {
-    const $sotd = sr.getSotDSection();
-    const { crType, cryType, longStatus, status, track } = sr.config!;
+export const check: RuleCheckFunction = async context => {
+    const $sotd = context.getSotDSection();
+    const { crType, cryType, longStatus, status, track } = context.config!;
     let docType = longStatus;
     if (status === 'CR' || status === 'CRD') {
         docType = `Candidate Recommendation ${crType}`;
@@ -18,7 +18,7 @@ export const check: RuleCheckFunction = async sr => {
         docType = `Candidate Registry ${cryType}`;
     }
 
-    const text = `^This document was (?:produced|published) by the (.+? Working Group|Technical Architecture Group|Advisory Board|.+? Interest Group)( and the (.+? Working Group|Technical Architecture Group|Advisory Board|.+? Interest Group))? as a ${docType} using the ${sr.config!.track} track.`;
+    const text = `^This document was (?:produced|published) by the (.+? Working Group|Technical Architecture Group|Advisory Board|.+? Interest Group)( and the (.+? Working Group|Technical Architecture Group|Advisory Board|.+? Interest Group))? as a ${docType} using the ${context.config!.track} track.`;
 
     if ($sotd) {
         // Find the paragraph of 'This document was published by ... , it includes ...'
@@ -26,9 +26,9 @@ export const check: RuleCheckFunction = async sr => {
         const paragraph = $sotd
             .find('p')
             .toArray()
-            .find(p => sr.norm(sr.$(p).text()).match(publishReg));
+            .find(p => context.norm(context.$(p).text()).match(publishReg));
         if (!paragraph) {
-            sr.error(self, 'not-found', { publishReg });
+            context.error(self, 'not-found', { publishReg });
             return;
         }
 
@@ -36,7 +36,7 @@ export const check: RuleCheckFunction = async sr => {
 
         let baseURL = /^https:\/\/www.w3.org\/2023\/Process-20230612\//;
         // 1 month transition period
-        sr.transition({
+        context.transition({
             from: new Date('2023-11-02'),
             to: new Date('2023-12-03'),
             doBefore() {
@@ -56,16 +56,18 @@ export const check: RuleCheckFunction = async sr => {
         const urlExpected = new RegExp(`${baseURL.source}#recs-and-notes$`);
         const trackEl = $sotdLinks
             .toArray()
-            .find(el => sr.norm(sr.$(el).text()).match(`${track} track`));
+            .find(el =>
+                context.norm(context.$(el).text()).match(`${track} track`)
+            );
         if (trackEl && !urlExpected.test(trackEl.attribs.href)) {
-            sr.error(self, 'url-not-match', {
+            context.error(self, 'url-not-match', {
                 url: urlExpected,
                 text: `${track} track`,
             });
         }
 
         // Check the Deliverer Group link.
-        const delivererGroups = await sr.getDelivererGroups();
+        const delivererGroups = await context.getDelivererGroups();
         const groupsURLRegExpExpected = delivererGroups.map(
             delivererGroup =>
                 new RegExp(
@@ -75,14 +77,14 @@ export const check: RuleCheckFunction = async sr => {
         const sotdLinksHrefs = $sotdLinks.toArray().map(l => l.attribs.href);
         groupsURLRegExpExpected.forEach(groupURLRegExpExpected => {
             if (!sotdLinksHrefs.some(l => groupURLRegExpExpected.test(l))) {
-                sr.error(self, 'no-homepage-link', {
+                context.error(self, 'no-homepage-link', {
                     homepage: groupURLRegExpExpected,
                 });
             }
         });
 
         // recType: doc has sentence 'It includes proposed ...' in sotd.
-        const recType = status === 'REC' ? sr.getRecMetadata() : null;
+        const recType = status === 'REC' ? context.getRecMetadata() : null;
         // check if 'candidate amendments' or 'proposed amendments' link in same paragraph is valid.
         if (recType && JSON.stringify(recType) !== '{}') {
             let urlExpected: RegExp;
@@ -120,15 +122,15 @@ export const check: RuleCheckFunction = async sr => {
                 );
                 textExpected = /candidate addition(s)?/;
             }
-            const linkFound = sr
+            const linkFound = context
                 .$(paragraph)
                 .find('a')
                 .toArray()
                 .some(el => {
-                    const $el = sr.$(el);
-                    if (sr.norm($el.text()).match(textExpected)) {
+                    const $el = context.$(el);
+                    if (context.norm($el.text()).match(textExpected)) {
                         if (!urlExpected.test($el.attr('href') || '')) {
-                            sr.error(self, 'url-not-match', {
+                            context.error(self, 'url-not-match', {
                                 url: urlExpected,
                                 text: textExpected,
                             });
@@ -138,7 +140,7 @@ export const check: RuleCheckFunction = async sr => {
                     return false;
                 });
             if (!linkFound)
-                sr.error(self, 'url-text-not-found', {
+                context.error(self, 'url-text-not-found', {
                     url: urlExpected!,
                     text: textExpected!,
                 });

--- a/lib/rules/sotd/rec-addition.ts
+++ b/lib/rules/sotd/rec-addition.ts
@@ -1,6 +1,6 @@
 import type { Cheerio } from 'cheerio';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 import type { Element } from 'domhandler';
 
 // This rule only apply to REC, check changes with colored background.

--- a/lib/rules/sotd/rec-addition.ts
+++ b/lib/rules/sotd/rec-addition.ts
@@ -1,6 +1,6 @@
 import type { Cheerio } from 'cheerio';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 import type { Element } from 'domhandler';
 
 // This rule only apply to REC, check changes with colored background.
@@ -28,7 +28,7 @@ interface CheckSectionOptions {
 /**
  * Check if the recommendation change type mentioned by text is consistent with the html element.
  */
-function checkSection(sr: Specberus, options: CheckSectionOptions) {
+function checkSection(sr: RuleContext, options: CheckSectionOptions) {
     if (options.typeOfRec) {
         if (options.$htmlSection.length) {
             const expectedReg = new RegExp(options.expectedText);

--- a/lib/rules/sotd/rec-addition.ts
+++ b/lib/rules/sotd/rec-addition.ts
@@ -28,44 +28,44 @@ interface CheckSectionOptions {
 /**
  * Check if the recommendation change type mentioned by text is consistent with the html element.
  */
-function checkSection(sr: RuleContext, options: CheckSectionOptions) {
+function checkSection(context: RuleContext, options: CheckSectionOptions) {
     if (options.typeOfRec) {
         if (options.$htmlSection.length) {
             const expectedReg = new RegExp(options.expectedText);
-            const text = sr.norm(options.$htmlSection.text());
+            const text = context.norm(options.$htmlSection.text());
             if (!expectedReg.test(text)) {
-                sr.error(self, 'wrong-text', {
+                context.error(self, 'wrong-text', {
                     typeOfChange: options.typeOfChange,
                     sectionClass: options.sectionClass,
                     expectText: options.expectedText,
                 });
             }
         } else {
-            sr.error(self, 'no-section', {
+            context.error(self, 'no-section', {
                 typeOfChange: options.typeOfChange,
                 sectionClass: options.sectionClass,
                 expectText: options.expectedText,
             });
         }
     } else if (options.$htmlSection.length)
-        sr.error(self, 'unnecessary-section', {
+        context.error(self, 'unnecessary-section', {
             typeOfChange: options.typeOfChange,
             sectionClass: options.sectionClass,
             expectText: options.expectedText,
         });
 }
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
-        const recType = sr.getRecMetadata();
+        const recType = context.getRecMetadata();
         const $pCorSection = $sotd.find('p.correction.proposed').first();
         const $pAddSection = $sotd.find('p.addition.proposed').first();
         const $cCorSection = $sotd.find('p.correction:not(.proposed)').first();
         const $cAddSection = $sotd.find('p.addition:not(.proposed)').first();
 
         // check for 'proposed corrections'
-        checkSection(sr, {
+        checkSection(context, {
             typeOfRec: recType.pSubChanges,
             $htmlSection: $pCorSection,
             expectedText: P_CORRECTION,
@@ -74,7 +74,7 @@ export const check: RuleCheckFunction = sr => {
         });
 
         // check for 'proposed additions'
-        checkSection(sr, {
+        checkSection(context, {
             typeOfRec: recType.pNewFeatures,
             $htmlSection: $pAddSection,
             expectedText: P_ADDITION,
@@ -83,7 +83,7 @@ export const check: RuleCheckFunction = sr => {
         });
 
         // check for 'candidate corrections'
-        checkSection(sr, {
+        checkSection(context, {
             typeOfRec: recType.cSubChanges,
             $htmlSection: $cCorSection,
             expectedText: C_CORRECTION,
@@ -92,7 +92,7 @@ export const check: RuleCheckFunction = sr => {
         });
 
         // check for 'candidate additions'
-        checkSection(sr, {
+        checkSection(context, {
             typeOfRec: recType.cNewFeatures,
             $htmlSection: $cAddSection,
             expectedText: C_ADDITION,

--- a/lib/rules/sotd/rec-comment-end.ts
+++ b/lib/rules/sotd/rec-comment-end.ts
@@ -9,14 +9,14 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
-        const recType = sr.getRecMetadata();
+        const recType = context.getRecMetadata();
         if (recType.pSubChanges || recType.pNewFeatures) {
-            const txt = sr.norm($sotd.text());
+            const txt = context.norm($sotd.text());
             const rex = new RegExp(dateRegexStrCapturing, 'g');
-            const docDate = sr.getDocumentDate()!;
+            const docDate = context.getDocumentDate()!;
 
             // 60 days later than docDate;
             const minimumEndDate = new Date(
@@ -29,25 +29,27 @@ export const check: RuleCheckFunction = sr => {
                 .slice(1)
                 .join(' ');
             if (!rex.test(txt))
-                sr.error(self, 'not-found', { minimumEndDate: readableDate });
+                context.error(self, 'not-found', {
+                    minimumEndDate: readableDate,
+                });
             else {
                 const matches = txt.match(rex);
                 const dateFound = [];
                 if (matches) {
                     for (const match of matches) {
-                        const date = sr.stringToDate(match);
+                        const date = context.stringToDate(match);
                         if (date && date > minimumEndDate) {
-                            dateFound.push(sr.stringToDate(match));
+                            dateFound.push(context.stringToDate(match));
                         }
                     }
                 }
                 if (dateFound.length > 1) {
-                    sr.warning(self, 'multi-found', {
+                    context.warning(self, 'multi-found', {
                         date: dateFound.join(', '),
                         minimumEndDate: readableDate,
                     });
                 } else if (!dateFound.length) {
-                    sr.error(self, 'not-found', {
+                    context.error(self, 'not-found', {
                         minimumEndDate: readableDate,
                     });
                 }

--- a/lib/rules/sotd/rec-comment-end.ts
+++ b/lib/rules/sotd/rec-comment-end.ts
@@ -1,5 +1,5 @@
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import { dateRegexStrCapturing } from '../../validator.js';
+import { dateRegexStrCapturing } from '../../rule-context.js';
 
 const self: RuleMeta = {
     name: 'sotd.rec-comment-end',

--- a/lib/rules/sotd/rec-comment-end.ts
+++ b/lib/rules/sotd/rec-comment-end.ts
@@ -1,5 +1,5 @@
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
-import { Specberus } from '../../validator.js';
+import { dateRegexStrCapturing } from '../../validator.js';
 
 const self: RuleMeta = {
     name: 'sotd.rec-comment-end',
@@ -15,7 +15,7 @@ export const check: RuleCheckFunction = sr => {
         const recType = sr.getRecMetadata();
         if (recType.pSubChanges || recType.pNewFeatures) {
             const txt = sr.norm($sotd.text());
-            const rex = new RegExp(Specberus.dateRegexStrCapturing, 'g');
+            const rex = new RegExp(dateRegexStrCapturing, 'g');
             const docDate = sr.getDocumentDate()!;
 
             // 60 days later than docDate;

--- a/lib/rules/sotd/stability.ts
+++ b/lib/rules/sotd/stability.ts
@@ -5,10 +5,10 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
-async function findSW($candidates: Cheerio<Element>, sr: Specberus) {
+async function findSW($candidates: Cheerio<Element>, sr: RuleContext) {
     let wanted = '';
     let $sw: Cheerio<Element> | undefined;
     const { crType, cryType, longStatus, status } = sr.config!;

--- a/lib/rules/sotd/stability.ts
+++ b/lib/rules/sotd/stability.ts
@@ -8,14 +8,14 @@ import type { Element } from 'domhandler';
 import type { RuleContext } from '../../validator.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
-async function findSW($candidates: Cheerio<Element>, sr: RuleContext) {
+async function findSW($candidates: Cheerio<Element>, context: RuleContext) {
     let wanted = '';
     let $sw: Cheerio<Element> | undefined;
-    const { crType, cryType, longStatus, status } = sr.config!;
+    const { crType, cryType, longStatus, status } = context.config!;
 
     if (longStatus === 'Group Note' || longStatus === 'Group Note Draft') {
         // Find the sentence of 'Group Notes are not endorsed by W3C nor its Members.' or 'This Group Note is endorsed by the @@ Group, but is not endorsed by W3C itself nor its Members.'
-        const groups = sr.getDelivererNames().join(' and the ');
+        const groups = context.getDelivererNames().join(' and the ');
         wanted = `(${longStatus}s are not endorsed by W3C nor its Members|This ${longStatus} is endorsed by the ${groups}, but is not endorsed by W3C itself nor its Members).`;
     } else if (longStatus === 'Statement') {
         wanted =
@@ -27,7 +27,7 @@ async function findSW($candidates: Cheerio<Element>, sr: RuleContext) {
         wanted =
             'A W3C Registry is a specification that, after extensive consensus-building, is endorsed by W3C and its Members.';
     } else {
-        const groupIds = await sr.getDelivererIDs();
+        const groupIds = await context.getDelivererIDs();
         const INTRO_S = ` A Candidate Recommendation Snapshot has received wide review, is intended to gather implementation experience, and has commitments from Working Group members to royalty-free licensing for implementations.`;
         const INTRO_D = ` A Candidate Recommendation Draft integrates changes from the previous Candidate Recommendation that the Working Group${
             groupIds.length > 1 ? 's intend' : ' intends'
@@ -56,8 +56,8 @@ async function findSW($candidates: Cheerio<Element>, sr: RuleContext) {
 
     // TODO: better loop
     $candidates.each((_, p) => {
-        const $p = sr.$(p);
-        const text = sr.norm($p.text());
+        const $p = context.$(p);
+        const text = context.norm($p.text());
         if (text.match(wantedRE)) {
             $sw = $p;
             return false;
@@ -74,33 +74,36 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async sr => {
-    const { crType, cryType, status } = sr.config!;
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = async context => {
+    const { crType, cryType, status } = context.config!;
+    const $sotd = context.getSotDSection();
     if ($sotd) {
         if (status === 'REC') {
-            const txt = sr.norm($sotd.text());
+            const txt = context.norm($sotd.text());
             const wanted = `A W3C Recommendation is a specification that, after extensive consensus-building, is endorsed by W3C and its Members, and has commitments from Working Group members to royalty-free licensing for implementations.`;
             const rex = new RegExp(wanted);
-            if (!rex.test(txt)) sr.error(self, 'no-rec-review');
+            if (!rex.test(txt)) context.error(self, 'no-rec-review');
         } else {
             const $paragraphs = $sotd.filter('p');
             const { $sw, expected } = await findSW(
                 $paragraphs.length ? $paragraphs : $sotd.find('p'),
-                sr
+                context
             );
-            if (!$sw) sr.error(self, 'no-stability', { expected });
+            if (!$sw) context.error(self, 'no-stability', { expected });
             else if (crType === 'Snapshot' || cryType === 'Snapshot') {
                 const review = $sw
                     .find('a')
                     .toArray()
-                    .find(el => sr.norm(sr.$(el).text()) === 'wide review');
-                if (!review) sr.error(self, 'no-cr-review');
+                    .find(
+                        el =>
+                            context.norm(context.$(el).text()) === 'wide review'
+                    );
+                if (!review) context.error(self, 'no-cr-review');
                 else if (
                     review.attribs.href !==
                     'https://www.w3.org/policies/process/20250818/#dfn-wide-review'
                 )
-                    sr.error(self, 'wrong-cr-review-link');
+                    context.error(self, 'wrong-cr-review-link');
             }
         }
 
@@ -114,11 +117,11 @@ export const check: RuleCheckFunction = async sr => {
                 .toArray()
                 .some(
                     link =>
-                        sr.norm(sr.$(link).text()) === licensingText &&
-                        link.attribs.href === licensingLink
+                        context.norm(context.$(link).text()) ===
+                            licensingText && link.attribs.href === licensingLink
                 );
             if (!licensingFound)
-                sr.error(self, 'no-licensing-link', {
+                context.error(self, 'no-licensing-link', {
                     licensingText,
                     licensingLink,
                 });

--- a/lib/rules/sotd/stability.ts
+++ b/lib/rules/sotd/stability.ts
@@ -5,7 +5,7 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 async function findSW($candidates: Cheerio<Element>, context: RuleContext) {

--- a/lib/rules/sotd/submission.ts
+++ b/lib/rules/sotd/submission.ts
@@ -1,7 +1,7 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { Specberus } from '../../validator.js';
+import type { RuleContext } from '../../validator.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 const self: RuleMeta = {
@@ -12,7 +12,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-function findSubmText($candidates: Cheerio<Element>, sr: Specberus) {
+function findSubmText($candidates: Cheerio<Element>, sr: RuleContext) {
     const wanted =
         'By publishing this document, W3C acknowledges that the Submitting Members ' +
         'have made a formal Submission request to W3C for discussion. Publication of ' +

--- a/lib/rules/sotd/submission.ts
+++ b/lib/rules/sotd/submission.ts
@@ -12,7 +12,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-function findSubmText($candidates: Cheerio<Element>, sr: RuleContext) {
+function findSubmText($candidates: Cheerio<Element>, context: RuleContext) {
     const wanted =
         'By publishing this document, W3C acknowledges that the Submitting Members ' +
         'have made a formal Submission request to W3C for discussion. Publication of ' +
@@ -27,21 +27,21 @@ function findSubmText($candidates: Cheerio<Element>, sr: RuleContext) {
         'complete list of acknowledged W3C Member Submissions.';
 
     for (const p of $candidates.toArray()) {
-        const $p = sr.$(p);
-        const text = sr.norm($p.text());
+        const $p = context.$(p);
+        const text = context.norm($p.text());
         if (text === wanted) return $p;
     }
     return null;
 }
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
         const $st =
-            findSubmText($sotd.filter('p'), sr) ||
-            findSubmText($sotd.find('p'), sr);
+            findSubmText($sotd.filter('p'), context) ||
+            findSubmText($sotd.find('p'), context);
         if (!$st) {
-            sr.error(self, 'no-submission-text');
+            context.error(self, 'no-submission-text');
             return;
         }
 
@@ -60,9 +60,9 @@ export const check: RuleCheckFunction = sr => {
         let foundSubmMembers = false;
         let foundComment = false;
         $st.find('a[href]').each((_, a) => {
-            const $a = sr.$(a);
+            const $a = context.$(a);
             const href = $a.attr('href')!;
-            const text = sr.norm($a.text());
+            const text = context.norm($a.text());
             if (
                 [w3cProcessNew, w3cProcessOld].includes(href) &&
                 text === 'W3C Process'
@@ -97,26 +97,26 @@ export const check: RuleCheckFunction = sr => {
             }
         });
         if (!foundW3CProcess)
-            sr.error(self, 'link-text', {
+            context.error(self, 'link-text', {
                 href: w3cProcessNew,
                 text: 'W3C Process',
             });
         if (!foundW3CMembership)
-            sr.error(self, 'link-text', {
+            context.error(self, 'link-text', {
                 href: w3cMembership,
                 text: 'W3C Membership',
             });
         if (!foundPP)
-            sr.error(self, 'link-text', {
+            context.error(self, 'link-text', {
                 href: w3cPP,
                 text: 'section 3.3 of the W3C Patent Policy',
             });
         if (!foundSubm)
-            sr.error(self, 'link-text', {
+            context.error(self, 'link-text', {
                 href: w3cSubm,
                 text: 'list of acknowledged W3C Member Submissions',
             });
-        if (!foundSubmMembers) sr.error(self, 'no-sm-link');
-        if (!foundComment) sr.error(self, 'no-tc-link');
+        if (!foundSubmMembers) context.error(self, 'no-sm-link');
+        if (!foundComment) context.error(self, 'no-tc-link');
     }
 };

--- a/lib/rules/sotd/submission.ts
+++ b/lib/rules/sotd/submission.ts
@@ -1,7 +1,7 @@
 import type { Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import type { RuleContext } from '../../validator.js';
+import type { RuleContext } from '../../rule-context.js';
 import type { RuleCheckFunction, RuleMeta } from '../../types.js';
 
 const self: RuleMeta = {

--- a/lib/rules/sotd/supersedable.ts
+++ b/lib/rules/sotd/supersedable.ts
@@ -15,14 +15,14 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
     if ($sotd) {
         let $em = $sotd.filter('p').children('em').first();
         if (!$em.length) $em = $sotd.find('p em').first();
-        const txt = sr.norm($em.text());
+        const txt = context.norm($em.text());
         const wanted = `${'This section describes the status of this document at the time of its publication. A list of current W3C publications '}${
-            sr.config!.status === 'SUBM'
+            context.config!.status === 'SUBM'
                 ? ''
                 : 'and the latest revision of this technical report '
         }can be found in the W3C standards and drafts index.`;
@@ -34,13 +34,13 @@ export const check: RuleCheckFunction = sr => {
 
         if (txt !== wanted) {
             if (txt === deprecatedWanted) {
-                sr.warning(self, 'deprecated');
+                context.warning(self, 'deprecated');
             } else {
-                sr.error(self, 'no-sotd-intro');
+                context.error(self, 'no-sotd-intro');
             }
         }
 
         const $a = $em.find("a[href='https://www.w3.org/TR/']");
-        if (!$a.length) sr.error(self, 'no-sotd-tr');
+        if (!$a.length) context.error(self, 'no-sotd-tr');
     }
 };

--- a/lib/rules/sotd/usage.ts
+++ b/lib/rules/sotd/usage.ts
@@ -10,8 +10,8 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $sotd = sr.getSotDSection();
+export const check: RuleCheckFunction = context => {
+    const $sotd = context.getSotDSection();
 
     if ($sotd) {
         // Find the sentence of 'W3C recommends the wide usage of this registry.'
@@ -19,7 +19,7 @@ export const check: RuleCheckFunction = sr => {
         const paragraph = $sotd
             .find('p')
             .toArray()
-            .find(p => sr.norm(sr.$(p).text()) === usageText);
-        if (!paragraph) sr.error(self, 'not-found');
+            .find(p => context.norm(context.$(p).text()) === usageText);
+        if (!paragraph) context.error(self, 'not-found');
     }
 };

--- a/lib/rules/structure/canonical.ts
+++ b/lib/rules/structure/canonical.ts
@@ -8,15 +8,16 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const checkCanonical = function () {
-        const $lnk = sr.$('head > link[rel=canonical]').first();
-        if (!$lnk.length || !$lnk.attr('href')) sr.error(self, 'not-found');
+        const $lnk = context.$('head > link[rel=canonical]').first();
+        if (!$lnk.length || !$lnk.attr('href'))
+            context.error(self, 'not-found');
     };
 
     // That canonical link is mandatory starting from Oct 1, 2017.
     // See https://lists.w3.org/Archives/Public/spec-prod/2017JulSep/0005.html
-    sr.transition({
+    context.transition({
         to: new Date('2017-09-30'),
         doMeanwhile: () => {},
         doAfter: checkCanonical,

--- a/lib/rules/structure/display-only.ts
+++ b/lib/rules/structure/display-only.ts
@@ -2,21 +2,21 @@ import type { RuleCheckFunction } from '../../types.js';
 
 export const name = 'structure.display-only';
 
-export const check: RuleCheckFunction = sr => {
-    if (sr.config!.status !== 'DISC')
-        sr.info(
+export const check: RuleCheckFunction = context => {
+    if (context.config!.status !== 'DISC')
+        context.info(
             { name, section: 'document-status', rule: 'customParagraph' },
             'customised-paragraph'
         );
 
-    sr.info(
+    context.info(
         { name, section: 'document-status', rule: 'knownDisclosureNumber' },
         'known-disclosures'
     );
-    sr.info({ name }, 'normative-representation');
-    sr.info({ name }, 'visual-style');
-    sr.info({ name }, 'alt-representation');
-    sr.info({ name }, 'special-box-markup');
-    sr.info({ name }, 'index-list-tables');
-    sr.info({ name }, 'fit-in-a4');
+    context.info({ name }, 'normative-representation');
+    context.info({ name }, 'visual-style');
+    context.info({ name }, 'alt-representation');
+    context.info({ name }, 'special-box-markup');
+    context.info({ name }, 'index-list-tables');
+    context.info({ name }, 'fit-in-a4');
 };

--- a/lib/rules/structure/h2.ts
+++ b/lib/rules/structure/h2.ts
@@ -18,17 +18,19 @@ const toc = {
     rule: 'toc',
 };
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const h2s: string[] = [];
-    sr.$('h2').each((_, h2) => {
-        const $h2 = sr.$(h2);
-        if ($h2.parents('.head').length === 0) h2s.push(sr.norm($h2.text()));
+    context.$('h2').each((_, h2) => {
+        const $h2 = context.$(h2);
+        if ($h2.parents('.head').length === 0)
+            h2s.push(context.norm($h2.text()));
     });
-    if (h2s[0] !== 'Abstract') sr.error(abstract, 'abstract', { was: h2s[0] });
+    if (h2s[0] !== 'Abstract')
+        context.error(abstract, 'abstract', { was: h2s[0] });
     // cspell:disable-next-line
     if (!/^Status [Oo]f [Tt]his [Dd]ocument$/.test(h2s[1]))
-        sr.error(sotd, 'sotd', { was: h2s[1] });
+        context.error(sotd, 'sotd', { was: h2s[1] });
     // cspell:disable-next-line
     if (!/^Table [Oo]f [Cc]ontents$/.test(h2s[2]))
-        sr.error(toc, 'toc', { was: h2s[2] });
+        context.error(toc, 'toc', { was: h2s[2] });
 };

--- a/lib/rules/structure/name.ts
+++ b/lib/rules/structure/name.ts
@@ -10,7 +10,7 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = async sr => {
+export const check: RuleCheckFunction = async context => {
     // Pseudo-constants:
     const EXPECTED_NAME = /\/Overview\.html$/;
     const OVERVIEW = 'Overview.html';
@@ -19,29 +19,29 @@ export const check: RuleCheckFunction = async sr => {
 
     let fileName;
 
-    if (!sr || !sr.url || EXPECTED_NAME.test(sr.url)) {
+    if (!context || !context.url || EXPECTED_NAME.test(context.url)) {
         return;
     }
 
-    if (!ALTERNATIVE_ENDING.test(sr.url)) {
-        fileName = sr.url.match(FILE_NAME);
+    if (!ALTERNATIVE_ENDING.test(context.url)) {
+        fileName = context.url.match(FILE_NAME);
         if (fileName && fileName.length === 1) {
             fileName = fileName[0];
-            sr.warning(self, 'wrong', {
+            context.warning(self, 'wrong', {
                 note: ` (instead of <code>${fileName}</code>)`,
             });
         } else {
-            sr.warning(self, 'wrong', { note: '' });
+            context.warning(self, 'wrong', { note: '' });
         }
         return;
     }
 
     try {
-        const result1 = await superagent.get(sr.url);
-        const result2 = await superagent.get(sr.url + OVERVIEW);
+        const result1 = await superagent.get(context.url);
+        const result2 = await superagent.get(context.url + OVERVIEW);
         if (!result1.ok || !result2.ok || result1.text !== result2.text)
-            sr.warning(self, 'wrong', { note: '' });
+            context.warning(self, 'wrong', { note: '' });
     } catch (error) {
-        sr.warning(self, 'wrong', { note: '' });
+        context.warning(self, 'wrong', { note: '' });
     }
 };

--- a/lib/rules/structure/neutral.ts
+++ b/lib/rules/structure/neutral.ts
@@ -17,14 +17,14 @@ for (const item of badterms) {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const blocklistReg = new RegExp(`\\b${blocklist.join('\\b|\\b')}\\b`, 'ig');
     const unneutralList: string[] = [];
     // Use a cloned body instead of the original one, prevent '.remove()' side effects.
-    const $body = sr.$('body').first().clone();
+    const $body = context.$('body').first().clone();
     const $links = $body.find('a');
     $links.each((_, link) => {
-        const $link = sr.$(link);
+        const $link = context.$(link);
         const href = $link.attr('href');
         const linkText = $link.text();
         // let words in link like: <a href="https://github.com/master/usage">https://github.com/master/usage</a> --> pass the check
@@ -41,5 +41,5 @@ export const check: RuleCheckFunction = sr => {
             }
         });
     if (unneutralList.length)
-        sr.warning(self, 'neutral', { words: unneutralList.join('", "') });
+        context.warning(self, 'neutral', { words: unneutralList.join('", "') });
 };

--- a/lib/rules/structure/section-ids.ts
+++ b/lib/rules/structure/section-ids.ts
@@ -8,17 +8,17 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $ignoreH3 = sr.$('.head > h3').first();
+export const check: RuleCheckFunction = context => {
+    const $ignoreH3 = context.$('.head > h3').first();
 
-    sr.$('h2, h3, h4, h5, h6').each((_, el) => {
-        const $el = sr.$(el);
+    context.$('h2, h3, h4, h5, h6').each((_, el) => {
+        const $el = context.$(el);
         // has an id
         if ($el.attr('id') || el === $ignoreH3[0]) return;
 
         // has no element previous sibling, has parent div or section, and that has an id
         //  without prevAll that sucks... get children of parent and find self
-        const $parent = sr.$(el).parent();
+        const $parent = context.$(el).parent();
         const $sibs = $parent.children();
         if (
             $sibs[0] === el &&
@@ -38,9 +38,9 @@ export const check: RuleCheckFunction = sr => {
         }
 
         // this is the status h2
-        const $stateEl = sr.getDocumentStateElement();
+        const $stateEl = context.getDocumentStateElement();
         if ($stateEl && el === $stateEl[0]) return;
 
-        sr.error(self, 'no-id', { text: el.name });
+        context.error(self, 'no-id', { text: el.name });
     });
 };

--- a/lib/rules/structure/security-privacy.ts
+++ b/lib/rules/structure/security-privacy.ts
@@ -8,12 +8,12 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     let security = false;
     let privacy = false;
 
-    sr.$('h2, h3, h4, h5, h6').each((_, el) => {
-        const text = sr.norm(sr.$(el).text()).toLowerCase();
+    context.$('h2, h3, h4, h5, h6').each((_, el) => {
+        const text = context.norm(context.$(el).text()).toLowerCase();
 
         if (text.includes('security')) {
             security = true;
@@ -24,10 +24,10 @@ export const check: RuleCheckFunction = sr => {
     });
 
     if (!security && !privacy) {
-        sr.warning(self, 'no-security-privacy');
+        context.warning(self, 'no-security-privacy');
     } else {
-        if (!security) sr.warning(self, 'no-security');
+        if (!security) context.warning(self, 'no-security');
 
-        if (!privacy) sr.warning(self, 'no-privacy');
+        if (!privacy) context.warning(self, 'no-privacy');
     }
 };

--- a/lib/rules/style/back-to-top.ts
+++ b/lib/rules/style/back-to-top.ts
@@ -10,10 +10,10 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const $candidates = sr.$(
+export const check: RuleCheckFunction = context => {
+    const $candidates = context.$(
         "body p#back-to-top[role='navigation'] a[href='#title']"
     );
 
-    if ($candidates.length !== 1) sr.warning(self, 'not-found');
+    if ($candidates.length !== 1) context.warning(self, 'not-found');
 };

--- a/lib/rules/style/body-toc-sidebar.ts
+++ b/lib/rules/style/body-toc-sidebar.ts
@@ -6,10 +6,11 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     try {
-        if (sr.$('body').hasClass('toc-sidebar')) sr.error(self, 'class-found');
+        if (context.$('body').hasClass('toc-sidebar'))
+            context.error(self, 'class-found');
     } catch (e) {
-        sr.error(self, 'selector-fail');
+        context.error(self, 'selector-fail');
     }
 };

--- a/lib/rules/style/meta.ts
+++ b/lib/rules/style/meta.ts
@@ -17,10 +17,10 @@ export const { name } = self;
 const width = /^device-width$/i;
 const shrinkToFit = /^no$/i;
 
-export const check: RuleCheckFunction = sr => {
-    const $meta = sr.$("head > meta[name='viewport'][content]");
+export const check: RuleCheckFunction = context => {
+    const $meta = context.$("head > meta[name='viewport'][content]");
     if ($meta.length !== 1) {
-        sr.error(self, 'not-found');
+        context.error(self, 'not-found');
     } else {
         const props = mvp.parseMetaViewPortContent(
             $meta.first().attr('content')
@@ -37,7 +37,7 @@ export const check: RuleCheckFunction = sr => {
             !shrinkToFit.test(props.validProperties['shrink-to-fit']) ||
             Object.keys(props.unknownProperties).length !== 0
         ) {
-            sr.error(self, 'not-found');
+            context.error(self, 'not-found');
         }
     }
 };

--- a/lib/rules/style/script.ts
+++ b/lib/rules/style/script.ts
@@ -10,16 +10,16 @@ const self = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
+export const check: RuleCheckFunction = context => {
     const PATTERN_SCRIPT =
         /^(https?:)?\/\/(www\.)?w3\.org\/scripts\/tr\/2021\/fixup\.js$/i;
 
-    const $candidates = sr.$('script[src]');
+    const $candidates = context.$('script[src]');
     let found = 0;
 
     $candidates.each((_, el) => {
         if (PATTERN_SCRIPT.test(el.attribs.src)) found++;
     });
 
-    if (found !== 1) sr.error(self, 'not-found');
+    if (found !== 1) context.error(self, 'not-found');
 };

--- a/lib/rules/style/sheet.ts
+++ b/lib/rules/style/sheet.ts
@@ -13,8 +13,8 @@ const notLast = {
     rule: 'lastStylesheet',
 };
 
-export const check: RuleCheckFunction = sr => {
-    const { styleSheet } = sr.config!;
+export const check: RuleCheckFunction = context => {
+    const { styleSheet } = context.config!;
     if (!styleSheet) return;
     const url = `https://www.w3.org/StyleSheets/TR/2021/${styleSheet}`;
     const dark = 'https://www.w3.org/StyleSheets/TR/2021/dark';
@@ -22,8 +22,8 @@ export const check: RuleCheckFunction = sr => {
         `head > link[rel=stylesheet][href='${url}']`,
         `head > link[rel=stylesheet][href='${url}.css']`,
     ];
-    const $lnk = sr.$(stylesheetLinks.join(', ')).first();
-    if (!$lnk.length) sr.error(missing, 'not-found', { url });
+    const $lnk = context.$(stylesheetLinks.join(', ')).first();
+    if (!$lnk.length) context.error(missing, 'not-found', { url });
     else {
         const $siblings = $lnk.nextAll('link[rel=stylesheet], style');
         if (
@@ -32,7 +32,7 @@ export const check: RuleCheckFunction = sr => {
                 $siblings.eq(0).attr('href') !== dark &&
                 $siblings.eq(0).attr('href') !== `${dark}.css`)
         ) {
-            sr.error(notLast, 'last');
+            context.error(notLast, 'last');
         }
     }
 };

--- a/lib/rules/validation/html.ts
+++ b/lib/rules/validation/html.ts
@@ -11,34 +11,34 @@ const TIMEOUT = 10000;
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    const { htmlValidator, skipValidation } = sr.config!;
+export const check: RuleCheckFunction = context => {
+    const { htmlValidator, skipValidation } = context.config!;
     const service = htmlValidator || 'https://validator.w3.org/nu/';
     if (skipValidation) {
-        sr.warning(self, 'skipped');
+        context.warning(self, 'skipped');
         return;
     }
-    if (!sr.url && !sr.source) {
-        sr.warning(self, 'no-source');
+    if (!context.url && !context.source) {
+        context.warning(self, 'no-source');
         return;
     }
     let req;
-    const ua = `W3C-Pubrules/${sr.version}`;
-    if (sr.url) {
+    const ua = `W3C-Pubrules/${context.version}`;
+    if (context.url) {
         req = get(service).set('User-Agent', ua);
-        req.query({ doc: sr.url, out: 'json' });
+        req.query({ doc: context.url, out: 'json' });
     } else {
         req = post(service)
             .set('User-Agent', ua)
             .set('Content-Type', 'text/html')
-            .send(sr.source)
+            .send(context.source)
             .query({ out: 'json' });
     }
     req.timeout(TIMEOUT);
     return req.then(
         res => {
             if (!res.ok)
-                return sr.error(self, 'failure', { status: res.status });
+                return context.error(self, 'failure', { status: res.status });
 
             const json = res.body;
             if (!json) throw new Error('No JSON returned from HTML validator.');
@@ -57,11 +57,11 @@ export const check: RuleCheckFunction = sr => {
                     //     "hiliteLength": 8
                     // }
                     if (msg.type === 'error') {
-                        sr.error(self, 'error', {
+                        context.error(self, 'error', {
                             line: msg.lastLine,
                             column: msg.lastColumn,
                             message: msg.message,
-                            link: `${service}?doc=${sr.url}`,
+                            link: `${service}?doc=${context.url}`,
                         });
                     }
                     // {
@@ -72,9 +72,9 @@ export const check: RuleCheckFunction = sr => {
                     // }
                     else if (msg.type === 'info') {
                         if (msg.subtype === 'warning') {
-                            sr.warning(self, 'warning', {
+                            context.warning(self, 'warning', {
                                 message: msg.message,
-                                link: `${service}?doc=${sr.url}`,
+                                link: `${service}?doc=${context.url}`,
                             });
                         }
                     }
@@ -84,7 +84,7 @@ export const check: RuleCheckFunction = sr => {
                     //     "message":"HTTP resource not retrievable. The HTTP status from the remote server was: 404."
                     // }
                     else if (msg.type === 'non-document-error') {
-                        sr.error(self, 'non-document-error', {
+                        context.error(self, 'non-document-error', {
                             subType: msg.subType,
                             message: msg.message,
                         });
@@ -93,8 +93,8 @@ export const check: RuleCheckFunction = sr => {
             }
         },
         (err: ResponseError) => {
-            if (err.timeout) sr.warning(self, 'timeout');
-            else sr.error(self, 'no-response');
+            if (err.timeout) context.warning(self, 'timeout');
+            else context.error(self, 'no-response');
         }
     );
 };

--- a/lib/rules/validation/wcag.ts
+++ b/lib/rules/validation/wcag.ts
@@ -8,6 +8,6 @@ const self: RuleMeta = {
 
 export const { name } = self;
 
-export const check: RuleCheckFunction = sr => {
-    sr.info(self, 'tools');
+export const check: RuleCheckFunction = context => {
+    context.info(self, 'tools');
 };

--- a/lib/specberus.ts
+++ b/lib/specberus.ts
@@ -1,0 +1,232 @@
+/**
+ * @file Main file of the Specberus npm package.
+ */
+
+import EventEmitter from 'events';
+import { access, constants, readFile } from 'fs/promises';
+
+import { load } from 'cheerio';
+// @ts-ignore (no typings)
+import w3cApi from 'node-w3capi';
+
+import { setLanguage } from './l10n.js';
+import * as profileMetadata from './profiles/metadata.js';
+import * as profileAdditionalMetadata from './profiles/additionalMetadata.js';
+import { get } from './throttled-ua.js';
+import { processParams, specberusVersion } from './util.js';
+import type {
+    HandlerMessage,
+    ProfileModule,
+    RuleBase,
+    RuleMeta,
+} from './types.js';
+import { RuleContext } from './rule-context.js';
+
+setLanguage('en_GB');
+
+interface BaseOptions {
+    file?: string;
+    source?: string;
+    url?: string;
+}
+
+interface ExtractMetadataOptions extends BaseOptions {
+    additionalMetadata?: boolean;
+}
+
+export interface ValidateOptions extends BaseOptions {
+    profile: ProfileModule;
+    validation?: 'no-validation' | 'recursive';
+}
+
+interface ExceptionsErrorOptions extends ErrorOptions {
+    exceptions: string[];
+}
+
+export interface SpecberusResult {
+    errors: HandlerMessage[];
+    info: HandlerMessage[];
+    metadata: Record<string, any>;
+    success: boolean;
+    warnings: HandlerMessage[];
+}
+
+/**
+ * Error which includes list of exception messages,
+ * thrown in case of unexpected errors during extractMetadata or validate
+ */
+export class ExceptionsError extends Error {
+    exceptions: string[];
+
+    constructor(message?: string, options?: ExceptionsErrorOptions) {
+        super(message, options);
+        this.exceptions = options?.exceptions || [];
+    }
+}
+
+type SpecberusMessageEventArgs = [
+    RuleMeta | RuleBase,
+    {
+        detailMessage: string;
+        extra?: Record<string, any>;
+        key: string;
+    },
+];
+
+interface SpecberusEvents {
+    done: [string];
+    err: SpecberusMessageEventArgs;
+    exception: [{ message: string }];
+    info: SpecberusMessageEventArgs;
+    warning: SpecberusMessageEventArgs;
+}
+
+export class Specberus extends EventEmitter<SpecberusEvents> {
+    source: string | undefined;
+    url: string | undefined;
+    version = specberusVersion;
+
+    /** Stores messages from any unexpected errors encountered during process */
+    #exceptions: string[] = [];
+
+    /**
+     * Internal function for handling common end-state logic for extractMetadata and validate,
+     * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
+     */
+    #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
+        if (this.#exceptions.length) {
+            throw new ExceptionsError(
+                'The following unexpected errors occurred:\n' +
+                    this.#exceptions.join('\n'),
+                { exceptions: this.#exceptions }
+            );
+        }
+        return {
+            ...result,
+            success: !result.errors.length,
+        };
+    }
+
+    /** Internal function containing setup logic common to both extractMetadata and validate. */
+    async #prepare(options: ExtractMetadataOptions | ValidateOptions) {
+        const errors: HandlerMessage[] = [];
+        const warnings: HandlerMessage[] = [];
+        const info: HandlerMessage[] = [];
+
+        this.on('err', (rule, data) => {
+            errors.push({ ...rule, ...data });
+        });
+        this.on('warning', (rule, data) => {
+            warnings.push({ ...rule, ...data });
+        });
+        this.on('info', (rule, data) => {
+            info.push({ ...rule, ...data });
+        });
+
+        try {
+            const $ = await this.#load(options);
+            return { $, errors, info, warnings };
+        } catch (error) {
+            this.#throw(error.toString());
+            throw error;
+        }
+    }
+
+    async extractMetadata(options: ExtractMetadataOptions) {
+        const { $, ...messages } = await this.#prepare(options);
+        const metadata: Record<string, any> = {};
+        const profile = options.additionalMetadata
+            ? profileAdditionalMetadata
+            : profileMetadata;
+        const ruleContext = new RuleContext(this, $);
+
+        await Promise.all(
+            profile.rules.map(async rule => {
+                try {
+                    const result = await rule.check(ruleContext);
+                    if (result)
+                        for (const [key, value] of Object.entries(result))
+                            metadata[key] = value;
+                } catch (error) {
+                    this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
+                }
+            })
+        );
+        return this.#reportResult({ ...messages, metadata });
+    }
+
+    async validate(options: ValidateOptions) {
+        if (!options.profile)
+            throw new Error('Without a profile there is nothing to check.');
+
+        const { profile } = options;
+        const config = await processParams(options, profile.config);
+        const { $, ...messages } = await this.#prepare(options);
+        const ruleContext = new RuleContext(this, $, config);
+
+        await Promise.all(
+            profile.rules.map(async rule => {
+                try {
+                    await rule.check(ruleContext);
+                } catch (error) {
+                    this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
+                }
+            })
+        );
+        return this.#reportResult({ ...messages, metadata: {} });
+    }
+
+    /**
+     * Emits an exception event, intended to signify that the process stopped on a critical error.
+     *
+     * NOTE: This should not be called from rules; they should throw an Error,
+     * which will result in extractMetadata or validate invoking this method.
+     */
+    #throw(message: string) {
+        console.error(`[EXCEPTION] ${message}`);
+        this.emit('exception', { message });
+        // Track in exceptions array, used to determine whether to resolve or reject process
+        this.#exceptions.push(message);
+    }
+
+    #load(options: ExtractMetadataOptions | ValidateOptions) {
+        if (options.url) return this.#loadURL(options.url);
+        if (options.source) return this.#loadSource(options.source);
+        if (options.file) return this.#loadFile(options.file);
+        throw new Error('url, source, or file must be specified.');
+    }
+
+    #loadURL(url: string) {
+        return get(url)
+            .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
+            .then(res => {
+                if (!res.text) throw new Error(`Body of ${url} is empty.`);
+                this.url = url;
+                return this.#loadSource(res.text);
+            });
+    }
+
+    #loadSource(src: string) {
+        this.source = src;
+        try {
+            return load(src);
+        } catch (e) {
+            throw new Error(
+                `Cheerio failed to parse source: ${JSON.stringify(e)}`
+            );
+        }
+    }
+
+    async #loadFile(file: string) {
+        try {
+            await access(file, constants.F_OK);
+        } catch (error) {
+            throw new Error(`File '${file}' not found or inaccessible.`);
+        }
+        return this.#loadSource(await readFile(file, 'utf8'));
+    }
+}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,4 @@
-import type { Specberus, ValidateOptions } from './validator.js';
+import type { RuleContext, ValidateOptions } from './validator.js';
 
 type Status =
     | 'FPWD'
@@ -64,7 +64,7 @@ export interface RecMetadata {
     rectrack?: string | null;
 }
 
-export type RuleCheckFunction<R = void> = (sr: Specberus) => R | Promise<R>;
+export type RuleCheckFunction<R = void> = (sr: RuleContext) => R | Promise<R>;
 
 export interface RuleBase {
     name: string;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,5 @@
-import type { RuleContext, ValidateOptions } from './validator.js';
+import type { ValidateOptions } from './specberus.js';
+import type { RuleContext } from './rule-context.js';
 
 type Status =
     | 'FPWD'

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -65,7 +65,9 @@ export interface RecMetadata {
     rectrack?: string | null;
 }
 
-export type RuleCheckFunction<R = void> = (sr: RuleContext) => R | Promise<R>;
+export type RuleCheckFunction<R = void> = (
+    context: RuleContext
+) => R | Promise<R>;
 
 export interface RuleBase {
     name: string;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -12,7 +12,7 @@ import { Octokit } from '@octokit/core';
 import w3cApi from 'node-w3capi';
 
 import type { SpecberusConfig } from './types.js';
-import type { ValidateOptions } from './validator.js';
+import type { ValidateOptions } from './specberus.js';
 import pkg from '../package.json' with { type: 'json' };
 
 /** Current specberus version recorded in package.json */

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -5,7 +5,7 @@
 import EventEmitter from 'events';
 import { access, constants, readFile } from 'fs/promises';
 
-import { type Cheerio, load } from 'cheerio';
+import { type Cheerio, type CheerioAPI, load } from 'cheerio';
 import type { Element } from 'domhandler';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
@@ -43,6 +43,200 @@ export interface ValidateOptions extends BaseOptions {
     profile: ProfileModule;
     validation?: 'no-validation' | 'recursive';
 }
+
+interface ExceptionsErrorOptions extends ErrorOptions {
+    exceptions: string[];
+}
+
+export interface SpecberusResult {
+    errors: HandlerMessage[];
+    info: HandlerMessage[];
+    metadata: Record<string, any>;
+    success: boolean;
+    warnings: HandlerMessage[];
+}
+
+/**
+ * Error which includes list of exception messages,
+ * thrown in case of unexpected errors during extractMetadata or validate
+ */
+export class ExceptionsError extends Error {
+    exceptions: string[];
+
+    constructor(message?: string, options?: ExceptionsErrorOptions) {
+        super(message, options);
+        this.exceptions = options?.exceptions || [];
+    }
+}
+
+type SpecberusMessageEventArgs = [
+    RuleMeta | RuleBase,
+    {
+        detailMessage: string;
+        extra?: Record<string, any>;
+        key: string;
+    },
+];
+
+interface SpecberusEvents {
+    done: [string];
+    err: SpecberusMessageEventArgs;
+    exception: [{ message: string }];
+    info: SpecberusMessageEventArgs;
+    warning: SpecberusMessageEventArgs;
+}
+
+export class Specberus extends EventEmitter<SpecberusEvents> {
+    source: string | undefined;
+    url: string | undefined;
+    version = specberusVersion;
+
+    /** Stores messages from any unexpected errors encountered during process */
+    #exceptions: string[] = [];
+
+    /**
+     * Internal function for handling common end-state logic for extractMetadata and validate,
+     * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
+     */
+    #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
+        if (this.#exceptions.length) {
+            throw new ExceptionsError(
+                'The following unexpected errors occurred:\n' +
+                    this.#exceptions.join('\n'),
+                { exceptions: this.#exceptions }
+            );
+        }
+        return {
+            ...result,
+            success: !result.errors.length,
+        };
+    }
+
+    /** Internal function containing setup logic common to both extractMetadata and validate. */
+    async #prepare(options: ExtractMetadataOptions | ValidateOptions) {
+        const errors: HandlerMessage[] = [];
+        const warnings: HandlerMessage[] = [];
+        const info: HandlerMessage[] = [];
+
+        this.on('err', (rule, data) => {
+            errors.push({ ...rule, ...data });
+        });
+        this.on('warning', (rule, data) => {
+            warnings.push({ ...rule, ...data });
+        });
+        this.on('info', (rule, data) => {
+            info.push({ ...rule, ...data });
+        });
+
+        try {
+            const $ = await this.#load(options);
+            return { $, errors, info, warnings };
+        } catch (error) {
+            this.#throw(error.toString());
+            throw error;
+        }
+    }
+
+    async extractMetadata(options: ExtractMetadataOptions) {
+        const { $, ...messages } = await this.#prepare(options);
+        const metadata: Record<string, any> = {};
+        const profile = options.additionalMetadata
+            ? profileAdditionalMetadata
+            : profileMetadata;
+        const ruleContext = new RuleContext(this, $);
+
+        await Promise.all(
+            profile.rules.map(async rule => {
+                try {
+                    const result = await rule.check(ruleContext);
+                    if (result)
+                        for (const [key, value] of Object.entries(result))
+                            metadata[key] = value;
+                } catch (error) {
+                    this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
+                }
+            })
+        );
+        return this.#reportResult({ ...messages, metadata });
+    }
+
+    async validate(options: ValidateOptions) {
+        if (!options.profile)
+            throw new Error('Without a profile there is nothing to check.');
+
+        const { profile } = options;
+        const config = await processParams(options, profile.config);
+        const { $, ...messages } = await this.#prepare(options);
+        const ruleContext = new RuleContext(this, $, config);
+
+        await Promise.all(
+            profile.rules.map(async rule => {
+                try {
+                    await rule.check(ruleContext);
+                } catch (error) {
+                    this.#throw(error.message);
+                } finally {
+                    this.emit('done', rule.name);
+                }
+            })
+        );
+        return this.#reportResult({ ...messages, metadata: {} });
+    }
+
+    /**
+     * Emits an exception event, intended to signify that the process stopped on a critical error.
+     *
+     * NOTE: This should not be called from rules; they should throw an Error,
+     * which will result in extractMetadata or validate invoking this method.
+     */
+    #throw(message: string) {
+        console.error(`[EXCEPTION] ${message}`);
+        this.emit('exception', { message });
+        // Track in exceptions array, used to determine whether to resolve or reject process
+        this.#exceptions.push(message);
+    }
+
+    #load(options: ExtractMetadataOptions | ValidateOptions) {
+        if (options.url) return this.#loadURL(options.url);
+        if (options.source) return this.#loadSource(options.source);
+        if (options.file) return this.#loadFile(options.file);
+        throw new Error('url, source, or file must be specified.');
+    }
+
+    #loadURL(url: string) {
+        return get(url)
+            .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
+            .then(res => {
+                if (!res.text) throw new Error(`Body of ${url} is empty.`);
+                this.url = url;
+                return this.#loadSource(res.text);
+            });
+    }
+
+    #loadSource(src: string) {
+        this.source = src;
+        try {
+            return load(src);
+        } catch (e) {
+            throw new Error(
+                `Cheerio failed to parse source: ${JSON.stringify(e)}`
+            );
+        }
+    }
+
+    async #loadFile(file: string) {
+        try {
+            await access(file, constants.F_OK);
+        } catch (error) {
+            throw new Error(`File '${file}' not found or inaccessible.`);
+        }
+        return this.#loadSource(await readFile(file, 'utf8'));
+    }
+}
+
+// End of Specberus-related code; start of RuleContext-related code
 
 type HeaderMap = Record<
     string,
@@ -107,6 +301,10 @@ const abbrMonths = [
 ];
 
 export const possibleMonths = [...months, ...abbrMonths].join('|');
+const separator = '[ -]{1}';
+
+export const dateRegexStrCapturing = `(\\d?\\d)${separator}(${possibleMonths})${separator}(\\d{4})`;
+const dateRegexStrNonCapturing = `\\d?\\d${separator}(?:${possibleMonths})${separator}\\d{4}`;
 
 // Regular expressions used by getDelivererIDs and getDelivererGroups
 
@@ -118,59 +316,20 @@ const REGEX_TAG_DISCLOSURE = /https?:\/\/www.w3.org\/2001\/tag\/disclosures/;
 const REGEX_DELIVERER_IPR_URL =
     /^https:\/\/www\.w3\.org\/groups\/([^/]+)\/([^/]+)\/ipr\/?(#.*)?$/i;
 
-const separator = '[ -]{1}';
-
-interface ExceptionsErrorOptions extends ErrorOptions {
-    exceptions: string[];
-}
-
-export interface SpecberusResult {
-    errors: HandlerMessage[];
-    info: HandlerMessage[];
-    metadata: Record<string, any>;
-    success: boolean;
-    warnings: HandlerMessage[];
-}
-
 /**
- * Error which includes list of exception messages,
- * thrown in case of unexpected errors during extractMetadata or validate
+ * Encapsulates all methods of interest to rule check functions,
+ * separate from the APIs responsible for core Specberus requests.
  */
-export class ExceptionsError extends Error {
-    exceptions: string[];
-
-    constructor(message?: string, options?: ExceptionsErrorOptions) {
-        super(message, options);
-        this.exceptions = options?.exceptions || [];
-    }
-}
-
-type SpecberusMessageEventArgs = [
-    RuleMeta | RuleBase,
-    {
-        detailMessage: string;
-        extra?: Record<string, any>;
-        key: string;
-    },
-];
-
-interface SpecberusEvents {
-    done: [string];
-    err: SpecberusMessageEventArgs;
-    exception: [{ message: string }];
-    info: SpecberusMessageEventArgs;
-    warning: SpecberusMessageEventArgs;
-}
-
-export class Specberus extends EventEmitter<SpecberusEvents> {
-    $ = load('');
+class RuleContext {
+    $: CheerioAPI;
+    /**
+     * Configuration that Specberus parsed from params.
+     * Only present for validation (not metadata extraction).
+     */
     config: SpecberusConfig | undefined;
-    source: string | undefined;
-    url: string | undefined;
     version = specberusVersion;
 
-    // Private fields
-
+    #sr: Specberus;
     #$docDateEl: Cheerio<Element> | undefined;
     #$sotdSection: Cheerio<Element> | null | undefined;
     /** Group objects returned by W3C API charters endpoint */
@@ -180,149 +339,23 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
     #delivererIDs: number[] | Promise<number[]> | undefined;
     #delivererGroups: Promise<DelivererGroup[]> | undefined;
     #docDate: Date | undefined;
-    /** Stores messages from any unexpected errors encountered during process */
-    #exceptions: string[] = [];
     #headers: HeaderMap | undefined;
     #isFirstPublic: boolean | undefined;
     #previousVersion: Promise<string | null> | undefined;
     #shortname: string | undefined = undefined;
 
-    /**
-     * Internal function for handling common end-state logic for extractMetadata and validate,
-     * returning results (resolving) or throwing an error if exceptions occurred (rejecting).
-     */
-    #reportResult(result: Omit<SpecberusResult, 'success'>): SpecberusResult {
-        if (this.#exceptions.length) {
-            throw new ExceptionsError(
-                'The following unexpected errors occurred:\n' +
-                    this.#exceptions.join('\n'),
-                { exceptions: this.#exceptions }
-            );
-        }
-        return {
-            ...result,
-            success: !result.errors.length,
-        };
+    constructor(sr: Specberus, $: CheerioAPI, config?: SpecberusConfig) {
+        this.$ = $;
+        this.#sr = sr;
+        if (config) this.config = config;
     }
 
-    /** Internal function containing setup logic common to both extractMetadata and validate. */
-    async #prepare(options: ExtractMetadataOptions | ValidateOptions) {
-        const errors: HandlerMessage[] = [];
-        const warnings: HandlerMessage[] = [];
-        const info: HandlerMessage[] = [];
-
-        this.on('err', (rule, data) => {
-            errors.push({ ...rule, ...data });
-        });
-        this.on('warning', (rule, data) => {
-            warnings.push({ ...rule, ...data });
-        });
-        this.on('info', (rule, data) => {
-            info.push({ ...rule, ...data });
-        });
-
-        try {
-            this.$ = await this.#load(options);
-        } catch (error) {
-            this.#throw(error.toString());
-            throw error;
-        }
-
-        return { errors, info, warnings };
+    get source() {
+        return this.#sr.source;
     }
 
-    async extractMetadata(options: ExtractMetadataOptions) {
-        const messages = await this.#prepare(options);
-        const metadata: Record<string, any> = {};
-        const profile = options.additionalMetadata
-            ? profileAdditionalMetadata
-            : profileMetadata;
-
-        await Promise.all(
-            profile.rules.map(async rule => {
-                try {
-                    const result = await rule.check(this);
-                    if (result)
-                        for (const [key, value] of Object.entries(result))
-                            metadata[key] = value;
-                } catch (error) {
-                    this.#throw(error.message);
-                } finally {
-                    this.emit('done', rule.name);
-                }
-            })
-        );
-        return this.#reportResult({ ...messages, metadata });
-    }
-
-    async validate(options: ValidateOptions) {
-        if (!options.profile)
-            throw new Error('Without a profile there is nothing to check.');
-
-        const { profile } = options;
-        this.config = await processParams(options, profile.config);
-        const messages = await this.#prepare(options);
-
-        await Promise.all(
-            profile.rules.map(async rule => {
-                try {
-                    await rule.check(this);
-                } catch (error) {
-                    this.#throw(error.message);
-                } finally {
-                    this.emit('done', rule.name);
-                }
-            })
-        );
-        return this.#reportResult({ ...messages, metadata: {} });
-    }
-
-    error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
-        const shortname = this.getShortname();
-        if (
-            typeof shortname !== 'undefined' &&
-            hasExceptions(shortname, rule.name, extra)
-        )
-            this.warning(rule, key, extra);
-        else
-            this.emit('err', rule, {
-                key,
-                ...(extra && { extra }),
-                detailMessage: assembleData(null, rule, key, extra).message,
-            });
-    }
-
-    warning(
-        rule: RuleBase | RuleMeta,
-        key: string,
-        extra?: Record<string, any>
-    ) {
-        this.emit('warning', rule, {
-            key,
-            ...(extra && { extra }),
-            detailMessage: assembleData(null, rule, key, extra).message,
-        });
-    }
-
-    info(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
-        this.emit('info', rule, {
-            key,
-            ...(extra && { extra }),
-            detailMessage: assembleData(null, rule, key, extra).message,
-        });
-    }
-
-    /**
-     * Emits an exception event, intended to signify that the process stopped on a critical error.
-     *
-     * NOTE: This should not be called from rules; they should throw an Error,
-     * which will result in extractMetadata or validate invoking this method.
-     */
-    #throw(message: string) {
-        console.error(`[EXCEPTION] ${message}`);
-        this.emit('exception', { message });
-        // Track in exceptions array, used to determine whether to resolve or reject process
-        this.#exceptions.push(message);
+    get url() {
+        return this.#sr.url;
     }
 
     /**
@@ -349,11 +382,8 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
             .replace(/\s+/g, ' ');
     }
 
-    static dateRegexStrCapturing = `(\\d?\\d)${separator}(${possibleMonths})${separator}(\\d{4})`;
-    static dateRegexStrNonCapturing = `\\d?\\d${separator}(?:${possibleMonths})${separator}\\d{4}`;
-
     stringToDate(str: string) {
-        const rex = new RegExp(Specberus.dateRegexStrCapturing);
+        const rex = new RegExp(dateRegexStrCapturing);
         const matches = str.match(rex);
         if (matches) {
             return new Date(
@@ -364,10 +394,45 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         }
     }
 
+    error(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
+        const shortname = this.getShortname();
+        if (
+            typeof shortname !== 'undefined' &&
+            hasExceptions(shortname, rule.name, extra)
+        )
+            this.warning(rule, key, extra);
+        else
+            this.#sr.emit('err', rule, {
+                key,
+                ...(extra && { extra }),
+                detailMessage: assembleData(null, rule, key, extra).message,
+            });
+    }
+
+    warning(
+        rule: RuleBase | RuleMeta,
+        key: string,
+        extra?: Record<string, any>
+    ) {
+        this.#sr.emit('warning', rule, {
+            key,
+            ...(extra && { extra }),
+            detailMessage: assembleData(null, rule, key, extra).message,
+        });
+    }
+
+    info(rule: RuleBase | RuleMeta, key: string, extra?: Record<string, any>) {
+        this.#sr.emit('info', rule, {
+            key,
+            ...(extra && { extra }),
+            detailMessage: assembleData(null, rule, key, extra).message,
+        });
+    }
+
     getDocumentDate() {
         if (this.#docDate) return this.#docDate;
         const rex = new RegExp(
-            `${Specberus.dateRegexStrCapturing}(?:, edited in place ${Specberus.dateRegexStrNonCapturing})?$`
+            `${dateRegexStrCapturing}(?:, edited in place ${dateRegexStrNonCapturing})?$`
         );
         const $el = this.$('#w3c-state');
 
@@ -514,7 +579,7 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         const dates = { list: [] as Date[], valid: [] as Date[] };
         if ($sotd) {
             const txt = this.norm($sotd.text());
-            const rex = new RegExp(Specberus.dateRegexStrCapturing, 'g');
+            const rex = new RegExp(dateRegexStrCapturing, 'g');
             const docDate = this.getDocumentDate()!;
             const lowBound = new Date(docDate).setDate(
                 new Date(docDate).getDate() + 27
@@ -815,43 +880,6 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         return this.#previousVersion;
     }
 
-    #load(options: ExtractMetadataOptions | ValidateOptions) {
-        if (options.url) return this.#loadURL(options.url);
-        if (options.source) return this.#loadSource(options.source);
-        if (options.file) return this.#loadFile(options.file);
-        throw new Error('url, source, or file must be specified.');
-    }
-
-    #loadURL(url: string) {
-        return get(url)
-            .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
-            .then(res => {
-                if (!res.text) throw new Error(`Body of ${url} is empty.`);
-                this.url = url;
-                return this.#loadSource(res.text);
-            });
-    }
-
-    #loadSource(src: string) {
-        this.source = src;
-        try {
-            return load(src);
-        } catch (e) {
-            throw new Error(
-                `Cheerio failed to parse source: ${JSON.stringify(e)}`
-            );
-        }
-    }
-
-    async #loadFile(file: string) {
-        try {
-            await access(file, constants.F_OK);
-        } catch (error) {
-            throw new Error(`File '${file}' not found or inaccessible.`);
-        }
-        return this.#loadSource(await readFile(file, 'utf8'));
-    }
-
     transition(options: TransitionOptions) {
         const documentDate = this.getDocumentDate();
         if (documentDate && 'from' in options && documentDate < options.from)
@@ -881,3 +909,6 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         return meta;
     }
 }
+
+// Expose typings for types.d.ts to use, separate from the unexposed implementation
+export type { RuleContext };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "12.3.1",
   "description": "Specberus is a checker used at W3C to validate the compliance of Technical Reports with publication rules.",
   "license": "MIT",
-  "main": "lib/validator",
+  "main": "lib/specberus",
   "type": "module",
   "repository": {
     "type": "git",

--- a/test/api.ts
+++ b/test/api.ts
@@ -15,7 +15,7 @@ import superagent, { type Response, type ResponseError } from 'superagent';
 
 import { setUp } from '../lib/api.js';
 import { specberusVersion } from '../lib/util.js';
-import type { SpecberusResult } from '../lib/validator.js';
+import type { SpecberusResult } from '../lib/specberus.js';
 import { cleanupMocks, setupMocks } from './lib/utils.js';
 
 // Settings:

--- a/test/l10n.ts
+++ b/test/l10n.ts
@@ -103,8 +103,8 @@ const scanStrings = function () {
 /**
  * Scans “baseDir” and finds heuristically all sections, rules, and message IDs.
  *
- * The search relies on a regex that tries to find instances of “sr.error()” etc, so it's not exact.
- * Return a promise that will be fulfilled if/when all directories and files are read successfully.
+ * The search relies on a regex that tries to find instances of “context.error()” etc, so it's not exact.
+ * Returns a promise that will be fulfilled if/when all directories and files are read successfully.
  */
 async function scanFileSystem() {
     const result: Record<string, Record<string, Record<string, true>>> = {};

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -11,7 +11,7 @@ import {
     ExceptionsError,
     Specberus,
     type SpecberusResult,
-} from '../lib/validator.js';
+} from '../lib/specberus.js';
 // A list of good documents to be tested, using all rules configured in the profiles.
 // Shouldn't cause any error.
 import { goodDocuments } from './data/goodDocuments.js';


### PR DESCRIPTION
This separates the APIs responsible for creating/running metadata extraction or validation from the APIs necessary to perform the various rule checks. This results in a far simpler API for typical consumers who only care about the former, and prevents each use case from crossing wires with one another.

## Changes

- Separates APIs used by rules to a `RuleContext` class, which now lives in `lib/rule-context.ts`
- Moves the remainder of the code in `validator.ts` (for the `Specberus` class) to `specberus.ts`, and updates `main` in `package.json` to match
- Updates all usage of "sr" as a variable name within rule check functions to "context"
- Updates nomenclature in the readme; also replaces outdated future plans sentence

The diff will appear larger than it really is due to moving existing code from `validator.ts` to `specberus.ts` and `rule-context.ts`, but no functional changes have been made to the code that previously lived in `validator.ts`.