### PR TITLE
Allow options.url to be a URL

### DIFF
--- a/lib/specberus.ts
+++ b/lib/specberus.ts
@@ -27,7 +27,7 @@ setLanguage('en_GB');
 interface BaseOptions {
     file?: string;
     source?: string;
-    url?: string;
+    url?: string | URL;
 }
 
 interface ExtractMetadataOptions extends BaseOptions {
@@ -200,12 +200,12 @@ export class Specberus extends EventEmitter<SpecberusEvents> {
         throw new Error('url, source, or file must be specified.');
     }
 
-    #loadURL(url: string) {
+    #loadURL(url: string | URL) {
         return get(url)
             .set('User-Agent', `W3C-Pubrules/${specberusVersion}`)
             .then(res => {
                 if (!res.text) throw new Error(`Body of ${url} is empty.`);
-                this.url = url;
+                this.url = '' + url;
                 return this.#loadSource(res.text);
             });
     }


### PR DESCRIPTION
This permits the `url` option to contain a value of type `URL` in addition to `string`.

This requires no functional changes, as `superagent` already supports either type as input (also confirmed in its typings).

This typing change will reduce necessary code changes when updating spec-prod to use Specberus 13.