### PR TITLE
Remove stale ignore rules and ignore built *.d.ts for cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -108,20 +108,16 @@
         "**/*.ttf",
         "**/*.woff",
         "**/*.svg",
-        ".nyc_output/**",
         ".github/**",
         "coverage/**",
         "test/**/*.html",
         "package-lock.json",
         "tsconfig.json",
-        "lib/**/*.js",
+        "{lib,test}/**/*.{d.ts,js}",
         "node_modules/**",
         "design/**"
     ],
-    "ignoreRegExpList": [
-        "/require\\(.*\\);/",
-        "(FIXME|TODO|XXX)\\(.[^\\)]+\\)"
-    ],
+    "ignoreRegExpList": ["(FIXME|TODO|XXX)\\(.[^\\)]+\\)"],
     "overrides": [
         {
             "filename": ["package.json"],

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ scratch
 .DS_Store
 */.DS_Store
 
-.nyc_output
-.eslintcache
-
 # TS build output
 app.js
 *.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 *.html
 *.handlebars
-.nyc_output


### PR DESCRIPTION
I realized that `cspell` was running over a bunch of files it shouldn't be on the typescript branch, though this only happens after running `npm run build` locally.

While I was looking at the cspell config, I found a few entries that no longer match anything, and some of this was also applicable to `.gitignore` and `.prettierignore`. (Technically `.nyc_output` became a thing of the past with #2088.)

Note that ignoring all `.d.ts` files for cspell does ignore one source file (`lib/types.d.ts`), which is only typings and no logic. Unfortunately, cspell doesn't support negative ignore patterns for exceptions, so this is not easy to avoid. Fortunately, any strings in this file are likely to be referenced in other `.ts` files, where typos _will_ be flagged by cspell.