### PR TITLE
Localize ParsedQs typing to avoid implicit dep; fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ so listeners can be registered using the `on` API.
 
 ```js
 const specberus = new Specberus();
-specberus.on('error', (rule, data) => {
+specberus.on('err', (rule, data) => {
     // ...
 });
 ```

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,7 +5,7 @@
 import { fileTypeFromFile } from 'file-type';
 import type { Express, Request, Response } from 'express';
 
-import type { HandlerMessage } from './types.js';
+import type { HandlerMessage, ParsedQs } from './types.js';
 import { processParams, specberusVersion } from './util.js';
 import {
     ExceptionsError,
@@ -124,7 +124,7 @@ function handlePromise(
 const processRequest = async (
     req: Request,
     res: Response,
-    params: qs.ParsedQs
+    params: ParsedQs
 ) => {
     const shouldValidate = getFullUrl(req).pathname === '/api/validate';
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -100,3 +100,8 @@ export interface ApiCharter {
 export interface ApiSpecificationVersion {
     uri: string;
 }
+
+/** Borrowed from @types/qs to avoid a transitive dependency for typings */
+export interface ParsedQs {
+    [key: string]: undefined | string | ParsedQs | (string | ParsedQs)[];
+}

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -11,7 +11,7 @@ import { Octokit } from '@octokit/core';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
 
-import type { SpecberusConfig } from './types.js';
+import type { ParsedQs, SpecberusConfig } from './types.js';
 import type { ValidateOptions } from './specberus.js';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -97,7 +97,7 @@ interface ProcessParamsConstraints {
  * @throws {Error} if there is an error in the parameters.
  */
 export async function processParams(
-    params: qs.ParsedQs | ValidateOptions,
+    params: ParsedQs | ValidateOptions,
     base: Partial<SpecberusConfig> = {},
     constraints: ProcessParamsConstraints = {}
 ) {
@@ -136,7 +136,7 @@ export async function processParams(
             // Other params:
             if (Object.hasOwn(result, p))
                 throw new Error(`Parameter “${p}” is used more than once`);
-            result[p] = (params as qs.ParsedQs)[p];
+            result[p] = (params as ParsedQs)[p];
         } else if (!constraints?.allowUnknownParams)
             // Illegal params:
             throw new Error(`Illegal parameter “${p}”`);

--- a/lib/views.ts
+++ b/lib/views.ts
@@ -7,6 +7,7 @@ import genericSections, {
     type GenericRulesSection,
 } from './rules-generic-sections.js';
 import { specberusVersion } from './util.js';
+import type { ParsedQs } from './types.js';
 
 // Settings:
 const DEBUG = process && process.env && process.env.DEBUG;
@@ -141,7 +142,7 @@ interface RetrieveProfileResult {
 }
 
 // TODO(tripu): Document.
-function retrieveProfile(query: qs.ParsedQs) {
+function retrieveProfile(query: ParsedQs) {
     let result: RetrieveProfileResult | { error: string } | undefined;
 
     if (query && query.profile && typeof query.profile === 'string') {


### PR DESCRIPTION
This addresses 2 issues:

- While working on updates for spec-prod, I noticed that importing certain specberus modules causes type errors due to referencing something from `@types/qs`, which would then need to be included as a `devDependency` in the dependent project
  - This can be easily averted by replicating the type within specberus' `lib/types.d.ts`; it is standalone with no dependencies
- I belatedly spotted a typo in the events example in the README (`on('error'` should have been `on('err'`)