### PR TITLE
API: Respond with HTTP 400 to POST requests with no/multiple file

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -70,14 +70,12 @@ const processPost = () => async (req: Request, res: Response) => {
 
     if (path === '/api/metadata' || path === '/api/validate') {
         if (!req.files || !req.files.file) {
-            return res.send({
-                status: 400,
+            return res.status(400).send({
                 message: 'Missing file.',
             });
         }
         if (Array.isArray(req.files.file)) {
-            return res.send({
-                status: 400,
+            return res.status(400).send({
                 message: 'Expected a single file.',
             });
         }
@@ -87,8 +85,7 @@ const processPost = () => async (req: Request, res: Response) => {
             // file must be an html file
             const type = await fileTypeFromFile(tempFilePath);
             if (type != null) {
-                return res.send({
-                    status: 500,
+                return res.status(400).send({
                     message: 'Invalid file type. Please send an HTML file.',
                 });
             }

--- a/test/api.ts
+++ b/test/api.ts
@@ -107,6 +107,12 @@ describe('API', () => {
     });
 
     describe('Method “metadata”', () => {
+        it('Should respond with 400 status if "file" is not specified via POST', () =>
+            assert.rejects(createPostRequest('metadata'), (error: any) => {
+                assertResponseStatus(error.response, 400);
+                return true;
+            }));
+
         it('Should accept "file" via POST, and return the right profile and date', () =>
             createPostRequest('metadata')
                 .attach('file', join(testDocsPath, 'ttml-imsc1.html'))
@@ -144,6 +150,12 @@ describe('API', () => {
                 .get(/^\/TR\/ttml-imsc1.3\/(Overview\.html)?$/)
                 .reply(200, await readFile(imscPath, 'utf8'));
         });
+
+        it('Should respond with 400 status if "file" is not specified via POST', () =>
+            assert.rejects(createPostRequest('validate'), (error: any) => {
+                assertResponseStatus(error.response, 400);
+                return true;
+            }));
 
         it('Should 400 and return an array of errors when validation fails', () =>
             assert.rejects(


### PR DESCRIPTION
This updates logic in `lib/api.ts` to respond with an actual 400 status code rather than a 200 OK status with `status: 400` in the response body, when the `file` parameter is missing or multiple values are passed.

(In 12.x, this currently responds with 200 OK containing `status: 500` in the body, which is doubly incorrect, since this is a user input error, not a server error. I had already updated the `500` to `400` when initially converting to Typescript.)