### PR TITLE
Fix error reporting typo when Editor's Draft link is not found

### DIFF
--- a/lib/rules/headers/dl.ts
+++ b/lib/rules/headers/dl.ts
@@ -218,7 +218,7 @@ export const check: RuleCheckFunction = async context => {
             context,
             rule: self,
             $element: $editorsDraftElement,
-            linkName: 'Implementation report',
+            linkName: "Editor's draft",
         });
         if (exist) {
             const editorsDraft = $editorsDraftElement.attr('href') || '';


### PR DESCRIPTION
Fixes #2144

This corrects the value of `linkName` passed to `checkLink` for the case of the Editor's Draft link in the `headers/dl` rule.

This change only affects error reporting. The current test data infrastructure does not make it possible to verify this deeply, but I performed some manual verification of what this error looks like.

Before fix:

```js
  {
    name: 'headers.dl',
    section: 'front-matter',
    rule: 'docIDFormat',
    key: 'not-found',
    extra: {
      linkName: 'Implementation report',
      message: 'Implementation report'
    },
    detailMessage: 'Cannot find the &lt;a&gt; tag or link for Implementation report.'
  }
```

After fix:

```js
  {
    name: 'headers.dl',
    section: 'front-matter',
    rule: 'docIDFormat',
    key: 'not-found',
    extra: { linkName: "Editor's draft", message: "Editor's draft" },
    detailMessage: "Cannot find the &lt;a&gt; tag or link for Editor's draft."
  }
```