### PR TITLE
Update README badges, replacing or removing outdated/defunct ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![Build Status](https://github.com/w3c/specberus/workflows/Specberus%20tests/badge.svg)](https://github.com/w3c/specberus/actions)
-[![Coverage Status](https://coveralls.io/repos/w3c/specberus/badge.svg)](https://coveralls.io/r/w3c/specberus)
-[![Dependency Status](https://david-dm.org/w3c/specberus.svg)](https://david-dm.org/w3c/specberus)
-[![devDependency Status](https://david-dm.org/w3c/specberus/dev-status.svg)](https://david-dm.org/w3c/specberus#info=devDependencies)
+[![Tests status](https://github.com/w3c/specberus/actions/workflows/node.js.yml/badge.svg)](https://github.com/w3c/specberus/actions/workflows/node.js.yml)
+[![Lint Status](https://github.com/w3c/specberus/actions/workflows/js-lint.yml/badge.svg)](https://github.com/w3c/specberus/actions/workflows/js-lint.yml)
+![Dependency Status](https://img.shields.io/librariesio/github/w3c/specberus)
 
 # Specberus
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Tests status](https://github.com/w3c/specberus/actions/workflows/node.js.yml/badge.svg)](https://github.com/w3c/specberus/actions/workflows/node.js.yml)
 [![Lint Status](https://github.com/w3c/specberus/actions/workflows/js-lint.yml/badge.svg)](https://github.com/w3c/specberus/actions/workflows/js-lint.yml)
-![Dependency Status](https://img.shields.io/librariesio/github/w3c/specberus)
 
 # Specberus
 


### PR DESCRIPTION
Resolves #2145

This updates the badges at the top of the README:

- Updates Markdown for the tests CI badge based on what GitHub currently provides
- Adds lint CI badge, matching what we do for spec-generator
- Removes Coverage Status badge, since the "latest" coveralls.io stats were ~5 years old and thus underreported our total coverage by roughly 18% (I assume we previously integrated with them but don't anymore?)
- ~~Replaces david-dm dependencies badge with [shields.io badge powered by libraries.io](https://shields.io/badges/libraries-io-dependency-status-for-git-hub-repo), reflecting the status of the main branch~~ After discussion with Denis, we're electing to remove the dependencies badge instead, since we now rely on Dependabot