### PR TITLE
Enable puppeteer to be run in automated tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+env:
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+  PUPPETEER_SKIP_DOWNLOAD: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ports only the workflow change from #2120 to `main` in case this is necessary first in order for tests on that PR to pass.

I successfully tested this from a fork, but I already deleted the fork after having seen the tests pass in CI for the `kgf-test-recursive` branch (which was before the same exact commit failed when I opened the PR).