### PR TITLE
Skip tests populated for inapplicable profile/rule combinations

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -11,7 +11,7 @@ import { Octokit } from '@octokit/core';
 // @ts-ignore (no typings)
 import w3cApi from 'node-w3capi';
 
-import type { ParsedQs, SpecberusConfig } from './types.js';
+import type { ParsedQs, ProfileModule, SpecberusConfig } from './types.js';
 import type { ValidateOptions } from './specberus.js';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -50,7 +50,10 @@ export const allProfiles = [
     ...SUBMProfiles.map(x => `SUBM/${x}`),
 ];
 
-export const profiles = Object.fromEntries(
+export const profiles: Record<
+    string,
+    Promise<ProfileModule>
+> = Object.fromEntries(
     allProfiles
         .map(file => {
             const match =

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -321,7 +321,11 @@ function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
         if (testType && test.data !== testType) return;
 
         it(`should ${passOrFail} for ${url}`, async () => {
-            const { config } = resolvedProfiles[profile];
+            const config = resolvedProfiles[profile]?.config;
+            if (!config)
+                throw new Error(
+                    `Config not found for profile ${suffix}; check that the module exists and is valid?`
+                );
             const ruleModule = await import(
                 `../lib/rules/${category}/${rule}.js`
             );

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -5,7 +5,7 @@ import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { rules as metadataRules } from '../lib/profiles/metadata.js';
 import { removeRules } from '../lib/profiles/profileUtil.js';
-import type { HandlerMessage } from '../lib/types.js';
+import type { HandlerMessage, ProfileModule } from '../lib/types.js';
 import { allProfiles } from '../lib/util.js';
 import {
     ExceptionsError,
@@ -300,25 +300,28 @@ interface CheckRuleOptions {
     track?: string | undefined;
 }
 
-function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
+async function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
     const { docType, track, profile, category, rule } = options;
+
+    const suffix = track ? `${track}/${profile}` : profile;
+    const { config, rules } = (await import(
+        `../lib/profiles/${docType}/${suffix}.js`
+    )) as ProfileModule;
+    if (!rules.some(({ name }) => name === `${category}.${rule}`)) {
+        console.log(`Skipping ${category}.${rule} for profile ${profile}`);
+        return;
+    }
+
+    const ruleModule = await import(`../lib/rules/${category}/${rule}.js`);
 
     tests.forEach(test => {
         const passOrFail = !test.errors ? 'pass' : 'fail';
-        const suffix = track ? `${track}/${profile}` : profile;
         const url = `${ENDPOINT}/doc-views/${docType}/${suffix}?rule=${rule}&type=${test.data}`;
 
         // If the test is not mentioned in the environment variables, skip it.
         if (testType && test.data !== testType) return;
 
         it(`should ${passOrFail} for ${url}`, async () => {
-            const { config } = await import(
-                `../lib/profiles/${docType}/${suffix}.js`
-            );
-            const ruleModule = await import(
-                `../lib/rules/${category}/${rule}.js`
-            );
-
             const sr = new Specberus();
             addValidationEventListeners(sr);
             const options = {
@@ -383,15 +386,14 @@ function runTestsForProfile({
                 if (testType && !tests.some(({ data }) => data === testType))
                     return;
 
-                describe(`Rule: ${category}.${rule}`, () => {
+                describe(`Rule: ${category}.${rule}`, () =>
                     checkRule(tests, {
                         docType,
                         track,
                         profile,
                         category,
                         rule,
-                    });
-                });
+                    }));
             });
         });
     });

--- a/test/rules.ts
+++ b/test/rules.ts
@@ -6,7 +6,7 @@ import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import { rules as metadataRules } from '../lib/profiles/metadata.js';
 import { removeRules } from '../lib/profiles/profileUtil.js';
 import type { HandlerMessage, ProfileModule } from '../lib/types.js';
-import { allProfiles } from '../lib/util.js';
+import { profiles } from '../lib/util.js';
 import {
     ExceptionsError,
     Specberus,
@@ -236,6 +236,11 @@ const verifySpecberusResult = (
 
 const testsGoodDoc = goodDocuments;
 
+const resolvedProfiles: Record<string, ProfileModule> = {};
+for (const [key, promise] of Object.entries(profiles)) {
+    resolvedProfiles[key] = await promise;
+}
+
 // The next check is running each profile using the rules configured.
 describe('Making sure good documents pass Specberus...', () => {
     beforeEach(() =>
@@ -254,10 +259,7 @@ describe('Making sure good documents pass Specberus...', () => {
         const url = `${ENDPOINT}/${doc.url}`;
 
         it(`should pass for ${docProfile} doc with ${url}`, async () => {
-            const profilePath = allProfiles.find(p =>
-                p.endsWith(`/${docProfile}`)
-            );
-            const profile = await import(`../lib/profiles/${profilePath}.js`);
+            const profile = resolvedProfiles[docProfile];
             // add custom config to test
             const extendedProfile = {
                 ...profile,
@@ -300,28 +302,29 @@ interface CheckRuleOptions {
     track?: string | undefined;
 }
 
-async function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
+function checkRule(tests: RuleTest[], options: CheckRuleOptions) {
     const { docType, track, profile, category, rule } = options;
 
-    const suffix = track ? `${track}/${profile}` : profile;
-    const { config, rules } = (await import(
-        `../lib/profiles/${docType}/${suffix}.js`
-    )) as ProfileModule;
-    if (!rules.some(({ name }) => name === `${category}.${rule}`)) {
+    const rules = resolvedProfiles[profile]?.rules;
+    // Up-front `rules` guard allows nonexistence to fail loudly within it() instead
+    if (rules && !rules.some(({ name }) => name === `${category}.${rule}`)) {
         console.log(`Skipping ${category}.${rule} for profile ${profile}`);
         return;
     }
 
-    const ruleModule = await import(`../lib/rules/${category}/${rule}.js`);
-
     tests.forEach(test => {
         const passOrFail = !test.errors ? 'pass' : 'fail';
+        const suffix = track ? `${track}/${profile}` : profile;
         const url = `${ENDPOINT}/doc-views/${docType}/${suffix}?rule=${rule}&type=${test.data}`;
 
         // If the test is not mentioned in the environment variables, skip it.
         if (testType && test.data !== testType) return;
 
         it(`should ${passOrFail} for ${url}`, async () => {
+            const { config } = resolvedProfiles[profile];
+            const ruleModule = await import(
+                `../lib/rules/${category}/${rule}.js`
+            );
             const sr = new Specberus();
             addValidationEventListeners(sr);
             const options = {
@@ -386,14 +389,15 @@ function runTestsForProfile({
                 if (testType && !tests.some(({ data }) => data === testType))
                     return;
 
-                describe(`Rule: ${category}.${rule}`, () =>
+                describe(`Rule: ${category}.${rule}`, () => {
                     checkRule(tests, {
                         docType,
                         track,
                         profile,
                         category,
                         rule,
-                    }));
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
The way test views are populated in this repository causes a few cases to be inherited under profiles that don't actually contain the rules being tested. The tests in question pass anyway, as they are forcibly hooked up to a fabricated profile containing the rule, even though the combination does not reflect reality.

This PR first checks whether the rule being tested actually exists in the profile's real list of rules, and skips any unrealistic combinations.

This results in 18 fewer tests being run; the following combinations are skipped:

- for profiles CR and CR-Echidna: sotd.draft-stability 
- for profile DISC: headers.editor-participation 
- for profile REC-RSCND:
  - sotd.charter 
  - sotd.publish 
  - sotd.stability 
  - sotd.pp 
- for profiles CRY, CRYD, and DRY: sotd.usage