### PR TITLE
Add test for validation=recursive; remove unreachable code & l10n string

### DIFF
--- a/lib/l10n-en_GB.ts
+++ b/lib/l10n-en_GB.ts
@@ -155,8 +155,6 @@ export const messages = {
     // links/compound
     'links.compound.skipped':
         'HTML and CSS validations for compound documents were skipped. ',
-    'links.compound.no-validation':
-        'Validation of <a href="${link}">${file}</a> <a href="https://validator.w3.org/nu/doc=${link}">HTML</a>.',
     'links.compound.link':
         'Validation of <a href="${link}">${file}</a> <a href="https://validator.w3.org/nu/doc=${link}">HTML ${markup}</a>.',
     'links.compound.error':

--- a/lib/rules/links/compound.ts
+++ b/lib/rules/links/compound.ts
@@ -33,63 +33,52 @@ export const check: RuleCheckFunction = sr => {
     if (!links.length) return;
 
     const markupService = 'https://validator.w3.org/nu/';
-    if (validation === 'recursive') {
-        return Promise.all(
-            links.map(l => {
-                const ua = `W3C-Pubrules/${sr.version}`;
-                const req = get(markupService)
-                    .set('User-Agent', ua)
-                    .query({ doc: l, out: 'json' })
-                    .on('error', err => {
-                        sr.error(self, 'error', {
+    return Promise.all(
+        links.map(l => {
+            const ua = `W3C-Pubrules/${sr.version}`;
+            const req = get(markupService)
+                .set('User-Agent', ua)
+                .query({ doc: l, out: 'json' })
+                .on('error', err => {
+                    sr.error(self, 'error', {
+                        file: l.split('/').pop(),
+                        link: l,
+                        errMsg: err,
+                    });
+                })
+                .timeout(TIMEOUT);
+            return req.then(
+                res => {
+                    const json = res.body;
+                    if (!json)
+                        throw new Error(
+                            'No JSON returned from HTML validator.'
+                        );
+
+                    const errors =
+                        json.messages?.filter(
+                            (msg: { type: string }) => msg.type === 'error'
+                        ) || [];
+                    if (errors.length === 0) {
+                        sr.info(self, 'link', {
                             file: l.split('/').pop(),
                             link: l,
-                            errMsg: err,
+                            markup: '\u2714',
                         });
-                    })
-                    .timeout(TIMEOUT);
-                return req.then(
-                    res => {
-                        const json = res.body;
-                        if (!json)
-                            throw new Error(
-                                'No JSON returned from HTML validator.'
-                            );
-
-                        const errors =
-                            json.messages?.filter(
-                                (msg: { type: string }) => msg.type === 'error'
-                            ) || [];
-                        if (errors.length === 0) {
-                            sr.info(self, 'link', {
-                                file: l.split('/').pop(),
-                                link: l,
-                                markup: '\u2714',
-                            });
-                        } else {
-                            sr.error(self, 'link', {
-                                file: l.split('/').pop(),
-                                link: l,
-                                markup: '\u2718',
-                            });
-                        }
-                    },
-                    (err: ResponseError) => {
-                        if (err.timeout) sr.warning(self, 'html-timeout');
-                        else
-                            throw new Error(
-                                `HTML validator error: ${err.message}`
-                            );
+                    } else {
+                        sr.error(self, 'link', {
+                            file: l.split('/').pop(),
+                            link: l,
+                            markup: '\u2718',
+                        });
                     }
-                );
-            })
-        ).then(() => {});
-    } else {
-        for (const l of links) {
-            sr.info(self, 'no-validation', {
-                file: l.split('/').pop(),
-                link: l,
-            });
-        }
-    }
+                },
+                (err: ResponseError) => {
+                    if (err.timeout) sr.warning(self, 'html-timeout');
+                    else
+                        throw new Error(`HTML validator error: ${err.message}`);
+                }
+            );
+        })
+    ).then(() => {});
 };

--- a/test/api.ts
+++ b/test/api.ts
@@ -3,16 +3,19 @@
  */
 
 import assert from 'assert';
+import { readFile } from 'fs/promises';
 import http, { type Server } from 'http';
 import { join } from 'path';
 import { after, before, describe, it } from 'node:test';
 
 import express from 'express';
 import fileUpload from 'express-fileupload';
+import nock from 'nock';
 import superagent, { type Response, type ResponseError } from 'superagent';
 
 import { setUp } from '../lib/api.js';
 import { specberusVersion } from '../lib/util.js';
+import type { SpecberusResult } from '../lib/validator.js';
 import { cleanupMocks, setupMocks } from './lib/utils.js';
 
 // Settings:
@@ -133,11 +136,20 @@ describe('API', () => {
     });
 
     describe('Method “validate”', () => {
+        const imscPath = join(testDocsPath, 'ttml-imsc1.html');
+        before(async () => {
+            // Additional mock for recursive validation test (which requires url)
+            nock('https://www.w3.org')
+                .persist()
+                .get(/^\/TR\/ttml-imsc1.3\/(Overview\.html)?$/)
+                .reply(200, await readFile(imscPath, 'utf8'));
+        });
+
         it('Should 400 and return an array of errors when validation fails', () =>
             assert.rejects(
                 createPostRequest('validate')
                     .field('profile', 'REC')
-                    .attach('file', join(testDocsPath, 'ttml-imsc1.html')),
+                    .attach('file', imscPath),
                 (error: any) => {
                     assertResponseStatus(error.response, 400);
                     const { success, errors } = JSON.parse(
@@ -155,6 +167,38 @@ describe('API', () => {
                             'Every error should consistently define fields'
                         );
                     }
+                    return true;
+                }
+            ));
+
+        it('Should run compound and linkchecker rules when validation=recursive and url are specified', () =>
+            // Note: This uses the same document as the previous test, so it still expects errors
+            assert.rejects(
+                get(
+                    `validate?profile=REC&validation=recursive&url=${encodeURIComponent(
+                        'https://www.w3.org/TR/ttml-imsc1.3/'
+                    )}`
+                ),
+                (error: any) => {
+                    assertResponseStatus(error.response, 400);
+                    const { success, errors, info, warnings } = JSON.parse(
+                        getErrorResponseText(error)
+                    ) as SpecberusResult;
+                    assert.strictEqual(success, false);
+                    assert(errors.length > 0, 'Response should report errors');
+                    assert(
+                        info.some(
+                            ({ name, key }) =>
+                                name === 'links.compound' && key === 'link'
+                        )
+                    );
+                    assert(
+                        warnings.some(
+                            ({ name, key }) =>
+                                name === 'links.linkchecker' &&
+                                key === 'display'
+                        )
+                    );
                     return true;
                 }
             ));

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -83,7 +83,7 @@ export const buildBadTestCases = async () => {
  * @param {Request} req
  */
 function warnOnNonLocalRequest(req: Request) {
-    if (!req.url.includes('//localhost')) {
+    if (!/\/\/(localhost|127\.0\.0\.1)/.test(req.url)) {
         console.warn('Unmocked non-local request:', req.url, req.body);
     }
 }
@@ -92,7 +92,9 @@ function warnOnNonLocalRequest(req: Request) {
 export function setupMocks(overrides?: Partial<NockData>) {
     // Report non-local URLs that were not mocked during test runs
     nock.emitter.on('no match', warnOnNonLocalRequest);
-    nock.enableNetConnect('localhost'); // Only allow localhost requests to proceed unmocked
+    // Only allow localhost requests to proceed unmocked
+    // (localhost matches documents; 127.0.0.1 matches puppeteer debug request)
+    nock.enableNetConnect(/localhost|127\.0\.0\.1/);
 
     const mockData: typeof nockData = overrides
         ? merge({}, nockData, overrides)
@@ -215,10 +217,12 @@ export function setupMocks(overrides?: Partial<NockData>) {
 
     // Mock Nu HTML Checker requests to return no messages
     // (without mocks, the validate API tests result in an error from the service anyway)
-    nock('https://validator.w3.org')
-        .persist()
-        .post('/nu/?out=json')
-        .reply(200, { messages: [] });
+    for (const method of ['GET', 'POST']) {
+        nock('https://validator.w3.org')
+            .persist()
+            .intercept(/^\/nu\/.*out=json/, method)
+            .reply(200, { messages: [] });
+    }
 }
 
 /** Cleans up mocks and event handler from setupMocks. */


### PR DESCRIPTION
This adds an automated test in the API suite for `validation=recursive` in a GET request with `url` specified, to enable testing the `compound` and `linkchecker` rules.

While looking at the `compound` rule, I realized that its if/else is completely redundant, because the code already bails out if `validation` is not `recursive` earlier in the rule check function. So I removed the unreachable code and the consequently unused l10n string. (The diff of `compound.ts` should be much smaller if viewed without whitespace changes.)

Testing this also required adjusting test mocks, as we always use a GET request to call the validator from the `compound` rule, as opposed to our previous test case covering the `html` rule which made the request via POST due to a file upload being involved. The `enableNetConnect` call was also added to account for a request that puppeteer makes to 127.0.0.1 to enable debugging.

Since the test suite now ends up running puppeteer, whereas it previously hadn't, I've also added the same environment variables we recently added to spec-generator. (Edit: I may need to send a separate PR to update the workflow in main first? I'm very confused about this because it [did pass once previously from this branch](https://github.com/w3c/specberus/actions/runs/27164100963).)